### PR TITLE
adjust unused `banner` from compiled JS files

### DIFF
--- a/packages/libraries/external-composition/build-example.mjs
+++ b/packages/libraries/external-composition/build-example.mjs
@@ -18,10 +18,6 @@ await tsup({
   skipNodeModulesBundle: false,
   noExternal: Object.keys(pkg.peerDependencies).concat(Object.keys(pkg.devDependencies)),
   banner: {
-    js: `
-      // Adds missing require function (reason: node_modules are not transpiled)
-      import { createRequire as _createRequire } from 'module';
-      const require = _createRequire(import.meta.url);        
-    `,
+    js: "const require = (await import('node:module')).createRequire(import.meta.url);const __filename = (await import('node:url')).fileURLToPath(import.meta.url);const __dirname = (await import('node:path')).dirname(__filename);",
   },
 });

--- a/packages/services/policy/package.json
+++ b/packages/services/policy/package.json
@@ -26,11 +26,8 @@
     "zod-validation-error": "3.0.2"
   },
   "buildOptions": {
-    "runify": true,
-    "tsup": true,
-    "tags": [
-      "backend"
-    ],
-    "banner": "../../../scripts/banner.js"
+    "external": [
+      "pg-native"
+    ]
   }
 }

--- a/scripts/banner.js
+++ b/scripts/banner.js
@@ -1,4 +1,0 @@
-// Adds missing require function (reason: node_modules are not transpiled)
-import { createRequire as _createRequire } from 'module';
-
-const require = _createRequire(import.meta.url);

--- a/scripts/runify.ts
+++ b/scripts/runify.ts
@@ -7,8 +7,6 @@ import { build as tsup } from 'tsup';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
-const requireShim = fs.readFileSync(normalize(join(__dirname, './banner.js')), 'utf-8');
-
 interface BuildOptions {
   external?: string[];
   next?: {
@@ -140,7 +138,7 @@ async function compile(
     noExternal: dependencies,
     external: buildOptions.external,
     banner: {
-      js: requireShim,
+      js: "const require = (await import('node:module')).createRequire(import.meta.url);const __filename = (await import('node:url')).fileURLToPath(import.meta.url);const __dirname = (await import('node:path')).dirname(__filename);",
     },
   });
 }

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,6 @@
     "pnpm-lock.yaml",
     "tsconfig.json",
     "scripts/patch-manifests.js",
-    "scripts/banner.js",
     "scripts/runify.ts",
     "scripts/templates/runify-next.ts",
     "patches/*"


### PR DESCRIPTION
I think it's no longer needed (also confirmed by @kamilkisiela ). 
Also, this breaks source maps and causes a shift in the lines position. 