### PR TITLE
Change View Pricing link to Documentation

### DIFF
--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -70,7 +70,7 @@
     "@types/env-ci": "3.1.4",
     "@types/mkdirp": "2.0.0",
     "graphql": "16.9.0",
-    "oclif": "4.15.8",
+    "oclif": "4.13.6",
     "rimraf": "4.4.1",
     "tsx": "4.18.0",
     "typescript": "5.5.4"

--- a/packages/web/docs/src/components/landing-page.tsx
+++ b/packages/web/docs/src/components/landing-page.tsx
@@ -81,8 +81,8 @@ export function IndexPage(): ReactElement {
             <CallToAction variant="primary-inverted" href="https://app.graphql-hive.com">
               Get started for free
             </CallToAction>
-            <CallToAction variant="secondary" href="/#pricing">
-              View Pricing
+            <CallToAction variant="secondary" href="/docs">
+              Documentation
             </CallToAction>
           </HeroLinks>
         </Hero>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1853,7 +1853,7 @@ importers:
         version: 4.3.1(vite@5.4.6(@types/node@20.16.1)(less@4.2.0)(terser@5.31.1))
       autoprefixer:
         specifier: 10.4.20
-        version: 10.4.20(postcss@8.4.41)
+        version: 10.4.20(postcss@8.4.47)
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -4402,6 +4402,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
@@ -26413,6 +26414,16 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.0.1
       postcss: 8.4.41
+      postcss-value-parser: 4.2.0
+
+  autoprefixer@10.4.20(postcss@8.4.47):
+    dependencies:
+      browserslist: 4.23.3
+      caniuse-lite: 1.0.30001651
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.1
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.5: {}


### PR DESCRIPTION
### Background

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/cebf3a39-d94f-4b52-bc27-af3cb7f2f40d">

### Description

Moving to docs is two clicks currently, this change makes them accessible in one.
