### PR TITLE
Replaces cleanId with slug and uses *Slug and *Id in place of ambiguous input field names

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -80,11 +80,11 @@ export function createOrganization(input: CreateOrganizationInput, authToken: st
   });
 }
 
-export function getOrganization(organizationId: string, authToken: string) {
+export function getOrganization(organizationSlug: string, authToken: string) {
   return execute({
     document: graphql(`
-      query getOrganization($organizationId: ID!) {
-        organization(selector: { organization: $organizationId }) {
+      query getOrganization($organizationSlug: String!) {
+        organization(selector: { organizationSlug: $organizationSlug }) {
           organization {
             id
             slug
@@ -102,7 +102,7 @@ export function getOrganization(organizationId: string, authToken: string) {
     `),
     authToken,
     variables: {
-      organizationId,
+      organizationSlug,
     },
   });
 }
@@ -140,7 +140,7 @@ export function updateOrganizationSlug(input: UpdateOrganizationSlugInput, authT
           ok {
             updatedOrganizationPayload {
               selector {
-                organization
+                organizationSlug
               }
               organization {
                 id
@@ -357,8 +357,8 @@ export function updateProjectSlug(input: UpdateProjectSlugInput, authToken: stri
         updateProjectSlug(input: $input) {
           ok {
             selector {
-              organization
-              project
+              organizationSlug
+              projectSlug
             }
             project {
               id
@@ -432,9 +432,9 @@ export function updateTargetSlug(input: UpdateTargetSlugInput, authToken: string
         updateTargetSlug(input: $input) {
           ok {
             selector {
-              organization
-              project
-              target
+              organizationSlug
+              projectSlug
+              targetSlug
             }
             target {
               id
@@ -926,9 +926,9 @@ export function readOperationsStats(input: OperationsStatsSelectorInput, token: 
 
 export function readOperationBody(
   selector: {
-    organization: string;
-    project: string;
-    target: string;
+    organizationSlug: string;
+    projectSlug: string;
+    targetSlug: string;
     hash: string;
   },
   token: string,
@@ -947,9 +947,9 @@ export function readOperationBody(
     token,
     variables: {
       selector: {
-        organization: selector.organization,
-        project: selector.project,
-        target: selector.target,
+        organizationSlug: selector.organizationSlug,
+        projectSlug: selector.projectSlug,
+        targetSlug: selector.targetSlug,
       },
       hash: selector.hash,
     },
@@ -1096,22 +1096,28 @@ export function fetchVersions(selector: TargetSelectorInput, first: number, toke
 
 export function compareToPreviousVersion(
   selector: {
-    organization: string;
-    project: string;
-    target: string;
+    organizationSlug: string;
+    projectSlug: string;
+    targetSlug: string;
     version: string;
   },
   token: string,
 ) {
   return execute({
     document: graphql(`
-      query SchemaCompareToPreviousVersionQuery(
-        $organization: ID!
-        $project: ID!
-        $target: ID!
+      query compareToPreviousVersion(
+        $organizationSlug: String!
+        $projectSlug: String!
+        $targetSlug: String!
         $version: ID!
       ) {
-        target(selector: { organization: $organization, project: $project, target: $target }) {
+        target(
+          selector: {
+            organizationSlug: $organizationSlug
+            projectSlug: $projectSlug
+            targetSlug: $targetSlug
+          }
+        ) {
           id
           schemaVersion(id: $version) {
             id

--- a/integration-tests/testkit/schema-policy.ts
+++ b/integration-tests/testkit/schema-policy.ts
@@ -36,8 +36,8 @@ export const TargetCalculatedPolicy = graphql(`
 `);
 
 export const OrganizationAndProjectsWithSchemaPolicy = graphql(`
-  query OrganizationAndProjectsWithSchemaPolicy($organization: ID!) {
-    organization(selector: { organization: $organization }) {
+  query OrganizationAndProjectsWithSchemaPolicy($organization: String!) {
+    organization(selector: { organizationSlug: $organization }) {
       organization {
         id
         schemaPolicy {

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -129,7 +129,7 @@ export function initSeed() {
                 variables: {
                   allowOverrides,
                   selector: {
-                    organization: organization.slug,
+                    organizationSlug: organization.slug,
                   },
                   policy,
                 },
@@ -153,8 +153,8 @@ export function initSeed() {
               const inviteResult = await inviteToOrganization(
                 {
                   email,
-                  organization: organization.slug,
-                  role: roleId,
+                  organizationSlug: organization.slug,
+                  roleId,
                 },
                 inviteToken,
               ).then(r => r.expectNoGraphQLErrors());
@@ -166,7 +166,7 @@ export function initSeed() {
             },
             async members() {
               const membersResult = await getOrganizationMembers(
-                { organization: organization.slug },
+                { organizationSlug: organization.slug },
                 ownerToken,
               ).then(r => r.expectNoGraphQLErrors());
 
@@ -180,7 +180,7 @@ export function initSeed() {
             },
             async projects() {
               const projectsResult = await getOrganizationProjects(
-                { organization: organization.slug },
+                { organizationSlug: organization.slug },
                 ownerToken,
               ).then(r => r.expectNoGraphQLErrors());
 
@@ -201,7 +201,7 @@ export function initSeed() {
               const useLegacyRegistryModels = options?.useLegacyRegistryModels === true;
               const projectResult = await createProject(
                 {
-                  organization: organization.slug,
+                  organizationSlug: organization.slug,
                   type: projectType,
                   slug: generateUnique(),
                 },
@@ -215,8 +215,8 @@ export function initSeed() {
               if (useLegacyRegistryModels) {
                 await updateRegistryModel(
                   {
-                    organization: organization.slug,
-                    project: projectResult.createProject.ok!.createdProject.slug,
+                    organizationSlug: organization.slug,
+                    projectSlug: projectResult.createProject.ok!.createdProject.slug,
                     model: RegistryModel.Legacy,
                   },
                   ownerToken,
@@ -241,8 +241,8 @@ export function initSeed() {
                     document: UpdateSchemaPolicyForProject,
                     variables: {
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
                       },
                       policy,
                     },
@@ -254,10 +254,10 @@ export function initSeed() {
                 async removeTokens(tokenIds: string[]) {
                   return await deleteTokens(
                     {
-                      organization: organization.slug,
-                      project: project.slug,
-                      target: target.slug,
-                      tokens: tokenIds,
+                      organizationSlug: organization.slug,
+                      projectSlug: project.slug,
+                      targetSlug: target.slug,
+                      tokenIds,
                     },
                     ownerToken,
                   )
@@ -281,9 +281,9 @@ export function initSeed() {
                         description,
                       },
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
-                        target: target.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: target.slug,
                       },
                     },
                     authToken: token,
@@ -311,9 +311,9 @@ export function initSeed() {
                         description,
                       },
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
-                        target: target.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: target.slug,
                       },
                     },
                     authToken: token,
@@ -333,9 +333,9 @@ export function initSeed() {
                     variables: {
                       id: collectionId,
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
-                        target: target.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: target.slug,
                       },
                     },
                     authToken: token,
@@ -362,9 +362,9 @@ export function initSeed() {
                         variables: input.variables,
                       },
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
-                        target: target.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: target.slug,
                       },
                     },
                     authToken: input.token || ownerToken,
@@ -378,9 +378,9 @@ export function initSeed() {
                     variables: {
                       id: input.operationId,
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
-                        target: target.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: target.slug,
                       },
                     },
                     authToken: input.token || ownerToken,
@@ -409,9 +409,9 @@ export function initSeed() {
                         variables: input.variables,
                       },
                       selector: {
-                        organization: organization.slug,
-                        project: project.slug,
-                        target: target.slug,
+                        organizationSlug: organization.slug,
+                        projectSlug: project.slug,
+                        targetSlug: target.slug,
                       },
                     },
                     authToken: input.token || ownerToken,
@@ -443,9 +443,9 @@ export function initSeed() {
                   const tokenResult = await createToken(
                     {
                       name: generateUnique(),
-                      organization: organization.slug,
-                      project: project.slug,
-                      target: target.slug,
+                      organizationSlug: organization.slug,
+                      projectSlug: project.slug,
+                      targetSlug: target.slug,
                       organizationScopes: organizationScopes,
                       projectScopes: projectScopes,
                       targetScopes: targetScopes,
@@ -462,9 +462,9 @@ export function initSeed() {
                     async readOperationBody(hash: string) {
                       const operationBodyResult = await readOperationBody(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                           hash,
                         },
                         secret,
@@ -475,9 +475,9 @@ export function initSeed() {
                     async readOperationsStats(from: string, to: string) {
                       const statsResult = await readOperationsStats(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                           period: {
                             from,
                             to,
@@ -522,9 +522,9 @@ export function initSeed() {
                       const result = await setTargetValidation(
                         {
                           enabled,
-                          target: target.slug,
-                          project: project.slug,
-                          organization: organization.slug,
+                          targetSlug: target.slug,
+                          projectSlug: project.slug,
+                          organizationSlug: organization.slug,
                         },
                         {
                           token: secret,
@@ -542,13 +542,13 @@ export function initSeed() {
                     }) {
                       const result = await updateTargetValidationSettings(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                           excludedClients,
                           percentage,
                           period: 2,
-                          targets: [target.id],
+                          targetIds: [target.id],
                         },
                         {
                           token: secret,
@@ -560,21 +560,21 @@ export function initSeed() {
                     async fetchMetadataFromCDN() {
                       return fetchMetadataFromCDN(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                         },
                         secret,
                       );
                     },
-                    async updateSchemaVersionStatus(version: string, valid: boolean) {
+                    async updateSchemaVersionStatus(versionId: string, valid: boolean) {
                       return await updateSchemaVersionStatus(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                           valid,
-                          version,
+                          versionId,
                         },
                         secret,
                       ).then(r => r.expectNoGraphQLErrors());
@@ -582,9 +582,9 @@ export function initSeed() {
                     async fetchSchemaFromCDN() {
                       return fetchSchemaFromCDN(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                         },
                         secret,
                       );
@@ -592,9 +592,9 @@ export function initSeed() {
                     async createCdnAccess() {
                       const result = await createCdnAccess(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                         },
                         secret,
                       ).then(r => r.expectNoGraphQLErrors());
@@ -654,9 +654,9 @@ export function initSeed() {
                       return (
                         await compareToPreviousVersion(
                           {
-                            organization: organization.slug,
-                            project: project.slug,
-                            target: target.slug,
+                            organizationSlug: organization.slug,
+                            projectSlug: project.slug,
+                            targetSlug: target.slug,
                             version,
                           },
                           secret,
@@ -667,9 +667,9 @@ export function initSeed() {
                       const result = await updateBaseSchema(
                         {
                           newBase,
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                         },
                         secret,
                       ).then(r => r.expectNoGraphQLErrors());
@@ -679,9 +679,9 @@ export function initSeed() {
                     async fetchVersions(count: number) {
                       const result = await fetchVersions(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                         },
                         count,
                         secret,
@@ -703,9 +703,9 @@ export function initSeed() {
                     async fetchSupergraph() {
                       const supergraphResponse = await fetchSupergraphFromCDN(
                         {
-                          organization: organization.slug,
-                          project: project.slug,
-                          target: target.slug,
+                          organizationSlug: organization.slug,
+                          projectSlug: project.slug,
+                          targetSlug: target.slug,
                         },
                         secret,
                       );
@@ -728,7 +728,7 @@ export function initSeed() {
 
               const invitationResult = await inviteToOrganization(
                 {
-                  organization: organization.slug,
+                  organizationSlug: organization.slug,
                   email: memberEmail,
                 },
                 inviteToken,
@@ -769,9 +769,9 @@ export function initSeed() {
                 ) {
                   const memberRoleAssignmentResult = await assignMemberRole(
                     {
-                      organization: organization.slug,
-                      user: input.userId,
-                      role: input.roleId,
+                      organizationSlug: organization.slug,
+                      userId: input.userId,
+                      roleId: input.roleId,
                     },
                     options.useMemberToken ? memberToken : ownerToken,
                   ).then(r => r.expectNoGraphQLErrors());
@@ -790,8 +790,8 @@ export function initSeed() {
                 ) {
                   const memberRoleDeletionResult = await deleteMemberRole(
                     {
-                      organization: organization.slug,
-                      role: roleId,
+                      organizationSlug: organization.slug,
+                      roleId,
                     },
                     options.useMemberToken ? memberToken : ownerToken,
                   ).then(r => r.expectNoGraphQLErrors());
@@ -820,7 +820,7 @@ export function initSeed() {
                   });
                   const memberRoleCreationResult = await createMemberRole(
                     {
-                      organization: organization.slug,
+                      organizationSlug: organization.slug,
                       name,
                       description: 'some description',
                       organizationAccessScopes: scopes.organization,
@@ -875,8 +875,8 @@ export function initSeed() {
                 ) {
                   const memberRoleUpdateResult = await updateMemberRole(
                     {
-                      organization: organization.slug,
-                      role: role.id,
+                      organizationSlug: organization.slug,
+                      roleId: role.id,
                       name: role.name,
                       description: role.description,
                       organizationAccessScopes: scopes.organization,

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -1524,9 +1524,9 @@ test('get app deployment documents via GraphQL API', async () => {
     document: GetPaginatedPersistedDocuments,
     variables: {
       targetSelector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
@@ -1641,9 +1641,9 @@ test('paginate app deployment documents via GraphQL API', async () => {
     document: GetPaginatedPersistedDocuments,
     variables: {
       targetSelector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
@@ -1674,9 +1674,9 @@ test('paginate app deployment documents via GraphQL API', async () => {
     document: GetPaginatedPersistedDocuments,
     variables: {
       targetSelector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
@@ -1708,9 +1708,9 @@ test('paginate app deployment documents via GraphQL API', async () => {
     document: GetPaginatedPersistedDocuments,
     variables: {
       targetSelector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
@@ -1814,9 +1814,9 @@ test('app deployment usage reporting', async () => {
     document: GetAppDeployment,
     variables: {
       targetSelector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',
@@ -1867,9 +1867,9 @@ test('app deployment usage reporting', async () => {
     document: GetAppDeployment,
     variables: {
       targetSelector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       appDeploymentName: 'app-name',
       appDeploymentVersion: 'app-version',

--- a/integration-tests/tests/api/artifacts-cdn.spec.ts
+++ b/integration-tests/tests/api/artifacts-cdn.spec.ts
@@ -485,9 +485,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
       },
       authToken: token.secret,
@@ -501,9 +501,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         after: endCursor,
       },
@@ -518,9 +518,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         after: endCursor,
       },
@@ -546,9 +546,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         first: 2,
       },
@@ -564,9 +564,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         first: 2,
       },
@@ -591,9 +591,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         first: 1,
       },
@@ -606,9 +606,9 @@ describe('CDN token', () => {
       variables: {
         input: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
           cdnAccessTokenId: paginatedResult.target!.cdnAccessTokens.edges[0].node.id,
         },
@@ -626,9 +626,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         first: 1,
       },
@@ -651,9 +651,9 @@ describe('CDN token', () => {
       document: TargetCDNAccessTokensQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         first: 1,
       },
@@ -667,9 +667,9 @@ describe('CDN token', () => {
       variables: {
         input: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
           cdnAccessTokenId: paginatedResult.target!.cdnAccessTokens.edges[0].node.id,
         },

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -4,8 +4,8 @@ import { execute } from '../../../testkit/graphql';
 import { initSeed } from '../../../testkit/seed';
 
 const OrganizationWithOIDCIntegration = graphql(`
-  query OrganizationWithOIDCIntegration($organizationId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query OrganizationWithOIDCIntegration($organizationSlug: String!) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         oidcIntegration {
@@ -18,8 +18,8 @@ const OrganizationWithOIDCIntegration = graphql(`
 `);
 
 const OrganizationReadTest = graphql(`
-  query OrganizationReadTest($organizationId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query OrganizationReadTest($organizationSlug: String!) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
       }
@@ -112,7 +112,7 @@ describe('create', () => {
       const refetchedOrg = await execute({
         document: OrganizationWithOIDCIntegration,
         variables: {
-          organizationId: organization.slug,
+          organizationSlug: organization.slug,
         },
         authToken: ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
@@ -455,7 +455,7 @@ describe('delete', () => {
       let refetchedOrg = await execute({
         document: OrganizationWithOIDCIntegration,
         variables: {
-          organizationId: organization.slug,
+          organizationSlug: organization.slug,
         },
         authToken: ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
@@ -494,7 +494,7 @@ describe('delete', () => {
       refetchedOrg = await execute({
         document: OrganizationWithOIDCIntegration,
         variables: {
-          organizationId: organization.slug,
+          organizationSlug: organization.slug,
         },
         authToken: ownerToken,
       }).then(r => r.expectNoGraphQLErrors());
@@ -800,7 +800,7 @@ describe('restrictions', () => {
     const refetchedOrg = await execute({
       document: OrganizationWithOIDCIntegration,
       variables: {
-        organizationId: organization.slug,
+        organizationSlug: organization.slug,
       },
       authToken: ownerToken,
     }).then(r => r.expectNoGraphQLErrors());
@@ -842,7 +842,7 @@ describe('restrictions', () => {
     const orgAfterOidc = await execute({
       document: OrganizationWithOIDCIntegration,
       variables: {
-        organizationId: organization.slug,
+        organizationSlug: organization.slug,
       },
       authToken: ownerToken,
     }).then(r => r.expectNoGraphQLErrors());
@@ -869,7 +869,7 @@ describe('restrictions', () => {
     const orgAfterDisablingOidcRestrictions = await execute({
       document: OrganizationWithOIDCIntegration,
       variables: {
-        organizationId: organization.slug,
+        organizationSlug: organization.slug,
       },
       authToken: ownerToken,
     }).then(r => r.expectNoGraphQLErrors());
@@ -924,7 +924,7 @@ describe('restrictions', () => {
       const readAccessCheck = await execute({
         document: OrganizationReadTest,
         variables: {
-          organizationId: organization.slug,
+          organizationSlug: organization.slug,
         },
         authToken: ownerToken,
       }).then(r => r.expectNoGraphQLErrors());

--- a/integration-tests/tests/api/organization/crud.spec.ts
+++ b/integration-tests/tests/api/organization/crud.spec.ts
@@ -10,7 +10,7 @@ test.concurrent(
 
     const changeOrganizationSlugResult = await updateOrganizationSlug(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         slug: organization.slug,
       },
       ownerToken,
@@ -21,7 +21,7 @@ test.concurrent(
     expect(changeOrganizationSlugResult.updateOrganizationSlug.error).toBeNull();
     expect(result?.organization.name).toBe(organization.slug);
     expect(result?.organization.slug).toEqual(organization.slug);
-    expect(result?.selector.organization).toEqual(organization.slug);
+    expect(result?.selector.organizationSlug).toEqual(organization.slug);
   },
 );
 
@@ -34,7 +34,7 @@ test.concurrent(
     const newSlug = randomUUID();
     const changeOrganizationSlugResult = await updateOrganizationSlug(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         slug: newSlug,
       },
       ownerToken,
@@ -45,7 +45,7 @@ test.concurrent(
     expect(changeOrganizationSlugResult.updateOrganizationSlug.error).toBeNull();
     expect(result?.organization.name).toBe(newSlug);
     expect(result?.organization.slug).toEqual(newSlug);
-    expect(result?.selector.organization).toEqual(newSlug);
+    expect(result?.selector.organizationSlug).toEqual(newSlug);
   },
 );
 
@@ -58,7 +58,7 @@ test.concurrent(
     const newSlug = randomUUID();
     const changeOrganizationSlugResult = await updateOrganizationSlug(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         slug: newSlug,
       },
       ownerToken,
@@ -71,7 +71,7 @@ test.concurrent(
     // We do it for legacy reasons, as some queries still use the name.
     expect(result?.organization.name).toBe(newSlug);
     expect(result?.organization.slug).toEqual(newSlug);
-    expect(result?.selector.organization).toEqual(newSlug);
+    expect(result?.selector.organizationSlug).toEqual(newSlug);
   },
 );
 
@@ -84,7 +84,7 @@ test.concurrent(
     const newSlug = 'graphql';
     const changeOrganizationSlugResult = await updateOrganizationSlug(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         slug: newSlug,
       },
       ownerToken,
@@ -104,7 +104,7 @@ test.concurrent(
 
     const changeOrganizationSlugResult = await updateOrganizationSlug(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         slug: anotherOrganization.slug,
       },
       ownerToken,

--- a/integration-tests/tests/api/organization/transfer.spec.ts
+++ b/integration-tests/tests/api/organization/transfer.spec.ts
@@ -18,7 +18,7 @@ test.concurrent(
 
     const transferRequestResult = await getOrganizationTransferRequest(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         code: 'non-existing-code',
       },
       ownerToken,
@@ -37,8 +37,8 @@ test.concurrent(
 
     const transferRequestResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -57,8 +57,8 @@ test.concurrent(
 
     const errors = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: orgMembers.find(u => u.user.email === ownerEmail)!.user.id,
+        organizationSlug: organization.slug,
+        userId: orgMembers.find(u => u.user.email === ownerEmail)!.user.id,
       },
       memberToken,
     ).then(r => r.expectGraphQLErrors());
@@ -77,8 +77,8 @@ test.concurrent(
 
     const transferRequestResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       memberToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -96,8 +96,8 @@ test.concurrent(
 
     const requestTransferResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -112,7 +112,7 @@ test.concurrent(
 
     const errors = await getOrganizationTransferRequest(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         code,
       },
       nonMemberToken,
@@ -133,8 +133,8 @@ test.concurrent(
 
     const requestTransferResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -147,7 +147,7 @@ test.concurrent(
 
     const requestResult = await getOrganizationTransferRequest(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         code,
       },
       lonelyMemberToken,
@@ -163,8 +163,8 @@ test.concurrent('recipient should be able to access the transfer request', async
   const { member, memberToken } = await inviteAndJoinMember();
   const requestTransferResult = await requestOrganizationTransfer(
     {
-      organization: organization.slug,
-      user: member.user.id,
+      organizationSlug: organization.slug,
+      userId: member.user.id,
     },
     ownerToken,
   ).then(r => r.expectNoGraphQLErrors());
@@ -177,7 +177,7 @@ test.concurrent('recipient should be able to access the transfer request', async
 
   const requestResult = await getOrganizationTransferRequest(
     {
-      organization: organization.slug,
+      organizationSlug: organization.slug,
       code,
     },
     memberToken,
@@ -193,8 +193,8 @@ test.concurrent('recipient should be able to answer the ownership transfer', asy
 
   const requestTransferResult = await requestOrganizationTransfer(
     {
-      organization: organization.slug,
-      user: member.user.id,
+      organizationSlug: organization.slug,
+      userId: member.user.id,
     },
     ownerToken,
   ).then(r => r.expectNoGraphQLErrors());
@@ -207,7 +207,7 @@ test.concurrent('recipient should be able to answer the ownership transfer', asy
 
   const answerResult = await answerOrganizationTransferRequest(
     {
-      organization: organization.slug,
+      organizationSlug: organization.slug,
       code,
       accept: true,
     },
@@ -227,8 +227,8 @@ test.concurrent(
 
     const requestTransferResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -241,7 +241,7 @@ test.concurrent(
 
     const answerResult = await answerOrganizationTransferRequest(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         code,
         accept: true,
       },
@@ -259,8 +259,8 @@ test.concurrent('owner should not be able to answer the ownership transfer', asy
 
   const requestTransferResult = await requestOrganizationTransfer(
     {
-      organization: organization.slug,
-      user: member.user.id,
+      organizationSlug: organization.slug,
+      userId: member.user.id,
     },
     ownerToken,
   ).then(r => r.expectNoGraphQLErrors());
@@ -273,7 +273,7 @@ test.concurrent('owner should not be able to answer the ownership transfer', asy
 
   const answerResult = await answerOrganizationTransferRequest(
     {
-      organization: organization.slug,
+      organizationSlug: organization.slug,
       code,
       accept: true,
     },
@@ -292,8 +292,8 @@ test.concurrent(
 
     const requestTransferResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -307,7 +307,7 @@ test.concurrent(
     const { ownerToken: nonMemberToken } = await initSeed().createOwner();
     const answerResult = await answerOrganizationTransferRequest(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         code,
         accept: true,
       },
@@ -327,8 +327,8 @@ test.concurrent(
 
     const requestTransferResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -376,8 +376,8 @@ test.concurrent(
 
     const requestTransferResult = await requestOrganizationTransfer(
       {
-        organization: organization.slug,
-        user: member.user.id,
+        organizationSlug: organization.slug,
+        userId: member.user.id,
       },
       ownerToken,
     ).then(r => r.expectNoGraphQLErrors());
@@ -390,7 +390,7 @@ test.concurrent(
 
     const answerResult = await answerOrganizationTransferRequest(
       {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         code,
         accept: true,
       },

--- a/integration-tests/tests/api/policy/policy-access.spec.ts
+++ b/integration-tests/tests/api/policy/policy-access.spec.ts
@@ -39,9 +39,9 @@ describe('Policy Access', () => {
           document: query,
           variables: {
             selector: {
-              organization: organization.slug,
-              project: project.slug,
-              target: target.slug,
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
+              targetSlug: target.slug,
             },
           },
           authToken: memberToken,
@@ -63,9 +63,9 @@ describe('Policy Access', () => {
           document: query,
           variables: {
             selector: {
-              organization: organization.slug,
-              project: project.slug,
-              target: target.slug,
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
+              targetSlug: target.slug,
             },
           },
           authToken: memberToken,
@@ -107,8 +107,8 @@ describe('Policy Access', () => {
           document: query,
           variables: {
             selector: {
-              organization: organization.slug,
-              project: project.slug,
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
             },
           },
           authToken: memberToken,
@@ -130,8 +130,8 @@ describe('Policy Access', () => {
           document: query,
           variables: {
             selector: {
-              organization: organization.slug,
-              project: project.slug,
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
             },
           },
           authToken: memberToken,
@@ -173,7 +173,7 @@ describe('Policy Access', () => {
           document: query,
           variables: {
             selector: {
-              organization: organization.slug,
+              organizationSlug: organization.slug,
             },
           },
           authToken: memberToken,
@@ -194,7 +194,7 @@ describe('Policy Access', () => {
           document: query,
           variables: {
             selector: {
-              organization: organization.slug,
+              organizationSlug: organization.slug,
             },
           },
           authToken: memberToken,

--- a/integration-tests/tests/api/policy/policy-crud.spec.ts
+++ b/integration-tests/tests/api/policy/policy-crud.spec.ts
@@ -25,9 +25,9 @@ describe('Policy CRUD', () => {
           document: TargetCalculatedPolicy,
           variables: {
             selector: {
-              organization: organization.slug,
-              project: project.slug,
-              target: target.slug,
+              organizationSlug: organization.slug,
+              projectSlug: project.slug,
+              targetSlug: target.slug,
             },
           },
           authToken: ownerToken,
@@ -49,9 +49,9 @@ describe('Policy CRUD', () => {
         document: TargetCalculatedPolicy,
         variables: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
         },
         authToken: ownerToken,
@@ -76,9 +76,9 @@ describe('Policy CRUD', () => {
         document: TargetCalculatedPolicy,
         variables: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
         },
         authToken: ownerToken,
@@ -104,9 +104,9 @@ describe('Policy CRUD', () => {
         document: TargetCalculatedPolicy,
         variables: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
         },
         authToken: ownerToken,
@@ -151,9 +151,9 @@ describe('Policy CRUD', () => {
         document: TargetCalculatedPolicy,
         variables: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
         },
         authToken: ownerToken,
@@ -202,9 +202,9 @@ describe('Policy CRUD', () => {
         document: TargetCalculatedPolicy,
         variables: {
           selector: {
-            organization: organization.slug,
-            project: project.slug,
-            target: target.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
+            targetSlug: target.slug,
           },
         },
         authToken: ownerToken,

--- a/integration-tests/tests/api/project/crud.spec.ts
+++ b/integration-tests/tests/api/project/crud.spec.ts
@@ -38,8 +38,8 @@ test.concurrent(`changing a project's slug should result changing its name`, asy
 
   const renameResult = await updateProjectSlug(
     {
-      organization: organization.slug,
-      project: project.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
       slug: 'bar',
     },
     ownerToken,
@@ -48,7 +48,7 @@ test.concurrent(`changing a project's slug should result changing its name`, asy
   expect(renameResult.updateProjectSlug.error).toBeNull();
   expect(renameResult.updateProjectSlug.ok?.project.name).toBe('bar');
   expect(renameResult.updateProjectSlug.ok?.project.slug).toBe('bar');
-  expect(renameResult.updateProjectSlug.ok?.selector.project).toBe('bar');
+  expect(renameResult.updateProjectSlug.ok?.selector.projectSlug).toBe('bar');
 });
 
 test.concurrent(
@@ -60,8 +60,8 @@ test.concurrent(
 
     const renameResult = await updateProjectSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: project.slug,
       },
       ownerToken,
@@ -70,7 +70,7 @@ test.concurrent(
     expect(renameResult.updateProjectSlug.error).toBeNull();
     expect(renameResult.updateProjectSlug.ok?.project.name).toBe(project.slug);
     expect(renameResult.updateProjectSlug.ok?.project.slug).toBe(project.slug);
-    expect(renameResult.updateProjectSlug.ok?.selector.project).toBe(project.slug);
+    expect(renameResult.updateProjectSlug.ok?.selector.projectSlug).toBe(project.slug);
   },
 );
 
@@ -84,8 +84,8 @@ test.concurrent(
 
     const renameResult = await updateProjectSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: project2.slug,
       },
       ownerToken,
@@ -123,8 +123,8 @@ test.concurrent(
 
     const renameResult = await updateProjectSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: project2.slug,
       },
       ownerToken,
@@ -133,7 +133,7 @@ test.concurrent(
     expect(renameResult.updateProjectSlug.error).toBeNull();
     expect(renameResult.updateProjectSlug.ok?.project.name).toBe(project2.slug);
     expect(renameResult.updateProjectSlug.ok?.project.slug).toBe(project2.slug);
-    expect(renameResult.updateProjectSlug.ok?.selector.project).toBe(project2.slug);
+    expect(renameResult.updateProjectSlug.ok?.selector.projectSlug).toBe(project2.slug);
   },
 );
 
@@ -146,8 +146,8 @@ test.concurrent(
 
     const renameResult = await updateProjectSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: 'view',
       },
       ownerToken,
@@ -167,8 +167,8 @@ test.concurrent(
 
     const renameResult = await updateProjectSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: 'new',
       },
       ownerToken,
@@ -188,8 +188,8 @@ test.concurrent(
 
     const renameResult = await updateProjectSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: 'new',
       },
       ownerToken,

--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -24,7 +24,7 @@ test('rate limit approaching and reached for organization', async () => {
 
   await updateOrgRateLimit(
     {
-      organization: organization.slug,
+      organizationSlug: organization.slug,
     },
     {
       operations: 11,

--- a/integration-tests/tests/api/schema/check.spec.ts
+++ b/integration-tests/tests/api/schema/check.spec.ts
@@ -1980,15 +1980,15 @@ test.concurrent(
       github: null,
       metadata: null,
       logIds: [],
-      project: project.id,
+      projectId: project.id,
       service: null,
-      organization: organization.id,
+      organizationId: organization.id,
       previousSchemaVersion: null,
       valid: true,
       schemaCompositionErrors: [],
       supergraphSDL: null,
       tags: null,
-      target: target.id,
+      targetId: target.id,
       url: null,
     });
     await storage.destroy();

--- a/integration-tests/tests/api/schema/check.spec.ts
+++ b/integration-tests/tests/api/schema/check.spec.ts
@@ -285,9 +285,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -372,9 +372,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -433,9 +433,9 @@ test.concurrent('failed check due to graphql validation is persisted', async ({ 
     document: SchemaCheckQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       id: schemaCheckId,
     },
@@ -522,9 +522,9 @@ test.concurrent('failed check due to breaking change is persisted', async ({ exp
     document: SchemaCheckQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       id: schemaCheckId,
     },
@@ -619,9 +619,9 @@ test.concurrent('failed check due to policy error is persisted', async ({ expect
     document: SchemaCheckQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       id: schemaCheckId,
     },
@@ -730,9 +730,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -856,9 +856,9 @@ test.concurrent('metadata is persisted', async ({ expect }) => {
     document: SchemaCheckQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       id: schemaCheckId,
     },
@@ -944,9 +944,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -973,9 +973,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -1066,9 +1066,9 @@ test.concurrent('approve failed schema check with a comment', async ({ expect })
     document: ApproveFailedSchemaCheckMutation,
     variables: {
       input: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         schemaCheckId,
         comment: 'This is a comment',
       },
@@ -1096,9 +1096,9 @@ test.concurrent('approve failed schema check with a comment', async ({ expect })
     document: SchemaCheckQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
       },
       id: schemaCheckId,
     },
@@ -1184,9 +1184,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -1236,9 +1236,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: newSchemaCheckId,
       },
@@ -1334,9 +1334,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -1386,9 +1386,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: newSchemaCheckId,
       },
@@ -1478,9 +1478,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -1531,9 +1531,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: newSchemaCheckId,
       },

--- a/integration-tests/tests/api/schema/composition-federation-2.spec.ts
+++ b/integration-tests/tests/api/schema/composition-federation-2.spec.ts
@@ -45,8 +45,8 @@ test.concurrent('call an external service to compose and validate services', asy
       endpoint: `http://${dockerAddress}/compose`,
       // eslint-disable-next-line no-process-env
       secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-      project: project.slug,
-      organization: organization.slug,
+      projectSlug: project.slug,
+      organizationSlug: organization.slug,
     },
     writeToken.secret,
   ).then(r => r.expectNoGraphQLErrors());

--- a/integration-tests/tests/api/schema/contracts-check.spec.ts
+++ b/integration-tests/tests/api/schema/contracts-check.spec.ts
@@ -494,9 +494,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -522,9 +522,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -670,9 +670,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -727,9 +727,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: newSchemaCheckId,
       },
@@ -875,9 +875,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -932,9 +932,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: newSchemaCheckId,
       },
@@ -1073,9 +1073,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },
@@ -1130,9 +1130,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: newSchemaCheckId,
       },
@@ -1276,9 +1276,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -1392,9 +1392,9 @@ test.concurrent(
       document: SchemaCheckQuery,
       variables: {
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
         id: schemaCheckId,
       },
@@ -1412,9 +1412,9 @@ test.concurrent(
       document: ApproveFailedSchemaCheckMutation,
       variables: {
         input: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
           schemaCheckId,
         },
       },

--- a/integration-tests/tests/api/schema/delete.spec.ts
+++ b/integration-tests/tests/api/schema/delete.spec.ts
@@ -178,9 +178,9 @@ test.concurrent(
       expect(deleteServiceResult.schemaDelete.__typename).toBe('SchemaDeleteSuccess');
 
       const latestVersion = await storage.getLatestVersion({
-        target: target.id,
-        project: project.id,
-        organization: organization.id,
+        targetId: target.id,
+        projectId: project.id,
+        organizationId: organization.id,
       });
 
       expect(latestVersion.compositeSchemaSDL).toMatchInlineSnapshot(`
@@ -310,9 +310,9 @@ test.concurrent(
       expect(deleteServiceResult.schemaDelete.__typename).toBe('SchemaDeleteSuccess');
 
       const latestVersion = await storage.getLatestVersion({
-        target: target.id,
-        project: project.id,
-        organization: organization.id,
+        targetId: target.id,
+        projectId: project.id,
+        organizationId: organization.id,
       });
 
       expect(latestVersion.compositeSchemaSDL).toEqual(null);

--- a/integration-tests/tests/api/schema/delete.spec.ts
+++ b/integration-tests/tests/api/schema/delete.spec.ts
@@ -249,8 +249,8 @@ test.concurrent(
           endpoint: `http://${await getServiceHost('composition_federation_2', 3069, false)}/compose`,
           // eslint-disable-next-line no-process-env
           secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-          project: project.slug,
-          organization: organization.slug,
+          projectSlug: project.slug,
+          organizationSlug: organization.slug,
         },
         readToken.secret,
       ).then(r => r.expectNoGraphQLErrors());

--- a/integration-tests/tests/api/schema/external-composition.spec.ts
+++ b/integration-tests/tests/api/schema/external-composition.spec.ts
@@ -50,8 +50,8 @@ test.concurrent('call an external service to compose and validate services', asy
       endpoint: `http://${dockerAddress}/compose`,
       // eslint-disable-next-line no-process-env
       secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-      project: project.slug,
-      organization: organization.slug,
+      projectSlug: project.slug,
+      organizationSlug: organization.slug,
     },
     writeToken.secret,
   ).then(r => r.expectNoGraphQLErrors());
@@ -138,8 +138,8 @@ test.concurrent(
         endpoint: `http://${dockerAddress}/fail_on_signature`,
         // eslint-disable-next-line no-process-env
         secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-        project: project.slug,
-        organization: organization.slug,
+        projectSlug: project.slug,
+        organizationSlug: organization.slug,
       },
       writeToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
@@ -238,8 +238,8 @@ test.concurrent(
         endpoint: `http://${dockerAddress}/non-existing-endpoint`,
         // eslint-disable-next-line no-process-env
         secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-        project: project.slug,
-        organization: organization.slug,
+        projectSlug: project.slug,
+        organizationSlug: organization.slug,
       },
       writeToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
@@ -333,8 +333,8 @@ test.concurrent('a timeout error should be visible to the user', async ({ expect
       endpoint: `http://${dockerAddress}/timeout`,
       // eslint-disable-next-line no-process-env
       secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-      project: project.slug,
-      organization: organization.slug,
+      projectSlug: project.slug,
+      organizationSlug: organization.slug,
     },
     writeToken.secret,
   ).then(r => r.expectNoGraphQLErrors());

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -692,9 +692,9 @@ describe('schema publishing changes are persisted', () => {
       }
 
       const latestVersion = await storage.getLatestVersion({
-        target: target.id,
-        project: project.id,
-        organization: organization.id,
+        targetId: target.id,
+        projectId: project.id,
+        organizationId: organization.id,
       });
 
       const changes = await storage.getSchemaChangesForVersion({
@@ -2796,9 +2796,9 @@ test('Target.schemaVersion: result is read from the database', async () => {
     }
 
     const latestVersion = await storage.getLatestVersion({
-      target: target.id,
-      project: project.id,
-      organization: organization.id,
+      targetId: target.id,
+      projectId: project.id,
+      organizationId: organization.id,
     });
 
     const result = await execute({
@@ -2935,9 +2935,9 @@ test('Composition Error (Federation 2) can be served from the database', async (
     }
 
     const latestVersion = await storage.getLatestVersion({
-      target: target.id,
-      project: project.id,
-      organization: organization.id,
+      targetId: target.id,
+      projectId: project.id,
+      organizationId: organization.id,
     });
 
     const result = await execute({
@@ -3092,9 +3092,9 @@ test('Composition Network Failure (Federation 2)', async () => {
     }
 
     const latestVersion = await storage.getLatestVersion({
-      target: target.id,
-      project: project.id,
-      organization: organization.id,
+      targetId: target.id,
+      projectId: project.id,
+      organizationId: organization.id,
     });
 
     const result = await execute({
@@ -4295,15 +4295,15 @@ test.concurrent(
       github: null,
       metadata: null,
       logIds: [],
-      project: project.id,
+      projectId: project.id,
       service: null,
-      organization: organization.id,
+      organizationId: organization.id,
       previousSchemaVersion: null,
       valid: true,
       schemaCompositionErrors: [],
       supergraphSDL: null,
       tags: null,
-      target: target.id,
+      targetId: target.id,
       url: null,
     });
     await storage.destroy();

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -575,8 +575,8 @@ describe.each`
       .then(r => r.expectNoGraphQLErrors());
     const createTargetResult = await createTarget(
       {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
         slug: 'target2',
       },
       ownerToken,
@@ -2667,12 +2667,18 @@ describe('schema publishing changes are persisted', () => {
 
 const SchemaCompareToPreviousVersionQuery = graphql(`
   query SchemaCompareToPreviousVersionQuery(
-    $organization: ID!
-    $project: ID!
-    $target: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $version: ID!
   ) {
-    target(selector: { organization: $organization, project: $project, target: $target }) {
+    target(
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
+    ) {
       id
       schemaVersion(id: $version) {
         id
@@ -2798,9 +2804,9 @@ test('Target.schemaVersion: result is read from the database', async () => {
     const result = await execute({
       document: SchemaCompareToPreviousVersionQuery,
       variables: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         version: latestVersion.id,
       },
       authToken: ownerToken,
@@ -2893,8 +2899,8 @@ test('Composition Error (Federation 2) can be served from the database', async (
         endpoint: `http://${serviceAddress}/compose`,
         // eslint-disable-next-line no-process-env
         secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-        project: project.slug,
-        organization: organization.slug,
+        projectSlug: project.slug,
+        organizationSlug: organization.slug,
       },
       readWriteToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
@@ -2937,9 +2943,9 @@ test('Composition Error (Federation 2) can be served from the database', async (
     const result = await execute({
       document: SchemaCompareToPreviousVersionQuery,
       variables: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         version: latestVersion.id,
       },
       authToken: ownerToken,
@@ -3022,8 +3028,8 @@ test('Composition Network Failure (Federation 2)', async () => {
         endpoint: `http://${serviceAddress}/compose`,
         // eslint-disable-next-line no-process-env
         secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-        project: project.slug,
-        organization: organization.slug,
+        projectSlug: project.slug,
+        organizationSlug: organization.slug,
       },
       readWriteToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
@@ -3062,8 +3068,8 @@ test('Composition Network Failure (Federation 2)', async () => {
       {
         endpoint: `http://${serviceAddress}/no_compose`,
         secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
-        project: project.slug,
-        organization: organization.slug,
+        projectSlug: project.slug,
+        organizationSlug: organization.slug,
       },
       readWriteToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
@@ -3094,9 +3100,9 @@ test('Composition Network Failure (Federation 2)', async () => {
     const result = await execute({
       document: SchemaCompareToPreviousVersionQuery,
       variables: {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         version: latestVersion.id,
       },
       authToken: ownerToken,

--- a/integration-tests/tests/api/target/crud.spec.ts
+++ b/integration-tests/tests/api/target/crud.spec.ts
@@ -9,9 +9,9 @@ test.concurrent(`changing a target's slug should result changing its name`, asyn
 
   const renameResult = await updateTargetSlug(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: target.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: target.slug,
       slug: 'bar',
     },
     ownerToken,
@@ -20,7 +20,7 @@ test.concurrent(`changing a target's slug should result changing its name`, asyn
   expect(renameResult.updateTargetSlug.error).toBeNull();
   expect(renameResult.updateTargetSlug.ok?.target.name).toBe('bar');
   expect(renameResult.updateTargetSlug.ok?.target.slug).toBe('bar');
-  expect(renameResult.updateTargetSlug.ok?.selector.target).toBe('bar');
+  expect(renameResult.updateTargetSlug.ok?.selector.targetSlug).toBe('bar');
 });
 
 test.concurrent(
@@ -32,9 +32,9 @@ test.concurrent(
 
     const renameResult = await updateTargetSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         slug: target.slug,
       },
       ownerToken,
@@ -43,7 +43,7 @@ test.concurrent(
     expect(renameResult.updateTargetSlug.error).toBeNull();
     expect(renameResult.updateTargetSlug.ok?.target.name).toBe(target.slug);
     expect(renameResult.updateTargetSlug.ok?.target.slug).toBe(target.slug);
-    expect(renameResult.updateTargetSlug.ok?.selector.target).toBe(target.slug);
+    expect(renameResult.updateTargetSlug.ok?.selector.targetSlug).toBe(target.slug);
   },
 );
 
@@ -62,9 +62,9 @@ test.concurrent(
 
     const renameResult = await updateTargetSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
-        target: firstTarget.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: firstTarget.slug,
         slug: secondTarget.slug,
       },
       ownerToken,
@@ -90,9 +90,9 @@ test.concurrent(
 
     await updateTargetSlug(
       {
-        organization: organization.slug,
-        project: project2.slug,
-        target: target2.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project2.slug,
+        targetSlug: target2.slug,
         slug: sharedSlug,
       },
       ownerToken,
@@ -100,9 +100,9 @@ test.concurrent(
 
     const renameResult = await updateTargetSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         slug: sharedSlug,
       },
       ownerToken,
@@ -111,7 +111,7 @@ test.concurrent(
     expect(renameResult.updateTargetSlug.error).toBeNull();
     expect(renameResult.updateTargetSlug.ok?.target.name).toBe(sharedSlug);
     expect(renameResult.updateTargetSlug.ok?.target.slug).toBe(sharedSlug);
-    expect(renameResult.updateTargetSlug.ok?.selector.target).toBe(sharedSlug);
+    expect(renameResult.updateTargetSlug.ok?.selector.targetSlug).toBe(sharedSlug);
   },
 );
 
@@ -124,9 +124,9 @@ test.concurrent(
 
     const renameResult = await updateTargetSlug(
       {
-        organization: organization.slug,
-        project: project.slug,
-        target: target.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        targetSlug: target.slug,
         slug: 'view',
       },
       ownerToken,

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -335,8 +335,8 @@ test.concurrent('check usage from two selected targets', async ({ expect }) => {
   const productionTargetResult = await createTarget(
     {
       slug: 'target2',
-      organization: organization.slug,
-      project: project.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
     },
     ownerToken,
   ).then(r => r.expectNoGraphQLErrors());
@@ -431,12 +431,12 @@ test.concurrent('check usage from two selected targets', async ({ expect }) => {
   // Now switch to using checking both staging and production
   const updateValidationResult = await updateTargetValidationSettings(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: staging.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: staging.slug,
       percentage: 50, // Out of 3 requests, 1 is for Query.me, 2 are done for Query.me so it's 1/3 = 33.3%
       period: 2,
-      targets: [productionTarget.id, staging.id],
+      targetIds: [productionTarget.id, staging.id],
     },
     {
       authToken: ownerToken,
@@ -581,12 +581,12 @@ test.concurrent('check usage not from excluded client names', async ({ expect })
   // Exclude app from the check (tests partial, incomplete exclusion)
   let updateValidationResult = await updateTargetValidationSettings(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: target.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: target.slug,
       percentage: 0,
       period: 2,
-      targets: [target.id],
+      targetIds: [target.id],
       excludedClients: ['app'],
     },
     {
@@ -617,12 +617,12 @@ test.concurrent('check usage not from excluded client names', async ({ expect })
   // Exclude BOTH 'app' and 'cli' (tests multi client covering exclusion)
   updateValidationResult = await updateTargetValidationSettings(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: target.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: target.slug,
       percentage: 0,
       period: 2,
-      targets: [target.id],
+      targetIds: [target.id],
       excludedClients: ['app', 'cli'],
     },
     {
@@ -2618,9 +2618,9 @@ test.concurrent(
       variables: {
         id: firstSchemaCheckId,
         selector: {
-          organization: organization.slug,
-          project: project.slug,
-          target: target.slug,
+          organizationSlug: organization.slug,
+          projectSlug: project.slug,
+          targetSlug: target.slug,
         },
       },
       authToken: token.secret,
@@ -2884,12 +2884,12 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
   // should accept a breaking change when percentage is 2%
   let updateValidationResult = await updateTargetValidationSettings(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: target.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: target.slug,
       percentage: 2,
       period: 2,
-      targets: [target.id],
+      targetIds: [target.id],
       excludedClients: [],
     },
     {
@@ -2912,12 +2912,12 @@ test.concurrent('ensure percentage precision up to 2 decimal places', async ({ e
   // should reject a breaking change when percentage is 1.99%
   updateValidationResult = await updateTargetValidationSettings(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: target.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: target.slug,
       percentage: 1.99,
       period: 2,
-      targets: [target.id],
+      targetIds: [target.id],
       excludedClients: [],
     },
     {

--- a/integration-tests/tests/models/federation-native-forceLegacyCompositionInTargets.spec.ts
+++ b/integration-tests/tests/models/federation-native-forceLegacyCompositionInTargets.spec.ts
@@ -878,9 +878,9 @@ async function prepare(targetPick: TargetOption) {
   // force legacy composition
   await updateTargetSchemaComposition(
     {
-      organization: organization.slug,
-      project: project.slug,
-      target: targetWithLegacyComposition.slug,
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+      targetSlug: targetWithLegacyComposition.slug,
       nativeComposition: false,
     },
     targetWithLegacyComposition.tokens.secrets.settings,

--- a/packages/services/api/src/modules/alerts/module.graphql.ts
+++ b/packages/services/api/src/modules/alerts/module.graphql.ts
@@ -85,8 +85,8 @@ export default gql`
   }
 
   input AddAlertChannelInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
     name: String!
     type: AlertChannelType!
     slack: SlackChannelInput
@@ -102,23 +102,23 @@ export default gql`
   }
 
   input DeleteAlertChannelsInput {
-    organization: ID!
-    project: ID!
-    channels: [ID!]!
+    organizationSlug: String!
+    projectSlug: String!
+    channelIds: [ID!]!
   }
 
   input AddAlertInput {
-    organization: ID!
-    project: ID!
-    target: ID!
-    channel: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
+    channelId: ID!
     type: AlertType!
   }
 
   input DeleteAlertsInput {
-    organization: ID!
-    project: ID!
-    alerts: [ID!]!
+    organizationSlug: String!
+    projectSlug: String!
+    alertIds: [ID!]!
   }
 
   interface AlertChannel {

--- a/packages/services/api/src/modules/alerts/providers/alerts-manager.ts
+++ b/packages/services/api/src/modules/alerts/providers/alerts-manager.ts
@@ -38,54 +38,74 @@ export class AlertsManager {
     this.logger = logger.child({ source: 'AlertsManager' });
   }
 
-  async addChannel(input: AlertsModule.AddAlertChannelInput): Promise<AlertChannel> {
+  async addChannel(input: {
+    name: string;
+    organizationId: string;
+    projectId: string;
+    type: AlertChannel['type'];
+    slackChannel?: string | null;
+    webhookEndpoint?: string | null;
+  }): Promise<AlertChannel> {
     this.logger.debug(
       'Adding Alert Channel (organization=%s, project=%s, type=%s)',
-      input.organization,
-      input.project,
+      input.organizationId,
+      input.projectId,
       input.type,
     );
     await this.authManager.ensureProjectAccess({
-      ...input,
       scope: ProjectAccessScope.ALERTS,
+      organization: input.organizationId,
+      project: input.projectId,
     });
 
-    const channel = await this.storage.addAlertChannel(input);
+    const channel = await this.storage.addAlertChannel({
+      slackChannel: input.slackChannel,
+      webhookEndpoint: input.webhookEndpoint,
+      name: input.name,
+      type: input.type,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+    });
 
     await this.triggerChannelConfirmation({
       kind: 'created',
       channel,
-      organization: input.organization,
-      project: input.project,
+      organization: input.organizationId,
+      project: input.projectId,
     });
 
     return channel;
   }
 
-  async deleteChannels(
-    input: ProjectSelector & {
-      channels: readonly string[];
-    },
-  ): Promise<readonly AlertChannel[]> {
+  async deleteChannels(input: {
+    channelIds: readonly string[];
+    organizationId: string;
+    projectId: string;
+  }): Promise<readonly AlertChannel[]> {
     this.logger.debug(
       'Deleting Alert Channels (organization=%s, project=%s, size=%s)',
-      input.organization,
-      input.project,
-      input.channels.length,
+      input.organizationId,
+      input.projectId,
+      input.channelIds.length,
     );
     await this.authManager.ensureProjectAccess({
-      ...input,
       scope: ProjectAccessScope.ALERTS,
+      organization: input.organizationId,
+      project: input.projectId,
     });
-    const channels = await this.storage.deleteAlertChannels(input);
+    const channels = await this.storage.deleteAlertChannels({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      channelIds: input.channelIds,
+    });
 
     await Promise.all(
       channels.map(channel =>
         this.triggerChannelConfirmation({
           kind: 'deleted',
           channel,
-          organization: input.organization,
-          project: input.project,
+          organization: input.organizationId,
+          project: input.projectId,
         }),
       ),
     );
@@ -107,19 +127,32 @@ export class AlertsManager {
     return this.storage.getAlertChannels(selector);
   }
 
-  async addAlert(input: AlertsModule.AddAlertInput): Promise<Alert> {
+  async addAlert(input: {
+    type: Alert['type'];
+    organizationId: string;
+    projectId: string;
+    targetId: string;
+    channelId: string;
+  }): Promise<Alert> {
     this.logger.debug(
       'Adding Alert (organization=%s, project=%s, type=%s)',
-      input.organization,
-      input.project,
+      input.organizationId,
+      input.projectId,
       input.type,
     );
     await this.authManager.ensureProjectAccess({
-      ...input,
       scope: ProjectAccessScope.ALERTS,
+      organization: input.organizationId,
+      project: input.projectId,
     });
 
-    return this.storage.addAlert(input);
+    return this.storage.addAlert({
+      type: input.type,
+      channelId: input.channelId,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      targetId: input.targetId,
+    });
   }
 
   async deleteAlerts(

--- a/packages/services/api/src/modules/alerts/providers/alerts-manager.ts
+++ b/packages/services/api/src/modules/alerts/providers/alerts-manager.ts
@@ -1,5 +1,4 @@
 import { Injectable, Scope } from 'graphql-modules';
-import type { AlertsModule } from '../__generated__/types';
 import type { Alert, AlertChannel } from '../../../shared/entities';
 import { cache } from '../../../shared/helpers';
 import { AuthManager } from '../../auth/providers/auth-manager';

--- a/packages/services/api/src/modules/alerts/resolvers/Alert.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Alert.ts
@@ -5,17 +5,17 @@ import type { AlertResolvers } from './../../../__generated__/types.next';
 export const Alert: AlertResolvers = {
   channel: async (alert, _, { injector }) => {
     const channels = await injector.get(AlertsManager).getChannels({
-      organization: alert.organizationId,
-      project: alert.projectId,
+      organizationId: alert.organizationId,
+      projectId: alert.projectId,
     });
 
     return channels.find(c => c.id === alert.channelId)!;
   },
   target: (alert, _, { injector }) => {
     return injector.get(TargetManager).getTarget({
-      organization: alert.organizationId,
-      project: alert.projectId,
-      target: alert.targetId,
+      organizationId: alert.organizationId,
+      projectId: alert.projectId,
+      targetId: alert.targetId,
     });
   },
 };

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlert.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlert.ts
@@ -17,8 +17,8 @@ export const addAlert: NonNullable<MutationResolvers['addAlert']> = async (
   ]);
 
   const project = await injector.get(ProjectManager).getProject({
-    organization: organizationId,
-    project: projectId,
+    organizationId: organizationId,
+    projectId: projectId,
   });
 
   try {

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlert.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlert.ts
@@ -23,10 +23,10 @@ export const addAlert: NonNullable<MutationResolvers['addAlert']> = async (
 
   try {
     const alert = await injector.get(AlertsManager).addAlert({
-      organization: organizationId,
-      project: projectId,
-      target: targetId,
-      channel: input.channel,
+      organizationId,
+      projectId,
+      targetId,
+      channelId: input.channelId,
       type: input.type,
     });
 

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlertChannel.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlertChannel.ts
@@ -43,8 +43,8 @@ export const addAlertChannel: NonNullable<MutationResolvers['addAlertChannel']> 
   return {
     ok: {
       updatedProject: await injector.get(ProjectManager).getProject({
-        organization: organizationId,
-        project: projectId,
+        organizationId: organizationId,
+        projectId: projectId,
       }),
       addedAlertChannel: await injector.get(AlertsManager).addChannel({
         organizationId,

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlertChannel.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/addAlertChannel.ts
@@ -47,12 +47,12 @@ export const addAlertChannel: NonNullable<MutationResolvers['addAlertChannel']> 
         project: projectId,
       }),
       addedAlertChannel: await injector.get(AlertsManager).addChannel({
-        organization: organizationId,
-        project: projectId,
+        organizationId,
+        projectId,
         name: input.name,
         type: input.type,
-        slack: input.slack,
-        webhook: input.webhook,
+        slackChannel: input.slack?.channel,
+        webhookEndpoint: input.webhook?.endpoint,
       }),
     },
   };

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlertChannels.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlertChannels.ts
@@ -16,8 +16,8 @@ export const deleteAlertChannels: NonNullable<MutationResolvers['deleteAlertChan
   ]);
 
   const project = await injector.get(ProjectManager).getProject({
-    organization: organizationId,
-    project: projectId,
+    organizationId: organizationId,
+    projectId: projectId,
   });
 
   try {

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlertChannels.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlertChannels.ts
@@ -22,9 +22,9 @@ export const deleteAlertChannels: NonNullable<MutationResolvers['deleteAlertChan
 
   try {
     await injector.get(AlertsManager).deleteChannels({
-      organization: organizationId,
-      project: projectId,
-      channels: input.channels,
+      organizationId,
+      projectId,
+      channelIds: input.channelIds,
     });
 
     return {

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlerts.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlerts.ts
@@ -16,14 +16,14 @@ export const deleteAlerts: NonNullable<MutationResolvers['deleteAlerts']> = asyn
   ]);
 
   const project = await injector.get(ProjectManager).getProject({
-    organization: organizationId,
-    project: projectId,
+    organizationId: organizationId,
+    projectId: projectId,
   });
 
   try {
     await injector.get(AlertsManager).deleteAlerts({
-      organization: organizationId,
-      project: projectId,
+      organizationId: organizationId,
+      projectId: projectId,
       alerts: input.alertIds,
     });
 

--- a/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlerts.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Mutation/deleteAlerts.ts
@@ -24,7 +24,7 @@ export const deleteAlerts: NonNullable<MutationResolvers['deleteAlerts']> = asyn
     await injector.get(AlertsManager).deleteAlerts({
       organization: organizationId,
       project: projectId,
-      alerts: input.alerts,
+      alerts: input.alertIds,
     });
 
     return {

--- a/packages/services/api/src/modules/alerts/resolvers/Project.ts
+++ b/packages/services/api/src/modules/alerts/resolvers/Project.ts
@@ -4,14 +4,14 @@ import type { ProjectResolvers } from './../../../__generated__/types.next';
 export const Project: Pick<ProjectResolvers, 'alertChannels' | 'alerts' | '__isTypeOf'> = {
   alerts: async (project, _, { injector }) => {
     return injector.get(AlertsManager).getAlerts({
-      organization: project.orgId,
-      project: project.id,
+      organizationId: project.orgId,
+      projectId: project.id,
     });
   },
   alertChannels: async (project, _, { injector }) => {
     return injector.get(AlertsManager).getChannels({
-      organization: project.orgId,
-      project: project.id,
+      organizationId: project.orgId,
+      projectId: project.id,
     });
   },
 };

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments-manager.ts
@@ -35,9 +35,9 @@ export class AppDeploymentsManager {
     },
   ): Promise<null | AppDeploymentRecord> {
     await this.auth.ensureTargetAccess({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
       scope: TargetAccessScope.READ,
     });
 
@@ -76,9 +76,9 @@ export class AppDeploymentsManager {
     const tokenRecord = await this.tokenStorage.getToken({ token });
 
     await this.auth.ensureTargetAccess({
-      organization: tokenRecord.organization,
-      project: tokenRecord.project,
-      target: tokenRecord.target,
+      organizationId: tokenRecord.organization,
+      projectId: tokenRecord.project,
+      targetId: tokenRecord.target,
       scope: TargetAccessScope.REGISTRY_WRITE,
     });
 
@@ -103,9 +103,9 @@ export class AppDeploymentsManager {
     const tokenRecord = await this.tokenStorage.getToken({ token });
 
     await this.auth.ensureTargetAccess({
-      organization: tokenRecord.organization,
-      project: tokenRecord.project,
-      target: tokenRecord.target,
+      organizationId: tokenRecord.organization,
+      projectId: tokenRecord.project,
+      targetId: tokenRecord.target,
       scope: TargetAccessScope.REGISTRY_WRITE,
     });
 
@@ -128,9 +128,9 @@ export class AppDeploymentsManager {
     const tokenRecord = await this.tokenStorage.getToken({ token });
 
     await this.auth.ensureTargetAccess({
-      organization: tokenRecord.organization,
-      project: tokenRecord.project,
-      target: tokenRecord.target,
+      organizationId: tokenRecord.organization,
+      projectId: tokenRecord.project,
+      targetId: tokenRecord.target,
       scope: TargetAccessScope.REGISTRY_WRITE,
     });
 
@@ -151,9 +151,9 @@ export class AppDeploymentsManager {
     const target = await this.targetManager.getTargetById({ targetId: args.targetId });
 
     await this.auth.ensureTargetAccess({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
       scope: TargetAccessScope.REGISTRY_WRITE,
     });
 
@@ -183,9 +183,9 @@ export class AppDeploymentsManager {
     args: { cursor: string | null; first: number | null },
   ) {
     await this.auth.ensureTargetAccess({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
       scope: TargetAccessScope.READ,
     });
 

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
@@ -118,7 +118,7 @@ export class AppDeployments {
 
     if (this.appDeploymentsEnabled === false) {
       const organization = await this.storage.getOrganization({
-        organization: args.organizationId,
+        organizationId: args.organizationId,
       });
       if (organization.featureFlags.appDeployments === false) {
         this.logger.debug(
@@ -233,7 +233,7 @@ export class AppDeployments {
   }) {
     if (this.appDeploymentsEnabled === false) {
       const organization = await this.storage.getOrganization({
-        organization: args.organizationId,
+        organizationId: args.organizationId,
       });
       if (organization.featureFlags.appDeployments === false) {
         this.logger.debug(
@@ -280,7 +280,7 @@ export class AppDeployments {
 
     if (args.operations.length !== 0) {
       const latestSchemaVersion = await this.storage.getMaybeLatestValidVersion({
-        target: args.targetId,
+        targetId: args.targetId,
       });
 
       if (latestSchemaVersion === null) {
@@ -296,9 +296,9 @@ export class AppDeployments {
 
       const compositeSchemaSdl = await this.schemaVersionHelper.getCompositeSchemaSdl({
         ...latestSchemaVersion,
-        organization: args.organizationId,
-        project: args.projectId,
-        target: args.targetId,
+        organizationId: args.organizationId,
+        projectId: args.projectId,
+        targetId: args.targetId,
       });
       if (compositeSchemaSdl === null) {
         // No valid schema found.
@@ -348,7 +348,7 @@ export class AppDeployments {
 
     if (this.appDeploymentsEnabled === false) {
       const organization = await this.storage.getOrganization({
-        organization: args.organizationId,
+        organizationId: args.organizationId,
       });
       if (organization.featureFlags.appDeployments === false) {
         this.logger.debug(
@@ -488,7 +488,7 @@ export class AppDeployments {
 
     if (this.appDeploymentsEnabled === false) {
       const organization = await this.storage.getOrganization({
-        organization: args.organizationId,
+        organizationId: args.organizationId,
       });
       if (organization.featureFlags.appDeployments === false) {
         this.logger.debug(

--- a/packages/services/api/src/modules/auth/providers/organization-access.ts
+++ b/packages/services/api/src/modules/auth/providers/organization-access.ts
@@ -12,24 +12,24 @@ import type { TargetAccessScope } from './target-access';
 export { OrganizationAccessScope } from './scopes';
 
 export interface OrganizationOwnershipSelector {
-  user: string;
-  organization: string;
+  userId: string;
+  organizationId: string;
 }
 
 export interface OrganizationUserScopesSelector {
-  user: string;
-  organization: string;
+  userId: string;
+  organizationId: string;
 }
 
 export interface OrganizationUserAccessSelector {
-  user: string;
-  organization: string;
+  userId: string;
+  organizationId: string;
   scope: OrganizationAccessScope;
 }
 
 interface OrganizationTokenAccessSelector {
   token: string;
-  organization: string;
+  organizationId: string;
   scope: OrganizationAccessScope;
 }
 
@@ -59,7 +59,7 @@ export class OrganizationAccess {
   tokenInfo: DataLoader<TokenSelector, Token | null, string>;
   ownership: DataLoader<
     {
-      organization: string;
+      organizationId: string;
     },
     string | null,
     string
@@ -96,8 +96,8 @@ export class OrganizationAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'OrganizationAccess:user',
-            organization: selector.organization,
-            user: selector.user,
+            organization: selector.organizationId,
+            user: selector.userId,
             scope: selector.scope,
           });
         },
@@ -109,7 +109,7 @@ export class OrganizationAccess {
           selectors.map(async selector => {
             const tokenInfo = await this.tokenInfo.load(selector);
 
-            if (tokenInfo?.organization === selector.organization) {
+            if (tokenInfo?.organization === selector.organizationId) {
               return tokenInfo.scopes.includes(selector.scope);
             }
 
@@ -120,7 +120,7 @@ export class OrganizationAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'OrganizationAccess:token',
-            organization: selector.organization,
+            organization: selector.organizationId,
             token: selector.token,
             scope: selector.scope,
           });
@@ -137,8 +137,8 @@ export class OrganizationAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'OrganizationAccess:allScopes',
-            organization: selector.organization,
-            user: selector.user,
+            organization: selector.organizationId,
+            user: selector.userId,
           });
         },
       },
@@ -166,8 +166,8 @@ export class OrganizationAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'OrganizationAccess:scopes',
-            organization: selector.organization,
-            user: selector.user,
+            organization: selector.organizationId,
+            user: selector.userId,
           });
         },
       },
@@ -185,7 +185,7 @@ export class OrganizationAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'OrganizationAccess:ownership',
-            organization: selector.organization,
+            organization: selector.organizationId,
           });
         },
       },
@@ -228,7 +228,7 @@ export class OrganizationAccess {
       return false;
     }
 
-    return owner === selector.user;
+    return owner === selector.userId;
   }
 
   async getMemberScopes(selector: OrganizationUserScopesSelector) {

--- a/packages/services/api/src/modules/auth/providers/project-access.ts
+++ b/packages/services/api/src/modules/auth/providers/project-access.ts
@@ -8,21 +8,21 @@ import { ProjectAccessScope } from './scopes';
 export { ProjectAccessScope } from './scopes';
 
 export interface ProjectUserAccessSelector {
-  user: string;
-  organization: string;
-  project: string;
+  userId: string;
+  organizationId: string;
+  projectId: string;
   scope: ProjectAccessScope;
 }
 
 export interface ProjectUserScopesSelector {
-  user: string;
-  organization: string;
+  userId: string;
+  organizationId: string;
 }
 
 interface ProjectTokenAccessSelector {
   token: string;
-  organization: string;
-  project: string;
+  organizationId: string;
+  projectId: string;
   scope: ProjectAccessScope;
 }
 
@@ -71,9 +71,9 @@ export class ProjectAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'ProjectAccess:user',
-            organization: selector.organization,
-            project: selector.project,
-            user: selector.user,
+            organization: selector.organizationId,
+            project: selector.projectId,
+            user: selector.userId,
             scope: selector.scope,
           });
         },
@@ -86,8 +86,8 @@ export class ProjectAccess {
             const tokenInfo = await this.organizationAccess.tokenInfo.load(selector);
 
             if (
-              tokenInfo?.organization === selector.organization &&
-              tokenInfo?.project === selector.project
+              tokenInfo?.organization === selector.organizationId &&
+              tokenInfo?.project === selector.projectId
             ) {
               return tokenInfo.scopes.includes(selector.scope);
             }
@@ -99,8 +99,8 @@ export class ProjectAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'ProjectAccess:token',
-            organization: selector.organization,
-            project: selector.project,
+            organization: selector.organizationId,
+            project: selector.projectId,
             token: selector.token,
             scope: selector.scope,
           });
@@ -130,8 +130,8 @@ export class ProjectAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'ProjectAccess:scopes',
-            organization: selector.organization,
-            user: selector.user,
+            organization: selector.organizationId,
+            user: selector.userId,
           });
         },
       },

--- a/packages/services/api/src/modules/auth/providers/target-access.ts
+++ b/packages/services/api/src/modules/auth/providers/target-access.ts
@@ -8,23 +8,23 @@ import { TargetAccessScope } from './scopes';
 export { TargetAccessScope } from './scopes';
 
 export interface TargetUserAccessSelector {
-  user: string;
-  organization: string;
-  project: string;
-  target: string;
+  userId: string;
+  organizationId: string;
+  projectId: string;
+  targetId: string;
   scope: TargetAccessScope;
 }
 
 export interface TargetUserScopesSelector {
-  user: string;
-  organization: string;
+  userId: string;
+  organizationId: string;
 }
 
 interface TargetTokenAccessSelector {
   token: string;
-  organization: string;
-  project: string;
-  target: string;
+  organizationId: string;
+  projectId: string;
+  targetId: string;
   scope: TargetAccessScope;
 }
 
@@ -73,10 +73,10 @@ export class TargetAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'TargetAccess:user',
-            organization: selector.organization,
-            project: selector.project,
-            target: selector.target,
-            user: selector.user,
+            organization: selector.organizationId,
+            project: selector.projectId,
+            target: selector.targetId,
+            user: selector.userId,
             scope: selector.scope,
           });
         },
@@ -89,9 +89,9 @@ export class TargetAccess {
             const tokenInfo = await this.organizationAccess.tokenInfo.load(selector);
 
             if (
-              tokenInfo?.organization === selector.organization &&
-              tokenInfo?.project === selector.project &&
-              tokenInfo?.target === selector.target
+              tokenInfo?.organization === selector.organizationId &&
+              tokenInfo?.project === selector.projectId &&
+              tokenInfo?.target === selector.targetId
             ) {
               return tokenInfo.scopes.includes(selector.scope);
             }
@@ -103,9 +103,9 @@ export class TargetAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'TargetAccess:token',
-            organization: selector.organization,
-            project: selector.project,
-            target: selector.target,
+            organization: selector.organizationId,
+            project: selector.projectId,
+            target: selector.targetId,
             token: selector.token,
             scope: selector.scope,
           });
@@ -136,8 +136,8 @@ export class TargetAccess {
         cacheKeyFn(selector) {
           return JSON.stringify({
             type: 'TargetAccess:scopes',
-            organization: selector.organization,
-            user: selector.user,
+            organization: selector.organizationId,
+            user: selector.userId,
           });
         },
       },

--- a/packages/services/api/src/modules/auth/resolvers/Member.ts
+++ b/packages/services/api/src/modules/auth/resolvers/Member.ts
@@ -13,20 +13,20 @@ export const Member: Pick<
 > = {
   organizationAccessScopes: (member, _, { injector }) => {
     return injector.get(AuthManager).getMemberOrganizationScopes({
-      user: member.user.id,
-      organization: member.organization,
+      userId: member.user.id,
+      organizationId: member.organization,
     });
   },
   projectAccessScopes: (member, _, { injector }) => {
     return injector.get(AuthManager).getMemberProjectScopes({
-      user: member.user.id,
-      organization: member.organization,
+      userId: member.user.id,
+      organizationId: member.organization,
     });
   },
   targetAccessScopes: (member, _, { injector }) => {
     return injector.get(AuthManager).getMemberTargetScopes({
-      user: member.user.id,
-      organization: member.organization,
+      userId: member.user.id,
+      organizationId: member.organization,
     });
   },
 };

--- a/packages/services/api/src/modules/billing/providers/billing.provider.ts
+++ b/packages/services/api/src/modules/billing/providers/billing.provider.ts
@@ -66,7 +66,7 @@ export class BillingProvider {
     this.logger.debug('Fetching organization billing (selector=%o)', selector);
 
     return this.storage.getOrganizationBilling({
-      organization: selector.organizationId,
+      organizationId: selector.organizationId,
     });
   }
 

--- a/packages/services/api/src/modules/billing/providers/billing.provider.ts
+++ b/packages/services/api/src/modules/billing/providers/billing.provider.ts
@@ -61,13 +61,13 @@ export class BillingProvider {
     return await this.billingService.availablePrices.query();
   }
 
-  async getOrganizationBillingParticipant(
-    selector: OrganizationSelector,
-  ): Promise<OrganizationBilling | null> {
+  async getOrganizationBillingParticipant(selector: {
+    organizationId: string;
+  }): Promise<OrganizationBilling | null> {
     this.logger.debug('Fetching organization billing (selector=%o)', selector);
 
     return this.storage.getOrganizationBilling({
-      organization: selector.organization,
+      organization: selector.organizationId,
     });
   }
 

--- a/packages/services/api/src/modules/billing/providers/billing.provider.ts
+++ b/packages/services/api/src/modules/billing/providers/billing.provider.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { StripeBillingApi, StripeBillingApiInput } from '@hive/stripe-billing';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { OrganizationSelector } from '../../../__generated__/types';
 import { OrganizationBilling } from '../../../shared/entities';
 import { Logger } from '../../shared/providers/logger';
 import { Storage } from '../../shared/providers/storage';

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/downgradeToHobby.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/downgradeToHobby.ts
@@ -16,12 +16,12 @@ export const downgradeToHobby: NonNullable<MutationResolvers['downgradeToHobby']
     organizationSlug: args.input.organization.organizationSlug,
   });
   await injector.get(AuthManager).ensureOrganizationAccess({
-    organization: organizationId,
+    organizationId: organizationId,
     scope: OrganizationAccessScope.SETTINGS,
   });
 
   let organization = await injector.get(OrganizationManager).getOrganization({
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   if (organization.billingPlan === 'PRO') {
@@ -33,11 +33,11 @@ export const downgradeToHobby: NonNullable<MutationResolvers['downgradeToHobby']
     // Upgrade the actual org plan to HOBBY
     organization = await injector
       .get(OrganizationManager)
-      .updatePlan({ plan: 'HOBBY', organization: organizationId });
+      .updatePlan({ plan: 'HOBBY', organizationId: organizationId });
 
     // Upgrade the limits
     organization = await injector.get(OrganizationManager).updateRateLimits({
-      organization: organizationId,
+      organizationId: organizationId,
       monthlyRateLimit: {
         retentionInDays: USAGE_DEFAULT_LIMITATIONS.HOBBY.retention,
         operations: USAGE_DEFAULT_LIMITATIONS.HOBBY.operations,

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/downgradeToHobby.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/downgradeToHobby.ts
@@ -13,7 +13,7 @@ export const downgradeToHobby: NonNullable<MutationResolvers['downgradeToHobby']
   { injector },
 ) => {
   const organizationId = await injector.get(IdTranslator).translateOrganizationId({
-    organization: args.input.organization.organization,
+    organizationSlug: args.input.organization.organizationSlug,
   });
   await injector.get(AuthManager).ensureOrganizationAccess({
     organization: organizationId,

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/generateStripePortalLink.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/generateStripePortalLink.ts
@@ -12,7 +12,7 @@ export const generateStripePortalLink: NonNullable<
   });
   const organization = await injector.get(OrganizationManager).getOrganization(
     {
-      organization: organizationId,
+      organizationId: organizationId,
     },
     OrganizationAccessScope.SETTINGS,
   );

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/generateStripePortalLink.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/generateStripePortalLink.ts
@@ -8,7 +8,7 @@ export const generateStripePortalLink: NonNullable<
   MutationResolvers['generateStripePortalLink']
 > = async (_, args, { injector }) => {
   const organizationId = await injector.get(IdTranslator).translateOrganizationId({
-    organization: args.selector.organization,
+    organizationSlug: args.selector.organizationSlug,
   });
   const organization = await injector.get(OrganizationManager).getOrganization(
     {

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/updateOrgRateLimit.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/updateOrgRateLimit.ts
@@ -13,7 +13,7 @@ export const updateOrgRateLimit: NonNullable<MutationResolvers['updateOrgRateLim
   });
 
   return injector.get(OrganizationManager).updateRateLimits({
-    organization: organizationId,
+    organizationId: organizationId,
     monthlyRateLimit: {
       retentionInDays: USAGE_DEFAULT_LIMITATIONS.PRO.retention,
       operations: args.monthlyLimits.operations,

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/updateOrgRateLimit.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/updateOrgRateLimit.ts
@@ -9,7 +9,7 @@ export const updateOrgRateLimit: NonNullable<MutationResolvers['updateOrgRateLim
   { injector },
 ) => {
   const organizationId = await injector.get(IdTranslator).translateOrganizationId({
-    organization: args.selector.organization,
+    organizationSlug: args.selector.organizationSlug,
   });
 
   return injector.get(OrganizationManager).updateRateLimits({

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/upgradeToPro.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/upgradeToPro.ts
@@ -17,12 +17,12 @@ export const upgradeToPro: NonNullable<MutationResolvers['upgradeToPro']> = asyn
     organizationSlug: args.input.organization.organizationSlug,
   });
   await injector.get(AuthManager).ensureOrganizationAccess({
-    organization: organizationId,
+    organizationId: organizationId,
     scope: OrganizationAccessScope.SETTINGS,
   });
 
   let organization = await injector.get(OrganizationManager).getOrganization({
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   if (organization.billingPlan === 'HOBBY') {
@@ -47,11 +47,11 @@ export const upgradeToPro: NonNullable<MutationResolvers['upgradeToPro']> = asyn
     // Upgrade the actual org plan to PRO
     organization = await injector
       .get(OrganizationManager)
-      .updatePlan({ plan: 'PRO', organization: organizationId });
+      .updatePlan({ plan: 'PRO', organizationId: organizationId });
 
     // Upgrade the limits
     organization = await injector.get(OrganizationManager).updateRateLimits({
-      organization: organizationId,
+      organizationId: organizationId,
       monthlyRateLimit: {
         retentionInDays: USAGE_DEFAULT_LIMITATIONS.PRO.retention,
         operations: args.input.monthlyLimits.operations || USAGE_DEFAULT_LIMITATIONS.PRO.operations,

--- a/packages/services/api/src/modules/billing/resolvers/Mutation/upgradeToPro.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Mutation/upgradeToPro.ts
@@ -14,7 +14,7 @@ export const upgradeToPro: NonNullable<MutationResolvers['upgradeToPro']> = asyn
   { injector },
 ) => {
   const organizationId = await injector.get(IdTranslator).translateOrganizationId({
-    organization: args.input.organization.organization,
+    organizationSlug: args.input.organization.organizationSlug,
   });
   await injector.get(AuthManager).ensureOrganizationAccess({
     organization: organizationId,

--- a/packages/services/api/src/modules/billing/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/billing/resolvers/Organization.ts
@@ -21,7 +21,7 @@ export const Organization: Pick<
 
     const billingRecord = await injector
       .get(BillingProvider)
-      .getOrganizationBillingParticipant({ organization: org.id });
+      .getOrganizationBillingParticipant({ organizationId: org.id });
 
     if (!billingRecord) {
       return {

--- a/packages/services/api/src/modules/cdn/providers/cdn.provider.ts
+++ b/packages/services/api/src/modules/cdn/providers/cdn.provider.ts
@@ -87,9 +87,9 @@ export class CdnProvider {
     }
 
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.READ,
     });
 
@@ -242,9 +242,9 @@ export class CdnProvider {
     );
 
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.SETTINGS,
     });
 
@@ -327,9 +327,9 @@ export class CdnProvider {
     cursor: string | null;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.SETTINGS,
     });
 

--- a/packages/services/api/src/modules/collection/resolvers.ts
+++ b/packages/services/api/src/modules/collection/resolvers.ts
@@ -54,13 +54,15 @@ async function validateTargetAccess(
   ]);
 
   await injector.get(AuthManager).ensureTargetAccess({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     scope,
   });
 
-  return await injector.get(Storage).getTarget({ target, organization, project });
+  return await injector
+    .get(Storage)
+    .getTarget({ targetId: target, organizationId: organization, projectId: project });
 }
 
 export const resolvers: CollectionModule.Resolvers = {

--- a/packages/services/api/src/modules/integrations/module.graphql.ts
+++ b/packages/services/api/src/modules/integrations/module.graphql.ts
@@ -29,12 +29,12 @@ export default gql`
   }
 
   input AddSlackIntegrationInput {
-    organization: ID!
+    organizationSlug: String!
     token: String!
   }
 
   input AddGitHubIntegrationInput {
-    organization: ID!
+    organizationSlug: String!
     installationId: ID!
   }
 

--- a/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
+++ b/packages/services/api/src/modules/integrations/providers/github-integration-manager.ts
@@ -62,7 +62,7 @@ export class GitHubIntegrationManager {
   ): Promise<void> {
     this.logger.debug(
       'Registering GitHub integration (organization=%s, installationId:%s)',
-      input.organization,
+      input.organizationId,
       input.installationId,
     );
     await this.authManager.ensureOrganizationAccess({
@@ -71,25 +71,25 @@ export class GitHubIntegrationManager {
     });
     this.logger.debug('Updating organization');
     await this.storage.addGitHubIntegration({
-      organization: input.organization,
+      organizationId: input.organizationId,
       installationId: input.installationId,
     });
   }
 
   async unregister(input: OrganizationSelector): Promise<void> {
-    this.logger.debug('Removing GitHub integration (organization=%s)', input.organization);
+    this.logger.debug('Removing GitHub integration (organization=%s)', input.organizationId);
     await this.authManager.ensureOrganizationAccess({
       ...input,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
     this.logger.debug('Updating organization');
     await this.storage.deleteGitHubIntegration({
-      organization: input.organization,
+      organizationId: input.organizationId,
     });
   }
 
   async isAvailable(selector: OrganizationSelector): Promise<boolean> {
-    this.logger.debug('Checking GitHub integration (organization=%s)', selector.organization);
+    this.logger.debug('Checking GitHub integration (organization=%s)', selector.organizationId);
 
     if (!this.isEnabled()) {
       this.logger.debug('GitHub integration is disabled.');
@@ -97,28 +97,31 @@ export class GitHubIntegrationManager {
     }
 
     const installationId = await this.getInstallationId({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
     });
 
     return installationId !== null;
   }
 
   private async getInstallationId(selector: OrganizationSelector): Promise<number | null> {
-    this.logger.debug('Fetching GitHub integration token (organization=%s)', selector.organization);
+    this.logger.debug(
+      'Fetching GitHub integration token (organization=%s)',
+      selector.organizationId,
+    );
 
     const rawInstallationId = await this.storage.getGitHubIntegrationInstallationId({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
     });
 
     if (!rawInstallationId) {
-      this.logger.debug('No installation found. (organization=%s)', selector.organization);
+      this.logger.debug('No installation found. (organization=%s)', selector.organizationId);
 
       return null;
     }
 
     this.logger.debug(
       'GitHub installation found. (organization=%s, installationId=%s)',
-      selector.organization,
+      selector.organizationId,
       rawInstallationId,
     );
 
@@ -127,7 +130,7 @@ export class GitHubIntegrationManager {
     if (Number.isNaN(installationId)) {
       this.logger.error(
         "GitHub installation ID can't be parsed. (organization=%s, installationId=%s)",
-        selector.organization,
+        selector.organizationId,
         rawInstallationId,
       );
       throw new Error("GitHub installation ID can't be parsed.");
@@ -191,7 +194,7 @@ export class GitHubIntegrationManager {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: organization.id,
+      organizationId: organization.id,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 
@@ -321,7 +324,7 @@ export class GitHubIntegrationManager {
       args.githubCheckRun.id,
     );
 
-    const octokit = await this.getOctokitForOrganization({ organization: args.organizationId });
+    const octokit = await this.getOctokitForOrganization({ organizationId: args.organizationId });
 
     if (!octokit) {
       throw new HiveError(
@@ -362,7 +365,7 @@ export class GitHubIntegrationManager {
       args.checkRun.checkRunId,
     );
     const octokit = await this.getOctokitForOrganization({
-      organization: args.organizationId,
+      organizationId: args.organizationId,
     });
 
     if (!octokit) {

--- a/packages/services/api/src/modules/integrations/providers/slack-integration-manager.ts
+++ b/packages/services/api/src/modules/integrations/providers/slack-integration-manager.ts
@@ -37,34 +37,34 @@ export class SlackIntegrationManager {
       token: string;
     },
   ): Promise<void> {
-    this.logger.debug('Registering Slack integration (organization=%s)', input.organization);
+    this.logger.debug('Registering Slack integration (organization=%s)', input.organizationId);
     await this.authManager.ensureOrganizationAccess({
       ...input,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
     this.logger.debug('Updating organization');
     await this.storage.addSlackIntegration({
-      organization: input.organization,
+      organizationId: input.organizationId,
       token: this.crypto.encrypt(input.token),
     });
   }
 
   async unregister(input: OrganizationSelector): Promise<void> {
-    this.logger.debug('Removing Slack integration (organization=%s)', input.organization);
+    this.logger.debug('Removing Slack integration (organization=%s)', input.organizationId);
     await this.authManager.ensureOrganizationAccess({
       ...input,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
     this.logger.debug('Updating organization');
     await this.storage.deleteSlackIntegration({
-      organization: input.organization,
+      organizationId: input.organizationId,
     });
   }
 
   async isAvailable(selector: OrganizationSelector): Promise<boolean> {
-    this.logger.debug('Checking Slack integration (organization=%s)', selector.organization);
+    this.logger.debug('Checking Slack integration (organization=%s)', selector.organizationId);
     const token = await this.getToken({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
       context: IntegrationsAccessContext.Integrations,
     });
 
@@ -102,7 +102,7 @@ export class SlackIntegrationManager {
       case IntegrationsAccessContext.Integrations: {
         this.logger.debug(
           'Fetching Slack integration token (organization=%s, context: %s)',
-          selector.organization,
+          selector.organizationId,
           selector.context,
         );
         await this.authManager.ensureOrganizationAccess({
@@ -114,8 +114,8 @@ export class SlackIntegrationManager {
       case IntegrationsAccessContext.ChannelConfirmation: {
         this.logger.debug(
           'Fetching Slack integration token (organization=%s, project=%s, context: %s)',
-          selector.organization,
-          selector.project,
+          selector.organizationId,
+          selector.projectId,
           selector.context,
         );
         await this.authManager.ensureProjectAccess({
@@ -127,9 +127,9 @@ export class SlackIntegrationManager {
       case IntegrationsAccessContext.SchemaPublishing: {
         this.logger.debug(
           'Fetching Slack integration token (organization=%s, project=%s, target=%s context: %s)',
-          selector.organization,
-          selector.project,
-          selector.target,
+          selector.organizationId,
+          selector.projectId,
+          selector.targetId,
           selector.context,
         );
         await this.authManager.ensureTargetAccess({
@@ -144,7 +144,7 @@ export class SlackIntegrationManager {
     }
 
     let token = await this.storage.getSlackIntegrationToken({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
     });
 
     if (token) {

--- a/packages/services/api/src/modules/integrations/resolvers/Mutation/addGitHubIntegration.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Mutation/addGitHubIntegration.ts
@@ -10,7 +10,7 @@ export const addGitHubIntegration: NonNullable<MutationResolvers['addGitHubInteg
   const organization = await injector.get(IdTranslator).translateOrganizationId(input);
 
   await injector.get(GitHubIntegrationManager).register({
-    organization,
+    organizationId: organization,
     installationId: input.installationId,
   });
 

--- a/packages/services/api/src/modules/integrations/resolvers/Mutation/addSlackIntegration.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Mutation/addSlackIntegration.ts
@@ -32,7 +32,7 @@ export const addSlackIntegration: NonNullable<MutationResolvers['addSlackIntegra
   const organization = await injector.get(IdTranslator).translateOrganizationId(input);
 
   await injector.get(SlackIntegrationManager).register({
-    organization,
+    organizationId: organization,
     token: input.token,
   });
 

--- a/packages/services/api/src/modules/integrations/resolvers/Mutation/deleteGitHubIntegration.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Mutation/deleteGitHubIntegration.ts
@@ -9,11 +9,11 @@ export const deleteGitHubIntegration: NonNullable<
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
 
   await injector.get(GitHubIntegrationManager).unregister({
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   const organization = await injector.get(OrganizationManager).getOrganization({
-    organization: organizationId,
+    organizationId: organizationId,
   });
   return { organization };
 };

--- a/packages/services/api/src/modules/integrations/resolvers/Mutation/deleteSlackIntegration.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Mutation/deleteSlackIntegration.ts
@@ -9,11 +9,11 @@ export const deleteSlackIntegration: NonNullable<
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
 
   await injector.get(SlackIntegrationManager).unregister({
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   const organization = await injector.get(OrganizationManager).getOrganization({
-    organization: organizationId,
+    organizationId: organizationId,
   });
   return { organization };
 };

--- a/packages/services/api/src/modules/integrations/resolvers/Mutation/enableProjectNameInGithubCheck.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Mutation/enableProjectNameInGithubCheck.ts
@@ -11,7 +11,7 @@ export const enableProjectNameInGithubCheck: NonNullable<
     translator.translateProjectId(input),
   ]);
   return injector.get(GitHubIntegrationManager).enableProjectNameInGithubCheck({
-    organization,
-    project,
+    organizationId: organization,
+    projectId: project,
   });
 };

--- a/packages/services/api/src/modules/integrations/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/integrations/resolvers/Organization.ts
@@ -8,7 +8,7 @@ export const Organization: Pick<
 > = {
   gitHubIntegration: async (organization, _, { injector }) => {
     const repositories = await injector.get(GitHubIntegrationManager).getRepositories({
-      organization: organization.id,
+      organizationId: organization.id,
     });
 
     if (repositories == null) {
@@ -21,12 +21,12 @@ export const Organization: Pick<
   },
   hasGitHubIntegration: (organization, _, { injector }) => {
     return injector.get(GitHubIntegrationManager).isAvailable({
-      organization: organization.id,
+      organizationId: organization.id,
     });
   },
   hasSlackIntegration: (organization, _, { injector }) => {
     return injector.get(SlackIntegrationManager).isAvailable({
-      organization: organization.id,
+      organizationId: organization.id,
     });
   },
 };

--- a/packages/services/api/src/modules/lab/resolvers/Query/lab.ts
+++ b/packages/services/api/src/modules/lab/resolvers/Query/lab.ts
@@ -14,18 +14,18 @@ export const lab: NonNullable<QueryResolvers['lab']> = async (_, { selector }, {
   ]);
 
   await injector.get(AuthManager).ensureTargetAccess({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     scope: TargetAccessScope.REGISTRY_READ,
   });
 
   const schemaManager = injector.get(SchemaManager);
 
   const latestSchema = await schemaManager.getMaybeLatestValidVersion({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 
   if (!latestSchema) {

--- a/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
+++ b/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
@@ -39,7 +39,7 @@ export class OIDCIntegrationsProvider {
 
     try {
       await this.authManager.ensureOrganizationAccess({
-        organization: organizationId,
+        organizationId: organizationId,
         scope: OrganizationAccessScope.INTEGRATIONS,
       });
       return true;
@@ -61,7 +61,7 @@ export class OIDCIntegrationsProvider {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: args.organizationId,
+      organizationId: args.organizationId,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 
@@ -91,11 +91,13 @@ export class OIDCIntegrationsProvider {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: args.organizationId,
+      organizationId: args.organizationId,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 
-    const organization = await this.storage.getOrganization({ organization: args.organizationId });
+    const organization = await this.storage.getOrganization({
+      organizationId: args.organizationId,
+    });
 
     if (!organization) {
       throw new Error(`Failed to locate organization ${args.organizationId}`);
@@ -193,7 +195,7 @@ export class OIDCIntegrationsProvider {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: integration.linkedOrganizationId,
+      organizationId: integration.linkedOrganizationId,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 
@@ -270,7 +272,7 @@ export class OIDCIntegrationsProvider {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: integration.linkedOrganizationId,
+      organizationId: integration.linkedOrganizationId,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 
@@ -302,7 +304,7 @@ export class OIDCIntegrationsProvider {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: oidcIntegration.linkedOrganizationId,
+      organizationId: oidcIntegration.linkedOrganizationId,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 
@@ -347,7 +349,7 @@ export class OIDCIntegrationsProvider {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: integration.linkedOrganizationId,
+      organizationId: integration.linkedOrganizationId,
       scope: OrganizationAccessScope.INTEGRATIONS,
     });
 

--- a/packages/services/api/src/modules/oidc-integrations/resolvers/Mutation/createOIDCIntegration.ts
+++ b/packages/services/api/src/modules/oidc-integrations/resolvers/Mutation/createOIDCIntegration.ts
@@ -18,7 +18,7 @@ export const createOIDCIntegration: NonNullable<
   if (result.type === 'ok') {
     const organization = await injector
       .get(OrganizationManager)
-      .getOrganization({ organization: input.organizationId });
+      .getOrganization({ organizationId: input.organizationId });
 
     return {
       ok: {

--- a/packages/services/api/src/modules/oidc-integrations/resolvers/Mutation/deleteOIDCIntegration.ts
+++ b/packages/services/api/src/modules/oidc-integrations/resolvers/Mutation/deleteOIDCIntegration.ts
@@ -14,7 +14,7 @@ export const deleteOIDCIntegration: NonNullable<
       ok: {
         organization: await injector
           .get(OrganizationManager)
-          .getOrganization({ organization: result.organizationId }),
+          .getOrganization({ organizationId: result.organizationId }),
       },
     };
   }

--- a/packages/services/api/src/modules/operations/module.graphql.ts
+++ b/packages/services/api/src/modules/operations/module.graphql.ts
@@ -13,33 +13,35 @@ export default gql`
   }
 
   input OperationsStatsSelectorInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     period: DateRangeInput!
+    # TODO: are these IDs or hashes?
     operations: [ID!]
     clientNames: [String!]
   }
 
   input ClientStatsInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     period: DateRangeInput!
     client: String!
   }
 
   input SchemaCoordinateStatsInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     period: DateRangeInput!
     schemaCoordinate: String!
   }
 
   input ClientStatsByTargetsInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    # TODO: are these IDs or slugs?
     targetIds: [ID!]!
     period: DateRangeInput!
   }
@@ -55,9 +57,9 @@ export default gql`
   }
 
   input FieldStatsInput {
-    target: String!
-    project: String!
-    organization: String!
+    targetSlug: String!
+    projectSlug: String!
+    organizationSlug: String!
     type: String!
     field: String!
     argument: String
@@ -66,9 +68,9 @@ export default gql`
   }
 
   input FieldListStatsInput {
-    target: String!
-    project: String!
-    organization: String!
+    targetSlug: String!
+    projectSlug: String!
+    organizationSlug: String!
     period: DateRangeInput!
     fields: [FieldTypePairInput!]!
     operationHash: String

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -103,11 +103,16 @@ export class OperationsManager {
     );
   }
 
-  async getOperation({ organization, project, target, hash }: { hash: string } & TargetSelector) {
+  async getOperation({
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
+    hash,
+  }: { hash: string } & TargetSelector) {
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -117,10 +122,10 @@ export class OperationsManager {
     });
   }
 
-  async readMonthlyUsage({ organization }: OrganizationSelector) {
+  async readMonthlyUsage({ organizationId: organization }: OrganizationSelector) {
     this.logger.info('Reading monthly usage (organization=%s)', organization);
     await this.authManager.ensureOrganizationAccess({
-      organization,
+      organizationId: organization,
       // Why? Monthly usage is specific to organization settings (subscription page)
       scope: OrganizationAccessScope.SETTINGS,
     });
@@ -129,9 +134,9 @@ export class OperationsManager {
   }
 
   async countUniqueOperations({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     period,
     operations,
     clients,
@@ -142,9 +147,9 @@ export class OperationsManager {
   } & TargetSelector) {
     this.logger.info('Counting unique operations (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -156,12 +161,16 @@ export class OperationsManager {
     });
   }
 
-  async hasCollectedOperations({ organization, project, target }: TargetSelector) {
+  async hasCollectedOperations({
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
+  }: TargetSelector) {
     this.logger.info('Checking existence of collected operations (target=%s)', target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -172,12 +181,16 @@ export class OperationsManager {
     );
   }
 
-  async hasCollectedSubscriptionOperations({ organization, project, target }: TargetSelector) {
+  async hasCollectedSubscriptionOperations({
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
+  }: TargetSelector) {
     this.logger.info('Checking existence of collected subscription operations (target=%s)', target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -187,15 +200,15 @@ export class OperationsManager {
   }
 
   async countRequestsWithSchemaCoordinate({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     period,
     schemaCoordinate,
   }: {
     period: DateRange;
     schemaCoordinate: string;
-  } & Listify<TargetSelector, 'target'>) {
+  } & Listify<TargetSelector, 'targetId'>) {
     this.logger.info(
       'Counting requests with schema coordinate (period=%o, target=%s, coordinate=%s)',
       period,
@@ -203,9 +216,9 @@ export class OperationsManager {
       schemaCoordinate,
     );
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -219,9 +232,9 @@ export class OperationsManager {
   }
 
   async countRequestsAndFailures({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     period,
     operations,
     clients,
@@ -229,12 +242,12 @@ export class OperationsManager {
     period: DateRange;
     operations?: readonly string[];
     clients?: readonly string[];
-  } & Listify<TargetSelector, 'target'>) {
+  } & Listify<TargetSelector, 'targetId'>) {
     this.logger.info('Counting requests and failures (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -249,18 +262,18 @@ export class OperationsManager {
   }
 
   async countRequests({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     period,
   }: {
     period: DateRange;
-  } & Listify<TargetSelector, 'target'>): Promise<number> {
+  } & Listify<TargetSelector, 'targetId'>): Promise<number> {
     this.logger.info('Counting requests (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -271,29 +284,29 @@ export class OperationsManager {
   }
 
   async countRequestsOfProject({
-    organization,
-    project,
+    organizationId: organization,
+    projectId: project,
     period,
   }: {
     period: DateRange;
   } & ProjectSelector): Promise<number> {
     this.logger.info('Counting requests of project (period=%o, project=%s)', period, project);
     const targets = await this.storage.getTargetIdsOfProject({
-      organization,
-      project,
+      organizationId: organization,
+      projectId: project,
     });
     return this.countRequests({
-      organization,
-      project,
-      target: targets,
+      organizationId: organization,
+      projectId: project,
+      targetId: targets,
       period,
     });
   }
 
   async countFailures({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     period,
     operations,
     clients,
@@ -304,9 +317,9 @@ export class OperationsManager {
   } & TargetSelector) {
     this.logger.info('Counting failures (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -323,12 +336,20 @@ export class OperationsManager {
     input: Optional<ReadFieldStatsInput, 'field'>,
   ): Promise<Optional<ReadFieldStatsOutput, 'field'>>;
   async readFieldStats(input: ReadFieldStatsInput): Promise<ReadFieldStatsOutput> {
-    const { type, field, argument, period, organization, project, target } = input;
+    const {
+      type,
+      field,
+      argument,
+      period,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
+    } = input;
     this.logger.info('Counting a field (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -356,9 +377,9 @@ export class OperationsManager {
   async readFieldListStats({
     fields,
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     excludedClients,
   }: {
     fields: ReadonlyArray<{
@@ -368,7 +389,7 @@ export class OperationsManager {
     }>;
     period: DateRange;
     excludedClients?: readonly string[];
-  } & Listify<TargetSelector, 'target'>) {
+  } & Listify<TargetSelector, 'targetId'>) {
     this.logger.info(
       'Counting fields (period=%o, target=%s, excludedClients=%s)',
       period,
@@ -377,9 +398,9 @@ export class OperationsManager {
     );
 
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -393,9 +414,9 @@ export class OperationsManager {
 
   async readOperationsStats({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
     schemaCoordinate,
@@ -407,9 +428,9 @@ export class OperationsManager {
   } & TargetSelector) {
     this.logger.info('Reading operations stats (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -426,8 +447,8 @@ export class OperationsManager {
   async readRequestsOverTimeOfProject({
     period,
     resolution,
-    organization,
-    project,
+    organizationId: organization,
+    projectId: project,
   }: {
     period: DateRange;
     resolution: number;
@@ -444,15 +465,15 @@ export class OperationsManager {
       project,
     );
     const targets = await this.storage.getTargetIdsOfProject({
-      organization,
-      project,
+      organizationId: organization,
+      projectId: project,
     });
     await Promise.all(
       targets.map(target =>
         this.authManager.ensureTargetAccess({
-          organization,
-          project,
-          target,
+          organizationId: organization,
+          projectId: project,
+          targetId: target,
           scope: TargetAccessScope.REGISTRY_READ,
         }),
       ),
@@ -494,8 +515,8 @@ export class OperationsManager {
   async readRequestsOverTimeOfTargets({
     period,
     resolution,
-    organization,
-    project,
+    organizationId: organization,
+    projectId: project,
     targets,
   }: {
     period: DateRange;
@@ -511,9 +532,9 @@ export class OperationsManager {
     await Promise.all(
       targets.map(target =>
         this.authManager.ensureTargetAccess({
-          organization,
-          project,
-          target,
+          organizationId: organization,
+          projectId: project,
+          targetId: target,
           scope: TargetAccessScope.REGISTRY_READ,
         }),
       ),
@@ -529,9 +550,9 @@ export class OperationsManager {
   async readRequestsOverTime({
     period,
     resolution,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
     schemaCoordinate,
@@ -549,9 +570,9 @@ export class OperationsManager {
       target,
     );
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -568,9 +589,9 @@ export class OperationsManager {
   async readFailuresOverTime({
     period,
     resolution,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
   }: {
@@ -586,9 +607,9 @@ export class OperationsManager {
       target,
     );
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -604,9 +625,9 @@ export class OperationsManager {
   async readDurationOverTime({
     period,
     resolution,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
   }: {
@@ -622,9 +643,9 @@ export class OperationsManager {
       target,
     );
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -639,9 +660,9 @@ export class OperationsManager {
 
   async readGeneralDurationPercentiles({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
   }: {
@@ -651,9 +672,9 @@ export class OperationsManager {
   } & TargetSelector) {
     this.logger.info('Reading overall duration percentiles (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -668,9 +689,9 @@ export class OperationsManager {
   @cache<{ period: DateRange } & TargetSelector>(selector => JSON.stringify(selector))
   async readDetailedDurationPercentiles({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
     schemaCoordinate,
@@ -687,9 +708,9 @@ export class OperationsManager {
       clients,
     );
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -704,9 +725,9 @@ export class OperationsManager {
 
   async readUniqueClients({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
     clients,
     schemaCoordinate,
@@ -718,9 +739,9 @@ export class OperationsManager {
   } & TargetSelector) {
     this.logger.info('Counting unique clients (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -735,16 +756,16 @@ export class OperationsManager {
 
   async readUniqueClientNames({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     operations,
-  }: { period: DateRange; operations?: readonly string[] } & Listify<TargetSelector, 'target'>) {
+  }: { period: DateRange; operations?: readonly string[] } & Listify<TargetSelector, 'targetId'>) {
     this.logger.info('Read unique client names (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -757,9 +778,9 @@ export class OperationsManager {
 
   async readClientVersions({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     clientName,
     limit,
   }: {
@@ -769,9 +790,9 @@ export class OperationsManager {
   } & TargetSelector) {
     this.logger.info('Read client versions (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -785,9 +806,9 @@ export class OperationsManager {
 
   async countClientVersions({
     period,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     clientName,
   }: {
     period: DateRange;
@@ -800,9 +821,9 @@ export class OperationsManager {
       clientName,
     );
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -854,14 +875,14 @@ export class OperationsManager {
     } & TargetSelector,
   ) {
     await this.authManager.ensureTargetAccess({
-      organization: args.organization,
-      project: args.project,
-      target: args.target,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
     const loader = this.getClientNamesPerCoordinateOfTypeLoader({
-      target: args.target,
+      target: args.targetId,
       period: args.period,
     });
 
@@ -933,9 +954,9 @@ export class OperationsManager {
     coordinate: string;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -955,9 +976,9 @@ export class OperationsManager {
     period: DateRange;
   }): Promise<Set<string>> {
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -970,7 +991,7 @@ export class OperationsManager {
   async hasOperationsForOrganization(selector: OrganizationSelector): Promise<boolean> {
     this.logger.info(
       'Checking existence of collected operations (organization=%s)',
-      selector.organization,
+      selector.organizationId,
     );
     const targets = await this.storage.getTargetIdsOfOrganization(selector);
 
@@ -982,7 +1003,7 @@ export class OperationsManager {
 
     if (hasCollectedOperations) {
       await this.storage.completeGetStartedStep({
-        organization: selector.organization,
+        organizationId: selector.organizationId,
         step: 'reportingOperations',
       });
       return true;
@@ -1002,18 +1023,18 @@ export class OperationsManager {
   >(selector => JSON.stringify(selector))
   async countCoordinatesOfType({
     period,
-    target,
-    project,
-    organization,
+    targetId: target,
+    projectId: project,
+    organizationId: organization,
     typename,
   }: {
     period: DateRange;
     typename: string;
   } & TargetSelector) {
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -1050,16 +1071,16 @@ export class OperationsManager {
   >(selector => JSON.stringify(selector))
   async countCoordinatesOfTarget({
     period,
-    target,
-    project,
-    organization,
+    targetId: target,
+    projectId: project,
+    organizationId: organization,
   }: {
     period: DateRange;
   } & TargetSelector) {
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 

--- a/packages/services/api/src/modules/operations/resolvers/ClientStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/ClientStats.ts
@@ -5,18 +5,18 @@ import type { ClientStatsResolvers } from './../../../__generated__/types.next';
 export const ClientStats: ClientStatsResolvers = {
   totalRequests: ({ organization, project, target, period, clientName }, _, { injector }) => {
     return injector.get(OperationsManager).countRequestsAndFailures({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       clients: clientName === 'unknown' ? ['unknown', ''] : [clientName],
     });
   },
   totalVersions: ({ organization, project, target, period, clientName }, _, { injector }) => {
     return injector.get(OperationsManager).countClientVersions({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       clientName,
     });
@@ -27,9 +27,9 @@ export const ClientStats: ClientStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readRequestsOverTime({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       resolution,
       clients: clientName === 'unknown' ? ['unknown', ''] : [clientName],
@@ -39,16 +39,16 @@ export const ClientStats: ClientStatsResolvers = {
     const operationsManager = injector.get(OperationsManager);
     const [operations, durations] = await Promise.all([
       operationsManager.readOperationsStats({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
         period,
         clients: clientName === 'unknown' ? ['unknown', ''] : [clientName],
       }),
       operationsManager.readDetailedDurationPercentiles({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
         period,
         clients: clientName === 'unknown' ? ['unknown', ''] : [clientName],
       }),
@@ -71,9 +71,9 @@ export const ClientStats: ClientStatsResolvers = {
   },
   versions: ({ organization, project, target, period, clientName }, { limit }, { injector }) => {
     return injector.get(OperationsManager).readClientVersions({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       clientName,
       limit,

--- a/packages/services/api/src/modules/operations/resolvers/OperationsStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/OperationsStats.ts
@@ -11,17 +11,17 @@ export const OperationsStats: OperationsStatsResolvers = {
     const operationsManager = injector.get(OperationsManager);
     const [operations, durations] = await Promise.all([
       operationsManager.readOperationsStats({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
         period,
         operations: operationsFilter,
         clients,
       }),
       operationsManager.readDetailedDurationPercentiles({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
         period,
         operations: operationsFilter,
         clients,
@@ -49,9 +49,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).countRequestsAndFailures({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       operations,
       clients,
@@ -63,9 +63,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).countFailures({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       operations: operationsFilter,
       clients,
@@ -77,9 +77,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).countUniqueOperations({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       operations: operationsFilter,
       clients,
@@ -91,9 +91,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readRequestsOverTime({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       resolution,
       operations: operationsFilter,
@@ -106,9 +106,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readFailuresOverTime({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       resolution,
       operations: operationsFilter,
@@ -121,9 +121,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readDurationOverTime({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       resolution,
       operations: operationsFilter,
@@ -136,9 +136,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readUniqueClients({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       operations: operationsFilter,
       clients,
@@ -150,9 +150,9 @@ export const OperationsStats: OperationsStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readGeneralDurationPercentiles({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       operations: operationsFilter,
       clients,

--- a/packages/services/api/src/modules/operations/resolvers/OrganizationGetStarted.ts
+++ b/packages/services/api/src/modules/operations/resolvers/OrganizationGetStarted.ts
@@ -11,7 +11,7 @@ export const OrganizationGetStarted: Pick<
     }
 
     return injector.get(OperationsManager).hasOperationsForOrganization({
-      organization: organization.id,
+      organizationId: organization.id,
     });
   },
 };

--- a/packages/services/api/src/modules/operations/resolvers/Project.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Project.ts
@@ -6,15 +6,15 @@ export const Project: Pick<ProjectResolvers, 'requestsOverTime' | 'totalRequests
   {
     totalRequests: (project, { period }, { injector }) => {
       return injector.get(OperationsManager).countRequestsOfProject({
-        project: project.id,
-        organization: project.orgId,
+        projectId: project.id,
+        organizationId: project.orgId,
         period: parseDateRangeInput(period),
       });
     },
     requestsOverTime: (project, { resolution, period }, { injector }) => {
       return injector.get(OperationsManager).readRequestsOverTimeOfProject({
-        project: project.id,
-        organization: project.orgId,
+        projectId: project.id,
+        organizationId: project.orgId,
         period: parseDateRangeInput(period),
         resolution,
       });

--- a/packages/services/api/src/modules/operations/resolvers/Query/clientStatsByTargets.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Query/clientStatsByTargets.ts
@@ -19,15 +19,15 @@ export const clientStatsByTargets: NonNullable<QueryResolvers['clientStatsByTarg
 
   const [rows, total] = await Promise.all([
     injector.get(OperationsManager).readUniqueClientNames({
-      target: targets,
-      project,
-      organization,
+      targetId: targets,
+      projectId: project,
+      organizationId: organization,
       period,
     }),
     injector.get(OperationsManager).countRequests({
-      organization,
-      project,
-      target: targets,
+      organizationId: organization,
+      projectId: project,
+      targetId: targets,
       period,
     }),
   ]);

--- a/packages/services/api/src/modules/operations/resolvers/Query/fieldListStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Query/fieldListStats.ts
@@ -16,9 +16,9 @@ export const fieldListStats: NonNullable<QueryResolvers['fieldListStats']> = asy
   ]);
 
   return injector.get(OperationsManager).readFieldListStats({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     fields: selector.fields,
     period: parseDateRangeInput(selector.period),
   });

--- a/packages/services/api/src/modules/operations/resolvers/Query/fieldStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Query/fieldStats.ts
@@ -16,9 +16,9 @@ export const fieldStats: NonNullable<QueryResolvers['fieldStats']> = async (
   ]);
 
   return injector.get(OperationsManager).readFieldStats({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     type: selector.type,
     field: selector.field,
     argument: selector.argument ?? undefined,

--- a/packages/services/api/src/modules/operations/resolvers/Query/hasCollectedOperations.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Query/hasCollectedOperations.ts
@@ -15,8 +15,8 @@ export const hasCollectedOperations: NonNullable<QueryResolvers['hasCollectedOpe
   ]);
 
   return injector.get(OperationsManager).hasCollectedOperations({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 };

--- a/packages/services/api/src/modules/operations/resolvers/Query/monthlyUsage.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Query/monthlyUsage.ts
@@ -11,6 +11,6 @@ export const monthlyUsage: NonNullable<QueryResolvers['monthlyUsage']> = async (
   const organization = await translator.translateOrganizationId(selector);
 
   return injector.get(OperationsManager).readMonthlyUsage({
-    organization,
+    organizationId: organization,
   });
 };

--- a/packages/services/api/src/modules/operations/resolvers/SchemaCoordinateStats.ts
+++ b/packages/services/api/src/modules/operations/resolvers/SchemaCoordinateStats.ts
@@ -5,9 +5,9 @@ import type { SchemaCoordinateStatsResolvers } from './../../../__generated__/ty
 export const SchemaCoordinateStats: SchemaCoordinateStatsResolvers = {
   totalRequests: ({ organization, project, target, period, schemaCoordinate }, _, { injector }) => {
     return injector.get(OperationsManager).countRequestsWithSchemaCoordinate({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       period,
       schemaCoordinate,
     });
@@ -18,9 +18,9 @@ export const SchemaCoordinateStats: SchemaCoordinateStatsResolvers = {
     { injector },
   ) => {
     return injector.get(OperationsManager).readRequestsOverTime({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       resolution,
       schemaCoordinate,
@@ -34,16 +34,16 @@ export const SchemaCoordinateStats: SchemaCoordinateStatsResolvers = {
     const operationsManager = injector.get(OperationsManager);
     const [operations, durations] = await Promise.all([
       operationsManager.readOperationsStats({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
         period,
         schemaCoordinate,
       }),
       operationsManager.readDetailedDurationPercentiles({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
         period,
         schemaCoordinate,
       }),
@@ -66,9 +66,9 @@ export const SchemaCoordinateStats: SchemaCoordinateStatsResolvers = {
   },
   clients: ({ organization, project, target, period, schemaCoordinate }, _, { injector }) => {
     return injector.get(OperationsManager).readUniqueClients({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
       period,
       schemaCoordinate,
     });

--- a/packages/services/api/src/modules/operations/resolvers/Target.ts
+++ b/packages/services/api/src/modules/operations/resolvers/Target.ts
@@ -8,16 +8,16 @@ export const Target: Pick<
 > = {
   totalRequests: (target, { period }, { injector }) => {
     return injector.get(OperationsManager).countRequests({
-      target: target.id,
-      project: target.projectId,
-      organization: target.orgId,
+      targetId: target.id,
+      projectId: target.projectId,
+      organizationId: target.orgId,
       period: parseDateRangeInput(period),
     });
   },
   requestsOverTime: async (target, { resolution, period }, { injector }) => {
     const result = await injector.get(OperationsManager).readRequestsOverTimeOfTargets({
-      project: target.projectId,
-      organization: target.orgId,
+      projectId: target.projectId,
+      organizationId: target.orgId,
       targets: [target.id],
       period: parseDateRangeInput(period),
       resolution,
@@ -28,9 +28,9 @@ export const Target: Pick<
   operation: (target, args, { injector }) => {
     return injector.get(OperationsManager).getOperation({
       hash: args.hash,
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
     });
   },
 };

--- a/packages/services/api/src/modules/organization/module.graphql.ts
+++ b/packages/services/api/src/modules/organization/module.graphql.ts
@@ -84,12 +84,12 @@ export default gql`
   }
 
   input OrganizationTransferRequestSelector {
-    organization: ID!
+    organizationSlug: String!
     code: String!
   }
 
   input AnswerOrganizationTransferRequestInput {
-    organization: ID!
+    organizationSlug: String!
     accept: Boolean!
     code: String!
   }
@@ -136,29 +136,29 @@ export default gql`
   }
 
   input OrganizationSelectorInput {
-    organization: ID!
+    organizationSlug: String!
   }
 
   type OrganizationSelector {
-    organization: ID!
+    organizationSlug: String!
   }
 
   input OrganizationMemberInput {
-    organization: ID!
-    user: ID!
+    organizationSlug: String!
+    userId: ID!
   }
 
   input OrganizationMemberAccessInput {
-    organization: ID!
-    user: ID!
+    organizationSlug: String!
+    userId: ID!
     organizationScopes: [OrganizationAccessScope!]!
     projectScopes: [ProjectAccessScope!]!
     targetScopes: [TargetAccessScope!]!
   }
 
   input RequestOrganizationTransferInput {
-    organization: ID!
-    user: ID!
+    organizationSlug: String!
+    userId: ID!
   }
 
   input CreateOrganizationInput {
@@ -166,18 +166,18 @@ export default gql`
   }
 
   input UpdateOrganizationSlugInput {
-    organization: ID!
+    organizationSlug: String!
     slug: String!
   }
 
   input InviteToOrganizationByEmailInput {
-    organization: ID!
-    role: ID
+    organizationSlug: String!
+    roleId: ID
     email: String!
   }
 
   input DeleteOrganizationInvitationInput {
-    organization: ID!
+    organizationSlug: String!
     email: String!
   }
 
@@ -207,7 +207,7 @@ export default gql`
 
   type Organization {
     id: ID!
-    slug: ID!
+    slug: String!
     cleanId: ID! @deprecated(reason: "Use the 'slug' field instead.")
     name: String! @deprecated(reason: "Use the 'slug' field instead.")
     owner: Member!
@@ -314,7 +314,7 @@ export default gql`
   }
 
   input CreateMemberRoleInput {
-    organization: ID!
+    organizationSlug: String!
     name: String!
     description: String!
     organizationAccessScopes: [OrganizationAccessScope!]!
@@ -348,8 +348,8 @@ export default gql`
   }
 
   input UpdateMemberRoleInput {
-    organization: ID!
-    role: ID!
+    organizationSlug: String!
+    roleId: ID!
     name: String!
     description: String!
     organizationAccessScopes: [OrganizationAccessScope!]!
@@ -383,8 +383,8 @@ export default gql`
   }
 
   input DeleteMemberRoleInput {
-    organization: ID!
-    role: ID!
+    organizationSlug: String!
+    roleId: ID!
   }
 
   type DeleteMemberRoleOk {
@@ -404,9 +404,9 @@ export default gql`
   }
 
   input AssignMemberRoleInput {
-    organization: ID!
-    user: ID!
-    role: ID!
+    organizationSlug: String!
+    userId: ID!
+    roleId: ID!
   }
 
   type AssignMemberRoleOk {
@@ -443,19 +443,19 @@ export default gql`
   }
 
   input AssignMemberRoleMigrationInput {
-    organization: ID!
-    role: ID!
-    users: [ID!]!
+    organizationSlug: String!
+    roleId: ID!
+    userIds: [ID!]!
   }
 
   input CreateMemberRoleMigrationInput {
-    organization: ID!
+    organizationSlug: String!
     name: String!
     description: String!
     organizationScopes: [OrganizationAccessScope!]!
     projectScopes: [ProjectAccessScope!]!
     targetScopes: [TargetAccessScope!]!
-    users: [ID!]!
+    userIds: [ID!]!
   }
 
   type MigrateUnassignedMembersResult {

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -75,12 +75,12 @@ export class OrganizationManager {
     const result = await this.tokenStorage.getToken({ token });
 
     await this.authManager.ensureOrganizationAccess({
-      organization: result.organization,
+      organizationId: result.organization,
       scope: OrganizationAccessScope.READ,
     });
 
     return this.storage.getOrganization({
-      organization: result.organization,
+      organizationId: result.organization,
     });
   });
 
@@ -108,7 +108,7 @@ export class OrganizationManager {
   async getOrganizations(): Promise<readonly Organization[]> {
     this.logger.debug('Fetching organizations');
     const user = await this.authManager.getCurrentUser();
-    return this.storage.getOrganizations({ user: user.id });
+    return this.storage.getOrganizations({ userId: user.id });
   }
 
   getFeatureFlags(selector: OrganizationSelector) {
@@ -123,8 +123,8 @@ export class OrganizationManager {
     userId: string;
   }) {
     const member = await this.storage.getOrganizationMember({
-      organization: organizationId,
-      user: userId,
+      organizationId: organizationId,
+      userId: userId,
     });
 
     if (!member) {
@@ -149,7 +149,7 @@ export class OrganizationManager {
     }
 
     const membersCount = await this.countOrganizationMembers({
-      organization: organizationId,
+      organizationId: organizationId,
     });
 
     if (membersCount > 1) {
@@ -190,14 +190,14 @@ export class OrganizationManager {
     }
 
     await this.storage.deleteOrganizationMember({
-      user: user.id,
-      organization: organizationId,
+      userId: user.id,
+      organizationId: organizationId,
     });
 
     await this.activityManager.create({
       type: 'MEMBER_LEFT',
       selector: {
-        organization: organizationId,
+        organizationId: organizationId,
       },
       user: user,
       meta: {
@@ -230,7 +230,7 @@ export class OrganizationManager {
     }
 
     const hasAccess = await this.authManager.checkOrganizationAccess({
-      organization: organization.id,
+      organizationId: organization.id,
       scope: OrganizationAccessScope.READ,
     });
 
@@ -243,7 +243,7 @@ export class OrganizationManager {
     return organization;
   }
 
-  @cache((selector: OrganizationSelector) => selector.organization)
+  @cache((selector: OrganizationSelector) => selector.organizationId)
   async getOrganizationMembers(selector: OrganizationSelector) {
     return this.storage.getOrganizationMembers(selector);
   }
@@ -252,7 +252,7 @@ export class OrganizationManager {
     return this.storage.countOrganizationMembers(selector);
   }
 
-  async getOrganizationMember(selector: OrganizationSelector & { user: string }) {
+  async getOrganizationMember(selector: OrganizationSelector & { userId: string }) {
     const member = await this.storage.getOrganizationMember(selector);
 
     if (!member) {
@@ -262,10 +262,10 @@ export class OrganizationManager {
     return member;
   }
 
-  @cache((selector: OrganizationSelector) => selector.organization)
+  @cache((selector: OrganizationSelector) => selector.organizationId)
   async getInvitations(selector: OrganizationSelector) {
     await this.authManager.ensureOrganizationAccess({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
     return this.storage.getOrganizationInvitations(selector);
@@ -296,7 +296,7 @@ export class OrganizationManager {
 
     const result = await this.storage.createOrganization({
       slug,
-      user: user.id,
+      userId: user.id,
       adminScopes: organizationAdminScopes,
       viewerScopes: organizationViewerScopes,
       reservedSlugs: reservedOrganizationSlugs,
@@ -306,7 +306,7 @@ export class OrganizationManager {
       await this.activityManager.create({
         type: 'ORGANIZATION_CREATED',
         selector: {
-          organization: result.organization.id,
+          organizationId: result.organization.id,
         },
         user,
       });
@@ -316,18 +316,18 @@ export class OrganizationManager {
   }
 
   async deleteOrganization(selector: OrganizationSelector): Promise<Organization> {
-    this.logger.info('Deleting an organization (organization=%s)', selector.organization);
+    this.logger.info('Deleting an organization (organization=%s)', selector.organizationId);
     await this.authManager.ensureOrganizationAccess({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
       scope: OrganizationAccessScope.DELETE,
     });
 
     const organization = await this.getOrganization({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
     });
 
     const deletedOrganization = await this.storage.deleteOrganization({
-      organization: organization.id,
+      organizationId: organization.id,
     });
 
     await this.tokenStorage.invalidateTokens(deletedOrganization.tokens);
@@ -350,18 +350,18 @@ export class OrganizationManager {
       scope: OrganizationAccessScope.SETTINGS,
     });
     const organization = await this.getOrganization({
-      organization: input.organization,
+      organizationId: input.organizationId,
     });
 
     const result = await this.storage.updateOrganizationPlan({
       billingPlan: plan,
-      organization: organization.id,
+      organizationId: organization.id,
     });
 
     await this.activityManager.create({
       type: 'ORGANIZATION_PLAN_UPDATED',
       selector: {
-        organization: organization.id,
+        organizationId: organization.id,
       },
       meta: {
         newPlan: plan,
@@ -382,12 +382,12 @@ export class OrganizationManager {
       scope: OrganizationAccessScope.SETTINGS,
     });
     const organization = await this.getOrganization({
-      organization: input.organization,
+      organizationId: input.organizationId,
     });
 
     const result = await this.storage.updateOrganizationRateLimits({
       monthlyRateLimit,
-      organization: organization.id,
+      organizationId: organization.id,
     });
 
     if (this.billingProvider.enabled) {
@@ -416,7 +416,7 @@ export class OrganizationManager {
     const [user, organization] = await Promise.all([
       this.authManager.getCurrentUser(),
       this.getOrganization({
-        organization: input.organization,
+        organizationId: input.organizationId,
       }),
     ]);
 
@@ -429,8 +429,8 @@ export class OrganizationManager {
 
     const result = await this.storage.updateOrganizationSlug({
       slug,
-      organization: organization.id,
-      user: user.id,
+      organizationId: organization.id,
+      userId: user.id,
       reservedSlugs: reservedOrganizationSlugs,
     });
 
@@ -438,7 +438,7 @@ export class OrganizationManager {
       await this.activityManager.create({
         type: 'ORGANIZATION_ID_UPDATED',
         selector: {
-          organization: organization.id,
+          organizationId: organization.id,
         },
         meta: {
           value: result.organization.slug,
@@ -449,10 +449,10 @@ export class OrganizationManager {
     return result;
   }
 
-  async deleteInvitation(input: { email: string; organization: string }) {
+  async deleteInvitation(input: { email: string; organizationId: string }) {
     await this.authManager.ensureOrganizationAccess({
       scope: OrganizationAccessScope.MEMBERS,
-      organization: input.organization,
+      organizationId: input.organizationId,
     });
     return this.storage.deleteOrganizationInvitationByEmail(input);
   }
@@ -460,7 +460,7 @@ export class OrganizationManager {
   async inviteByEmail(input: { email: string; organization: string; role?: string | null }) {
     await this.authManager.ensureOrganizationAccess({
       scope: OrganizationAccessScope.MEMBERS,
-      organization: input.organization,
+      organizationId: input.organization,
     });
 
     const { email } = input;
@@ -471,11 +471,11 @@ export class OrganizationManager {
       input.role,
     );
     const organization = await this.getOrganization({
-      organization: input.organization,
+      organizationId: input.organization,
     });
 
     const [members, currentUserAccessScopes] = await Promise.all([
-      this.getOrganizationMembers({ organization: input.organization }),
+      this.getOrganizationMembers({ organizationId: input.organization }),
       this.authManager.getCurrentUserAccessScopes(organization.id),
     ]);
     const existingMember = members.find(member => member.user.email === email);
@@ -519,20 +519,20 @@ export class OrganizationManager {
 
     // Delete existing invitation
     await this.storage.deleteOrganizationInvitationByEmail({
-      organization: organization.id,
+      organizationId: organization.id,
       email,
     });
 
     // create an invitation code (with 7d TTL)
     const invitation = await this.storage.createOrganizationInvitation({
-      organization: organization.id,
+      organizationId: organization.id,
       email,
       roleId: role.id,
     });
 
     await Promise.all([
       this.storage.completeGetStartedStep({
-        organization: organization.id,
+        organizationId: organization.id,
         step: 'invitingMembers',
       }),
       // schedule an email
@@ -607,8 +607,8 @@ export class OrganizationManager {
 
     await this.storage.addOrganizationMemberViaInvitationCode({
       code,
-      user: user.id,
-      organization: organization.id,
+      userId: user.id,
+      organizationId: organization.id,
     });
 
     // Because we checked the access before, it's stale by now
@@ -616,14 +616,14 @@ export class OrganizationManager {
 
     await Promise.all([
       this.storage.completeGetStartedStep({
-        organization: organization.id,
+        organizationId: organization.id,
         step: 'invitingMembers',
       }),
       this.activityManager.create({
         type: 'MEMBER_ADDED',
         selector: {
-          organization: organization.id,
-          user: user.id,
+          organizationId: organization.id,
+          userId: user.id,
         },
       }),
     ]);
@@ -633,12 +633,12 @@ export class OrganizationManager {
 
   async requestOwnershipTransfer(
     selector: {
-      user: string;
+      userId: string;
     } & OrganizationSelector,
   ) {
     const currentUser = await this.authManager.getCurrentUser();
 
-    if (currentUser.id === selector.user) {
+    if (currentUser.id === selector.userId) {
       return {
         error: {
           message: 'Cannot transfer ownership to yourself',
@@ -647,7 +647,7 @@ export class OrganizationManager {
     }
 
     await this.authManager.ensureOrganizationOwnership({
-      organization: selector.organization,
+      organization: selector.organizationId,
     });
 
     const member = await this.storage.getOrganizationMember(selector);
@@ -663,8 +663,8 @@ export class OrganizationManager {
     const organization = await this.getOrganization(selector);
 
     const { code } = await this.storage.createOrganizationTransferRequest({
-      organization: organization.id,
-      user: member.user.id,
+      organizationId: organization.id,
+      userId: member.user.id,
     });
 
     await this.emails.schedule({
@@ -707,15 +707,15 @@ export class OrganizationManager {
     } & OrganizationSelector,
   ) {
     await this.authManager.ensureOrganizationAccess({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
       scope: OrganizationAccessScope.READ,
     });
     const currentUser = await this.authManager.getCurrentUser();
 
     return this.storage.getOrganizationTransferRequest({
-      organization: selector.organization,
+      organizationId: selector.organizationId,
       code: selector.code,
-      user: currentUser.id,
+      userId: currentUser.id,
     });
   }
 
@@ -726,15 +726,15 @@ export class OrganizationManager {
     } & OrganizationSelector,
   ) {
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organization,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.READ,
     });
     const currentUser = await this.authManager.getCurrentUser();
 
     await this.storage.answerOrganizationTransferRequest({
-      organization: input.organization,
+      organizationId: input.organizationId,
       code: input.code,
-      user: currentUser.id,
+      userId: currentUser.id,
       accept: input.accept,
     });
   }
@@ -750,7 +750,7 @@ export class OrganizationManager {
       scope: OrganizationAccessScope.MEMBERS,
     });
     const owner = await this.getOrganizationOwner(selector);
-    const { user, organization } = selector;
+    const { user, organizationId: organization } = selector;
 
     if (user === owner.id) {
       throw new HiveError(`Cannot remove the owner from the organization`);
@@ -760,12 +760,12 @@ export class OrganizationManager {
 
     const [currentUserAsMember, member] = await Promise.all([
       this.storage.getOrganizationMember({
-        organization,
-        user: currentUser.id,
+        organizationId: organization,
+        userId: currentUser.id,
       }),
       this.storage.getOrganizationMember({
-        organization,
-        user,
+        organizationId: organization,
+        userId: user,
       }),
     ]);
 
@@ -789,15 +789,15 @@ export class OrganizationManager {
     }
 
     await this.storage.deleteOrganizationMember({
-      user,
-      organization,
+      userId: user,
+      organizationId: organization,
     });
 
     if (member) {
       await this.activityManager.create({
         type: 'MEMBER_DELETED',
         selector: {
-          organization,
+          organizationId: organization,
         },
         meta: {
           email: member.user.email,
@@ -809,7 +809,7 @@ export class OrganizationManager {
     this.authManager.resetAccessCache();
 
     return this.storage.getOrganization({
-      organization,
+      organizationId: organization,
     });
   }
 
@@ -831,12 +831,12 @@ export class OrganizationManager {
 
     const [currentMember, member] = await Promise.all([
       this.getOrganizationMember({
-        organization: input.organization,
-        user: currentUser.id,
+        organizationId: input.organizationId,
+        userId: currentUser.id,
       }),
       this.getOrganizationMember({
-        organization: input.organization,
-        user: input.user,
+        organizationId: input.organizationId,
+        userId: input.user,
       }),
     ]);
 
@@ -866,8 +866,8 @@ export class OrganizationManager {
 
     // Update the scopes
     await this.storage.updateOrganizationMemberAccess({
-      organization: input.organization,
-      user: input.user,
+      organizationId: input.organizationId,
+      userId: input.user,
       scopes: newScopes,
     });
 
@@ -875,7 +875,7 @@ export class OrganizationManager {
     this.authManager.resetAccessCache();
 
     return this.storage.getOrganization({
-      organization: input.organization,
+      organizationId: input.organizationId,
     });
   }
 
@@ -888,7 +888,7 @@ export class OrganizationManager {
     targetAccessScopes: readonly TargetAccessScope[];
   }) {
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
 
@@ -900,8 +900,8 @@ export class OrganizationManager {
 
     const currentUser = await this.authManager.getCurrentUser();
     const currentUserAsMember = await this.getOrganizationMember({
-      organization: input.organizationId,
-      user: currentUser.id,
+      organizationId: input.organizationId,
+      userId: currentUser.id,
     });
 
     // Ensure user has access to all scopes in the role
@@ -950,7 +950,7 @@ export class OrganizationManager {
     return {
       ok: {
         updatedOrganization: await this.storage.getOrganization({
-          organization: input.organizationId,
+          organizationId: input.organizationId,
         }),
         createdRole: role,
       },
@@ -959,7 +959,7 @@ export class OrganizationManager {
 
   async deleteMemberRole(input: { organizationId: string; roleId: string }) {
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
 
@@ -978,8 +978,8 @@ export class OrganizationManager {
 
     const currentUser = await this.authManager.getCurrentUser();
     const currentUserAsMember = await this.getOrganizationMember({
-      organization: input.organizationId,
-      user: currentUser.id,
+      organizationId: input.organizationId,
+      userId: currentUser.id,
     });
 
     const accessCheckResult = await this.canDeleteRole(role, currentUserAsMember.scopes);
@@ -1001,7 +1001,7 @@ export class OrganizationManager {
     return {
       ok: {
         updatedOrganization: await this.storage.getOrganization({
-          organization: input.organizationId,
+          organizationId: input.organizationId,
         }),
       },
     };
@@ -1009,14 +1009,14 @@ export class OrganizationManager {
 
   async assignMemberRole(input: { organizationId: string; userId: string; roleId: string }) {
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
 
     // Ensure selected member is part of the organization
     const member = await this.storage.getOrganizationMember({
-      organization: input.organizationId,
-      user: input.userId,
+      organizationId: input.organizationId,
+      userId: input.userId,
     });
 
     if (!member) {
@@ -1026,8 +1026,8 @@ export class OrganizationManager {
     const currentUser = await this.authManager.getCurrentUser();
     const [currentUserAsMember, newRole] = await Promise.all([
       this.getOrganizationMember({
-        organization: input.organizationId,
-        user: currentUser.id,
+        organizationId: input.organizationId,
+        userId: currentUser.id,
       }),
       this.storage.getOrganizationMemberRole({
         organizationId: input.organizationId,
@@ -1105,8 +1105,8 @@ export class OrganizationManager {
     return {
       ok: {
         updatedMember: await this.getOrganizationMember({
-          organization: input.organizationId,
-          user: input.userId,
+          organizationId: input.organizationId,
+          userId: input.userId,
         }),
         previousMemberRole: member.role,
       },
@@ -1123,7 +1123,7 @@ export class OrganizationManager {
     targetAccessScopes: readonly TargetAccessScope[];
   }) {
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
 
@@ -1134,8 +1134,8 @@ export class OrganizationManager {
         roleId: input.roleId,
       }),
       this.getOrganizationMember({
-        organization: input.organizationId,
-        user: currentUser.id,
+        organizationId: input.organizationId,
+        userId: currentUser.id,
       }),
     ]);
 
@@ -1243,7 +1243,7 @@ export class OrganizationManager {
   async getMembersWithoutRole(selector: { organizationId: string }) {
     if (
       await this.authManager.checkOrganizationAccess({
-        organization: selector.organizationId,
+        organizationId: selector.organizationId,
         scope: OrganizationAccessScope.MEMBERS,
       })
     ) {
@@ -1258,7 +1258,7 @@ export class OrganizationManager {
 
   async getMemberRoles(selector: { organizationId: string }) {
     await this.authManager.ensureOrganizationAccess({
-      organization: selector.organizationId,
+      organizationId: selector.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
 
@@ -1269,7 +1269,7 @@ export class OrganizationManager {
 
   async getMemberRole(selector: { organizationId: string; roleId: string }) {
     await this.authManager.ensureOrganizationAccess({
-      organization: selector.organizationId,
+      organizationId: selector.organizationId,
       scope: OrganizationAccessScope.MEMBERS,
     });
 
@@ -1444,8 +1444,8 @@ export class OrganizationManager {
   }) {
     const currentUser = await this.authManager.getCurrentUser();
     const currentUserAsMember = await this.getOrganizationMember({
-      organization: organizationId,
-      user: currentUser.id,
+      organizationId: organizationId,
+      userId: currentUser.id,
     });
 
     if (!this.isAdminRole(currentUserAsMember.role)) {
@@ -1517,7 +1517,7 @@ export class OrganizationManager {
     return {
       ok: {
         updatedOrganization: await this.storage.getOrganization({
-          organization: input.organizationId,
+          organizationId: input.organizationId,
         }),
       },
     };

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1430,8 +1430,8 @@ export class OrganizationManager {
   }: {
     organizationId: string;
     assignRole?: {
-      role: string;
-      users: readonly string[];
+      roleId: string;
+      userIds: readonly string[];
     } | null;
     createRole?: {
       name: string;
@@ -1439,7 +1439,7 @@ export class OrganizationManager {
       organizationScopes: readonly OrganizationAccessScope[];
       projectScopes: readonly ProjectAccessScope[];
       targetScopes: readonly TargetAccessScope[];
-      users: readonly string[];
+      userIds: readonly string[];
     } | null;
   }) {
     const currentUser = await this.authManager.getCurrentUser();
@@ -1459,8 +1459,8 @@ export class OrganizationManager {
     if (assignRole) {
       return this.assignRoleToMembersMigration({
         organizationId,
-        roleId: assignRole.role,
-        users: assignRole.users,
+        roleId: assignRole.roleId,
+        userIds: assignRole.userIds,
       });
     }
 
@@ -1481,7 +1481,7 @@ export class OrganizationManager {
     organizationScopes: readonly OrganizationAccessScope[];
     projectScopes: readonly ProjectAccessScope[];
     targetScopes: readonly TargetAccessScope[];
-    users: readonly string[];
+    userIds: readonly string[];
   }) {
     const result = await this.createMemberRole({
       organizationId: input.organizationId,
@@ -1496,7 +1496,7 @@ export class OrganizationManager {
       return this.assignRoleToMembersMigration({
         roleId: result.ok.createdRole.id,
         organizationId: input.organizationId,
-        users: input.users,
+        userIds: input.userIds,
       });
     }
 
@@ -1506,12 +1506,12 @@ export class OrganizationManager {
   private async assignRoleToMembersMigration(input: {
     organizationId: string;
     roleId: string;
-    users: readonly string[];
+    userIds: readonly string[];
   }) {
     await this.storage.assignOrganizationMemberRoleToMany({
       organizationId: input.organizationId,
       roleId: input.roleId,
-      userIds: input.users,
+      userIds: input.userIds,
     });
 
     return {

--- a/packages/services/api/src/modules/organization/resolvers/MemberRole.ts
+++ b/packages/services/api/src/modules/organization/resolvers/MemberRole.ts
@@ -35,8 +35,8 @@ export const MemberRole: MemberRoleResolvers = {
 
     const currentUser = await injector.get(AuthManager).getCurrentUser();
     const currentUserAsMember = await injector.get(OrganizationManager).getOrganizationMember({
-      organization: role.organizationId,
-      user: currentUser.id,
+      organizationId: role.organizationId,
+      userId: currentUser.id,
     });
 
     const result = await injector
@@ -51,8 +51,8 @@ export const MemberRole: MemberRoleResolvers = {
     }
     const currentUser = await injector.get(AuthManager).getCurrentUser();
     const currentUserAsMember = await injector.get(OrganizationManager).getOrganizationMember({
-      organization: role.organizationId,
-      user: currentUser.id,
+      organizationId: role.organizationId,
+      userId: currentUser.id,
     });
 
     const result = injector
@@ -64,8 +64,8 @@ export const MemberRole: MemberRoleResolvers = {
   canInvite: async (role, _, { injector }) => {
     const currentUser = await injector.get(AuthManager).getCurrentUser();
     const currentUserAsMember = await injector.get(OrganizationManager).getOrganizationMember({
-      organization: role.organizationId,
-      user: currentUser.id,
+      organizationId: role.organizationId,
+      userId: currentUser.id,
     });
 
     const result = injector

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/answerOrganizationTransferRequest.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/answerOrganizationTransferRequest.ts
@@ -10,7 +10,7 @@ export const answerOrganizationTransferRequest: NonNullable<
 
   try {
     await injector.get(OrganizationManager).answerOwnershipTransferRequest({
-      organization,
+      organizationId: organization,
       code: input.code,
       accept: input.accept,
     });

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/assignMemberRole.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/assignMemberRole.ts
@@ -11,7 +11,7 @@ export const assignMemberRole: NonNullable<MutationResolvers['assignMemberRole']
 
   return injector.get(OrganizationManager).assignMemberRole({
     organizationId,
-    userId: input.user,
-    roleId: input.role,
+    userId: input.userId,
+    roleId: input.roleId,
   });
 };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/createOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/createOrganization.ts
@@ -31,7 +31,7 @@ export const createOrganization: NonNullable<MutationResolvers['createOrganizati
       ok: {
         createdOrganizationPayload: {
           selector: {
-            organization: result.organization.slug,
+            organizationSlug: result.organization.slug,
           },
           organization: result.organization,
         },

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/deleteMemberRole.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/deleteMemberRole.ts
@@ -11,6 +11,6 @@ export const deleteMemberRole: NonNullable<MutationResolvers['deleteMemberRole']
 
   return injector.get(OrganizationManager).deleteMemberRole({
     organizationId,
-    roleId: input.role,
+    roleId: input.roleId,
   });
 };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganization.ts
@@ -12,7 +12,7 @@ export const deleteOrganization: NonNullable<MutationResolvers['deleteOrganizati
     organizationSlug: selector.organizationSlug,
   });
   const organization = await injector.get(OrganizationManager).deleteOrganization({
-    organization: organizationId,
+    organizationId: organizationId,
   });
   return {
     selector: {

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganization.ts
@@ -9,14 +9,14 @@ export const deleteOrganization: NonNullable<MutationResolvers['deleteOrganizati
 ) => {
   const translator = injector.get(IdTranslator);
   const organizationId = await translator.translateOrganizationId({
-    organization: selector.organization,
+    organizationSlug: selector.organizationSlug,
   });
   const organization = await injector.get(OrganizationManager).deleteOrganization({
     organization: organizationId,
   });
   return {
     selector: {
-      organization: organizationId,
+      organizationSlug: organization.slug,
     },
     organization,
   };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganizationInvitation.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganizationInvitation.ts
@@ -8,7 +8,7 @@ export const deleteOrganizationInvitation: NonNullable<
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
   const invitation = await injector
     .get(OrganizationManager)
-    .deleteInvitation({ organization: organizationId, email: input.email });
+    .deleteInvitation({ organizationId: organizationId, email: input.email });
 
   if (invitation) {
     return {

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganizationMember.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganizationMember.ts
@@ -8,7 +8,7 @@ export const deleteOrganizationMember: NonNullable<
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
   const organization = await injector
     .get(OrganizationManager)
-    .deleteMember({ organization: organizationId, user: input.userId });
+    .deleteMember({ organizationId: organizationId, user: input.userId });
 
   return {
     selector: input,

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganizationMember.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/deleteOrganizationMember.ts
@@ -8,7 +8,7 @@ export const deleteOrganizationMember: NonNullable<
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
   const organization = await injector
     .get(OrganizationManager)
-    .deleteMember({ organization: organizationId, user: input.user });
+    .deleteMember({ organization: organizationId, user: input.userId });
 
   return {
     selector: input,

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/inviteToOrganizationByEmail.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/inviteToOrganizationByEmail.ts
@@ -33,6 +33,6 @@ export const inviteToOrganizationByEmail: NonNullable<
   return await injector.get(OrganizationManager).inviteByEmail({
     organization,
     email: input.email,
-    role: input.role,
+    role: input.roleId,
   });
 };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/joinOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/joinOrganization.ts
@@ -15,7 +15,7 @@ export const joinOrganization: NonNullable<MutationResolvers['joinOrganization']
   return {
     __typename: 'OrganizationPayload',
     selector: {
-      organization: organization.slug,
+      organizationSlug: organization.slug,
     },
     organization,
   };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/leaveOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/leaveOrganization.ts
@@ -9,7 +9,7 @@ export const leaveOrganization: NonNullable<MutationResolvers['leaveOrganization
 ) => {
   const translator = injector.get(IdTranslator);
   const organizationId = await translator.translateOrganizationId({
-    organization: input.organization,
+    organizationSlug: input.organizationSlug,
   });
 
   const result = await injector.get(OrganizationManager).leaveOrganization(organizationId);

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/migrateUnassignedMembers.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/migrateUnassignedMembers.ts
@@ -5,9 +5,10 @@ import type { MutationResolvers } from './../../../../__generated__/types.next';
 export const migrateUnassignedMembers: NonNullable<
   MutationResolvers['migrateUnassignedMembers']
 > = async (_, { input }, { injector }) => {
-  const organizationIdFromInput = input.assignRole?.organization ?? input.createRole?.organization;
+  const organizationSlugFromInput =
+    input.assignRole?.organizationSlug ?? input.createRole?.organizationSlug;
 
-  if (!organizationIdFromInput) {
+  if (!organizationSlugFromInput) {
     return {
       error: {
         message: 'Assign a role or create a new one',
@@ -16,7 +17,7 @@ export const migrateUnassignedMembers: NonNullable<
   }
 
   const organizationId = await injector.get(IdTranslator).translateOrganizationId({
-    organization: organizationIdFromInput,
+    organizationSlug: organizationSlugFromInput,
   });
 
   return injector.get(OrganizationManager).migrateUnassignedMembers({

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/requestOrganizationTransfer.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/requestOrganizationTransfer.ts
@@ -7,7 +7,7 @@ export const requestOrganizationTransfer: NonNullable<
 > = async (_, { input }, { injector }) => {
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
   return injector.get(OrganizationManager).requestOwnershipTransfer({
-    organization: organizationId,
-    user: input.userId,
+    organizationId: organizationId,
+    userId: input.userId,
   });
 };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/requestOrganizationTransfer.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/requestOrganizationTransfer.ts
@@ -5,9 +5,9 @@ import type { MutationResolvers } from './../../../../__generated__/types.next';
 export const requestOrganizationTransfer: NonNullable<
   MutationResolvers['requestOrganizationTransfer']
 > = async (_, { input }, { injector }) => {
-  const organization = await injector.get(IdTranslator).translateOrganizationId(input);
+  const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
   return injector.get(OrganizationManager).requestOwnershipTransfer({
-    organization,
-    user: input.user,
+    organization: organizationId,
+    user: input.userId,
   });
 };

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/updateMemberRole.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/updateMemberRole.ts
@@ -28,7 +28,7 @@ export const updateMemberRole: NonNullable<MutationResolvers['updateMemberRole']
 
   return injector.get(OrganizationManager).updateMemberRole({
     organizationId,
-    roleId: input.role,
+    roleId: input.roleId,
     name: inputValidation.data.name,
     description: inputValidation.data.description,
     organizationAccessScopes: input.organizationAccessScopes,

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationMemberAccess.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationMemberAccess.ts
@@ -12,7 +12,7 @@ export const updateOrganizationMemberAccess: NonNullable<
       organizationSlug: input.organizationSlug,
     },
     organization: await injector.get(OrganizationManager).updateMemberAccess({
-      organization: organizationId,
+      organizationId: organizationId,
       user: input.userId,
       organizationScopes: input.organizationScopes,
       projectScopes: input.projectScopes,

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationMemberAccess.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationMemberAccess.ts
@@ -5,15 +5,15 @@ import type { MutationResolvers } from './../../../../__generated__/types.next';
 export const updateOrganizationMemberAccess: NonNullable<
   MutationResolvers['updateOrganizationMemberAccess']
 > = async (_, { input }, { injector }) => {
-  const organization = await injector.get(IdTranslator).translateOrganizationId(input);
+  const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
 
   return {
     selector: {
-      organization: input.organization,
+      organizationSlug: input.organizationSlug,
     },
     organization: await injector.get(OrganizationManager).updateMemberAccess({
-      organization,
-      user: input.user,
+      organization: organizationId,
+      user: input.userId,
       organizationScopes: input.organizationScopes,
       projectScopes: input.projectScopes,
       targetScopes: input.targetScopes,

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationSlug.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationSlug.ts
@@ -21,7 +21,7 @@ export const updateOrganizationSlug: NonNullable<
   const organizationId = await injector.get(IdTranslator).translateOrganizationId(input);
   const result = await injector.get(OrganizationManager).updateSlug({
     slug: parsedInput.data,
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   if (result.ok) {

--- a/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationSlug.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Mutation/updateOrganizationSlug.ts
@@ -29,7 +29,7 @@ export const updateOrganizationSlug: NonNullable<
       ok: {
         updatedOrganizationPayload: {
           selector: {
-            organization: result.organization.slug,
+            organizationSlug: result.organization.slug,
           },
           organization: result.organization,
         },

--- a/packages/services/api/src/modules/organization/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Organization.ts
@@ -30,24 +30,24 @@ export const Organization: Pick<
   owner: (organization, _, { injector }) => {
     return injector
       .get(OrganizationManager)
-      .getOrganizationOwner({ organization: organization.id });
+      .getOrganizationOwner({ organizationId: organization.id });
   },
   me: async (organization, _, { injector }) => {
     const me = await injector.get(AuthManager).getCurrentUser();
     const members = await injector
       .get(OrganizationManager)
-      .getOrganizationMembers({ organization: organization.id });
+      .getOrganizationMembers({ organizationId: organization.id });
 
     return members.find(m => m.id === me.id)!;
   },
   members: (organization, _, { injector }) => {
     return injector
       .get(OrganizationManager)
-      .getOrganizationMembers({ organization: organization.id });
+      .getOrganizationMembers({ organizationId: organization.id });
   },
   invitations: async (organization, _, { injector }) => {
     const invitations = await injector.get(OrganizationManager).getInvitations({
-      organization: organization.id,
+      organizationId: organization.id,
     });
 
     return {

--- a/packages/services/api/src/modules/organization/resolvers/Query/myDefaultOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Query/myDefaultOrganization.ts
@@ -19,7 +19,7 @@ export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganiz
     });
     if (oidcIntegration.type === 'ok') {
       const org = await organizationManager.getOrganization({
-        organization: oidcIntegration.organizationId,
+        organizationId: oidcIntegration.organizationId,
       });
 
       return {
@@ -42,7 +42,7 @@ export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganiz
 
     if (orgId) {
       const org = await organizationManager.getOrganization({
-        organization: orgId,
+        organizationId: orgId,
       });
 
       if (org) {

--- a/packages/services/api/src/modules/organization/resolvers/Query/myDefaultOrganization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Query/myDefaultOrganization.ts
@@ -6,7 +6,7 @@ import type { QueryResolvers } from './../../../../__generated__/types.next';
 
 export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganization']> = async (
   _,
-  { previouslyVisitedOrganizationId },
+  { previouslyVisitedOrganizationId: previouslyVisitedOrganizationSlug },
   { injector },
 ) => {
   const user = await injector.get(AuthManager).getCurrentUser();
@@ -24,7 +24,7 @@ export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganiz
 
       return {
         selector: {
-          organization: org.slug,
+          organizationSlug: org.slug,
         },
         organization: org,
       };
@@ -35,9 +35,9 @@ export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganiz
 
   // This is the organization that got stored as an cookie
   // We make sure it actually exists before directing to it.
-  if (previouslyVisitedOrganizationId) {
+  if (previouslyVisitedOrganizationSlug) {
     const orgId = await injector.get(IdTranslator).translateOrganizationIdSafe({
-      organization: previouslyVisitedOrganizationId,
+      organizationSlug: previouslyVisitedOrganizationSlug,
     });
 
     if (orgId) {
@@ -48,7 +48,7 @@ export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganiz
       if (org) {
         return {
           selector: {
-            organization: org.slug,
+            organizationSlug: org.slug,
           },
           organization: org,
         };
@@ -64,7 +64,7 @@ export const myDefaultOrganization: NonNullable<QueryResolvers['myDefaultOrganiz
 
       return {
         selector: {
-          organization: firstOrg.slug,
+          organizationSlug: firstOrg.slug,
         },
         organization: firstOrg,
       };

--- a/packages/services/api/src/modules/organization/resolvers/Query/organization.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Query/organization.ts
@@ -12,7 +12,7 @@ export const organization: NonNullable<QueryResolvers['organization']> = async (
   return {
     selector,
     organization: await injector.get(OrganizationManager).getOrganization({
-      organization,
+      organizationId: organization,
     }),
   };
 };

--- a/packages/services/api/src/modules/organization/resolvers/Query/organizationTransferRequest.ts
+++ b/packages/services/api/src/modules/organization/resolvers/Query/organizationTransferRequest.ts
@@ -9,7 +9,7 @@ export const organizationTransferRequest: NonNullable<
   const organizationManager = injector.get(OrganizationManager);
 
   const transferRequest = await organizationManager.getOwnershipTransferRequest({
-    organization: organizationId,
+    organizationId: organizationId,
     code: selector.code,
   });
 
@@ -19,7 +19,7 @@ export const organizationTransferRequest: NonNullable<
 
   return {
     organization: await organizationManager.getOrganization({
-      organization: organizationId,
+      organizationId: organizationId,
     }),
   };
 };

--- a/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
@@ -115,7 +115,7 @@ export class SchemaPolicyProvider {
     }
 
     const results = await this.api.checkPolicy({
-      target: selector.target,
+      target: selector.targetId,
       policy: mergedPolicy,
       schema: completeSchema,
       source: modifiedSdl,
@@ -149,7 +149,7 @@ export class SchemaPolicyProvider {
     });
 
     return await this.storage.setSchemaPolicyForOrganization({
-      organizationId: selector.organization,
+      organizationId: selector.organizationId,
       policy,
       allowOverrides,
     });
@@ -162,7 +162,7 @@ export class SchemaPolicyProvider {
     });
 
     return await this.storage.setSchemaPolicyForProject({
-      projectId: selector.project,
+      projectId: selector.projectId,
       policy,
     });
   }
@@ -173,7 +173,7 @@ export class SchemaPolicyProvider {
       scope: OrganizationAccessScope.SETTINGS,
     });
 
-    return this.storage.getSchemaPolicyForOrganization(selector.organization);
+    return this.storage.getSchemaPolicyForOrganization(selector.organizationId);
   }
 
   async getOrganizationPolicyForProject(selector: ProjectSelector) {
@@ -182,7 +182,7 @@ export class SchemaPolicyProvider {
       scope: ProjectAccessScope.SETTINGS,
     });
 
-    return this.storage.getSchemaPolicyForOrganization(selector.organization);
+    return this.storage.getSchemaPolicyForOrganization(selector.organizationId);
   }
 
   async getProjectPolicy(selector: ProjectSelector) {
@@ -191,6 +191,6 @@ export class SchemaPolicyProvider {
       scope: ProjectAccessScope.SETTINGS,
     });
 
-    return this.storage.getSchemaPolicyForProject(selector.project);
+    return this.storage.getSchemaPolicyForProject(selector.projectId);
   }
 }

--- a/packages/services/api/src/modules/policy/resolvers/Mutation/updateSchemaPolicyForOrganization.ts
+++ b/packages/services/api/src/modules/policy/resolvers/Mutation/updateSchemaPolicyForOrganization.ts
@@ -15,12 +15,14 @@ export const updateSchemaPolicyForOrganization: NonNullable<
     await injector.get(SchemaPolicyApiProvider).validateConfig({ config });
     const updatedPolicy = await injector
       .get(SchemaPolicyProvider)
-      .setOrganizationPolicy({ organization }, config, allowOverrides);
+      .setOrganizationPolicy({ organizationId: organization }, config, allowOverrides);
 
     return {
       ok: {
         updatedPolicy,
-        organization: await injector.get(OrganizationManager).getOrganization({ organization }),
+        organization: await injector
+          .get(OrganizationManager)
+          .getOrganization({ organizationId: organization }),
       },
     };
   } catch (e) {

--- a/packages/services/api/src/modules/policy/resolvers/Mutation/updateSchemaPolicyForProject.ts
+++ b/packages/services/api/src/modules/policy/resolvers/Mutation/updateSchemaPolicyForProject.ts
@@ -17,9 +17,11 @@ export const updateSchemaPolicyForProject: NonNullable<
     ]);
     const organizationPolicy = await injector
       .get(SchemaPolicyProvider)
-      .getOrganizationPolicy({ organization: organization });
+      .getOrganizationPolicy({ organizationId: organization });
     const allowOverrides = organizationPolicy === null || organizationPolicy.allowOverrides;
-    const projectObject = await injector.get(ProjectManager).getProject({ organization, project });
+    const projectObject = await injector
+      .get(ProjectManager)
+      .getProject({ organizationId: organization, projectId: project });
 
     if (projectObject.legacyRegistryModel) {
       throw new Error(
@@ -37,12 +39,14 @@ export const updateSchemaPolicyForProject: NonNullable<
     await injector.get(SchemaPolicyApiProvider).validateConfig({ config });
     const updatedPolicy = await injector
       .get(SchemaPolicyProvider)
-      .setProjectPolicy({ organization, project }, config);
+      .setProjectPolicy({ organizationId: organization, projectId: project }, config);
 
     return {
       ok: {
         updatedPolicy,
-        project: await injector.get(ProjectManager).getProject({ organization, project }),
+        project: await injector
+          .get(ProjectManager)
+          .getProject({ organizationId: organization, projectId: project }),
       },
     };
   } catch (e) {

--- a/packages/services/api/src/modules/policy/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/policy/resolvers/Organization.ts
@@ -4,6 +4,6 @@ import type { OrganizationResolvers } from './../../../__generated__/types.next'
 export const Organization: Pick<OrganizationResolvers, 'schemaPolicy' | '__isTypeOf'> = {
   schemaPolicy: async (org, _, { injector }) =>
     injector.get(SchemaPolicyProvider).getOrganizationPolicy({
-      organization: org.id,
+      organizationId: org.id,
     }),
 };

--- a/packages/services/api/src/modules/policy/resolvers/Project.ts
+++ b/packages/services/api/src/modules/policy/resolvers/Project.ts
@@ -5,12 +5,12 @@ export const Project: Pick<ProjectResolvers, 'parentSchemaPolicy' | 'schemaPolic
   {
     schemaPolicy: async (project, _, { injector }) =>
       injector.get(SchemaPolicyProvider).getProjectPolicy({
-        project: project.id,
-        organization: project.orgId,
+        projectId: project.id,
+        organizationId: project.orgId,
       }),
     parentSchemaPolicy: async (project, _, { injector }) =>
       injector.get(SchemaPolicyProvider).getOrganizationPolicyForProject({
-        project: project.id,
-        organization: project.orgId,
+        projectId: project.id,
+        organizationId: project.orgId,
       }),
   };

--- a/packages/services/api/src/modules/policy/resolvers/Target.ts
+++ b/packages/services/api/src/modules/policy/resolvers/Target.ts
@@ -8,9 +8,9 @@ export const Target: Pick<TargetResolvers, 'schemaPolicy' | '__isTypeOf'> = {
     const { mergedPolicy, orgLevel, projectLevel } = await injector
       .get(SchemaPolicyProvider)
       .getCalculatedTargetPolicyForApi({
-        project: target.projectId,
-        organization: target.orgId,
-        target: target.id,
+        projectId: target.projectId,
+        organizationId: target.orgId,
+        targetId: target.id,
       });
 
     if (!mergedPolicy) {

--- a/packages/services/api/src/modules/project/module.graphql.ts
+++ b/packages/services/api/src/modules/project/module.graphql.ts
@@ -28,8 +28,8 @@ export default gql`
 
   input UpdateProjectSlugInput {
     slug: String!
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
   }
 
   type UpdateProjectSlugResult {
@@ -66,13 +66,13 @@ export default gql`
   }
 
   input ProjectSelectorInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
   }
 
   type ProjectSelector {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
   }
 
   enum ProjectType {
@@ -87,7 +87,7 @@ export default gql`
 
   type Project {
     id: ID!
-    slug: ID!
+    slug: String!
     cleanId: ID! @deprecated(reason: "Use the 'slug' field instead.")
     name: String! @deprecated(reason: "Use the 'slug' field instead.")
     type: ProjectType!
@@ -104,13 +104,13 @@ export default gql`
   input CreateProjectInput {
     slug: String!
     type: ProjectType!
-    organization: ID!
+    organizationSlug: String!
   }
 
   input UpdateProjectGitRepositoryInput {
     gitRepository: String
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
   }
 
   type UpdateProjectPayload {

--- a/packages/services/api/src/modules/project/providers/project-manager.ts
+++ b/packages/services/api/src/modules/project/providers/project-manager.ts
@@ -38,11 +38,11 @@ export class ProjectManager {
       type: ProjectType;
     } & OrganizationSelector,
   ) {
-    const { slug, type, organization } = input;
+    const { slug, type, organizationId: organization } = input;
     this.logger.info('Creating a project (input=%o)', input);
 
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organization,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.READ,
     });
 
@@ -57,20 +57,20 @@ export class ProjectManager {
     const result = await this.storage.createProject({
       slug,
       type,
-      organization,
+      organizationId: organization,
     });
 
     if (result.ok) {
       await Promise.all([
         this.storage.completeGetStartedStep({
-          organization,
+          organizationId: organization,
           step: 'creatingProject',
         }),
         this.activityManager.create({
           type: 'PROJECT_CREATED',
           selector: {
-            organization,
-            project: result.project.id,
+            organizationId: organization,
+            projectId: result.project.id,
           },
           meta: {
             projectType: type,
@@ -82,17 +82,20 @@ export class ProjectManager {
     return result;
   }
 
-  async deleteProject({ organization, project }: ProjectSelector): Promise<Project> {
+  async deleteProject({
+    organizationId: organization,
+    projectId: project,
+  }: ProjectSelector): Promise<Project> {
     this.logger.info('Deleting a project (project=%s, organization=%s)', project, organization);
     await this.authManager.ensureProjectAccess({
-      project,
-      organization,
+      projectId: project,
+      organizationId: organization,
       scope: ProjectAccessScope.DELETE,
     });
 
     const deletedProject = await this.storage.deleteProject({
-      project,
-      organization,
+      projectId: project,
+      organizationId: organization,
     });
 
     await this.tokenStorage.invalidateTokens(deletedProject.tokens);
@@ -100,7 +103,7 @@ export class ProjectManager {
     await this.activityManager.create({
       type: 'PROJECT_DELETED',
       selector: {
-        organization,
+        organizationId: organization,
       },
       meta: {
         name: deletedProject.name,
@@ -150,7 +153,7 @@ export class ProjectManager {
         message: string;
       }
   > {
-    const { slug, organization, project } = input;
+    const { slug, organizationId: organization, projectId: project } = input;
     this.logger.info('Updating a project slug (input=%o)', input);
     await this.authManager.ensureProjectAccess({
       ...input,
@@ -166,9 +169,9 @@ export class ProjectManager {
     }
 
     const result = await this.storage.updateProjectSlug({
-      organization,
-      project,
-      user: user.id,
+      organizationId: organization,
+      projectId: project,
+      userId: user.id,
       slug,
     });
 
@@ -176,8 +179,8 @@ export class ProjectManager {
       await this.activityManager.create({
         type: 'PROJECT_ID_UPDATED',
         selector: {
-          organization,
-          project,
+          organizationId: organization,
+          projectId: project,
         },
         meta: {
           value: slug,

--- a/packages/services/api/src/modules/project/resolvers/Mutation/createProject.ts
+++ b/packages/services/api/src/modules/project/resolvers/Mutation/createProject.ts
@@ -38,7 +38,7 @@ export const createProject: NonNullable<MutationResolvers['createProject']> = as
   const result = await injector.get(ProjectManager).createProject({
     slug: input.slug,
     type: input.type,
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   if (result.ok === false) {
@@ -53,7 +53,7 @@ export const createProject: NonNullable<MutationResolvers['createProject']> = as
   assertOk(result, 'Expected result to be ok');
 
   const organization = await injector.get(OrganizationManager).getOrganization({
-    organization: organizationId,
+    organizationId: organizationId,
   });
 
   const targetManager = injector.get(TargetManager);
@@ -61,18 +61,18 @@ export const createProject: NonNullable<MutationResolvers['createProject']> = as
   const targetResults = await Promise.all([
     targetManager.createTarget({
       slug: 'production',
-      project: result.project.id,
-      organization: organizationId,
+      projectId: result.project.id,
+      organizationId: organizationId,
     }),
     targetManager.createTarget({
       slug: 'staging',
-      project: result.project.id,
-      organization: organizationId,
+      projectId: result.project.id,
+      organizationId: organizationId,
     }),
     targetManager.createTarget({
       slug: 'development',
-      project: result.project.id,
-      organization: organizationId,
+      projectId: result.project.id,
+      organizationId: organizationId,
     }),
   ]);
 

--- a/packages/services/api/src/modules/project/resolvers/Mutation/createProject.ts
+++ b/packages/services/api/src/modules/project/resolvers/Mutation/createProject.ts
@@ -32,7 +32,7 @@ export const createProject: NonNullable<MutationResolvers['createProject']> = as
 
   const translator = injector.get(IdTranslator);
   const organizationId = await translator.translateOrganizationId({
-    organization: input.organization,
+    organizationSlug: input.organizationSlug,
   });
 
   const result = await injector.get(ProjectManager).createProject({

--- a/packages/services/api/src/modules/project/resolvers/Mutation/deleteProject.ts
+++ b/packages/services/api/src/modules/project/resolvers/Mutation/deleteProject.ts
@@ -18,8 +18,8 @@ export const deleteProject: NonNullable<MutationResolvers['deleteProject']> = as
     }),
   ]);
   const deletedProject = await injector.get(ProjectManager).deleteProject({
-    organization: organizationId,
-    project: projectId,
+    organizationId: organizationId,
+    projectId: projectId,
   });
   return {
     selector: {

--- a/packages/services/api/src/modules/project/resolvers/Mutation/deleteProject.ts
+++ b/packages/services/api/src/modules/project/resolvers/Mutation/deleteProject.ts
@@ -10,11 +10,11 @@ export const deleteProject: NonNullable<MutationResolvers['deleteProject']> = as
   const translator = injector.get(IdTranslator);
   const [organizationId, projectId] = await Promise.all([
     translator.translateOrganizationId({
-      organization: selector.organization,
+      organizationSlug: selector.organizationSlug,
     }),
     translator.translateProjectId({
-      organization: selector.organization,
-      project: selector.project,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
     }),
   ]);
   const deletedProject = await injector.get(ProjectManager).deleteProject({
@@ -23,8 +23,8 @@ export const deleteProject: NonNullable<MutationResolvers['deleteProject']> = as
   });
   return {
     selector: {
-      organization: organizationId,
-      project: projectId,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
     },
     deletedProject,
   };

--- a/packages/services/api/src/modules/project/resolvers/Mutation/updateProjectSlug.ts
+++ b/packages/services/api/src/modules/project/resolvers/Mutation/updateProjectSlug.ts
@@ -32,8 +32,8 @@ export const updateProjectSlug: NonNullable<MutationResolvers['updateProjectSlug
 
   const result = await injector.get(ProjectManager).updateSlug({
     slug: input.slug,
-    organization: organizationId,
-    project: projectId,
+    organizationId: organizationId,
+    projectId: projectId,
   });
 
   if (result.ok) {

--- a/packages/services/api/src/modules/project/resolvers/Mutation/updateProjectSlug.ts
+++ b/packages/services/api/src/modules/project/resolvers/Mutation/updateProjectSlug.ts
@@ -40,8 +40,8 @@ export const updateProjectSlug: NonNullable<MutationResolvers['updateProjectSlug
     return {
       ok: {
         selector: {
-          organization: input.organization,
-          project: result.project.slug,
+          organizationSlug: input.organizationSlug,
+          projectSlug: result.project.slug,
         },
         project: result.project,
       },

--- a/packages/services/api/src/modules/project/resolvers/Organization.ts
+++ b/packages/services/api/src/modules/project/resolvers/Organization.ts
@@ -3,6 +3,6 @@ import type { OrganizationResolvers } from './../../../__generated__/types.next'
 
 export const Organization: Pick<OrganizationResolvers, 'projects' | '__isTypeOf'> = {
   projects: (organization, _, { injector }) => {
-    return injector.get(ProjectManager).getProjects({ organization: organization.id });
+    return injector.get(ProjectManager).getProjects({ organizationId: organization.id });
   },
 };

--- a/packages/services/api/src/modules/project/resolvers/Project.ts
+++ b/packages/services/api/src/modules/project/resolvers/Project.ts
@@ -24,7 +24,7 @@ export const Project: Pick<
     }
 
     const organization = await injector.get(OrganizationManager).getOrganization({
-      organization: project.orgId,
+      organizationId: project.orgId,
     });
 
     return organization.featureFlags.forceLegacyCompositionInTargets.length > 0;

--- a/packages/services/api/src/modules/project/resolvers/Query/project.ts
+++ b/packages/services/api/src/modules/project/resolvers/Query/project.ts
@@ -13,7 +13,7 @@ export const project: NonNullable<QueryResolvers['project']> = async (
     translator.translateProjectId(selector),
   ]);
   return injector.get(ProjectManager).getProject({
-    project,
-    organization,
+    projectId: project,
+    organizationId: organization,
   });
 };

--- a/packages/services/api/src/modules/project/resolvers/Query/projects.ts
+++ b/packages/services/api/src/modules/project/resolvers/Query/projects.ts
@@ -8,5 +8,5 @@ export const projects: NonNullable<QueryResolvers['projects']> = async (
   { injector },
 ) => {
   const organization = await injector.get(IdTranslator).translateOrganizationId(selector);
-  return injector.get(ProjectManager).getProjects({ organization });
+  return injector.get(ProjectManager).getProjects({ organizationId: organization });
 };

--- a/packages/services/api/src/modules/schema/module.graphql.mappers.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.mappers.ts
@@ -27,9 +27,9 @@ export type SchemaVersionConnectionMapper = Readonly<{
   edges: ReadonlyArray<{
     cursor: string;
     node: SchemaVersion & {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
   }>;
   pageInfo: Readonly<{
@@ -40,9 +40,9 @@ export type SchemaVersionConnectionMapper = Readonly<{
   }>;
 }>;
 export interface SchemaVersionMapper extends SchemaVersion {
-  project: string;
-  target: string;
-  organization: string;
+  projectId: string;
+  targetId: string;
+  organizationId: string;
 }
 export type SingleSchemaMapper = SingleSchema;
 export type CompositeSchemaMapper = PushedCompositeSchema;
@@ -51,9 +51,9 @@ export type SchemaExplorerMapper = {
   schema: GraphQLSchema;
   usage: {
     period: DateRange;
-    organization: string;
-    project: string;
-    target: string;
+    organizationId: string;
+    projectId: string;
+    targetId: string;
   };
   supergraph: null | SuperGraphInformation;
 };
@@ -61,9 +61,9 @@ export type UnusedSchemaExplorerMapper = {
   sdl: DocumentNode;
   usage: {
     period: DateRange;
-    organization: string;
-    project: string;
-    target: string;
+    organizationId: string;
+    projectId: string;
+    targetId: string;
     usedCoordinates: Set<string>;
   };
   supergraph: null | SuperGraphInformation;
@@ -72,9 +72,9 @@ export type DeprecatedSchemaExplorerMapper = {
   sdl: DocumentNode;
   usage: {
     period: DateRange;
-    organization: string;
-    project: string;
-    target: string;
+    organizationId: string;
+    projectId: string;
+    targetId: string;
   };
   supergraph: null | SuperGraphInformation;
 };
@@ -99,9 +99,9 @@ export type SchemaCoordinateUsageForUnusedExplorer = {
   isUsed: false;
   usedCoordinates: Set<string>;
   period: DateRange;
-  organization: string;
-  project: string;
-  target: string;
+  organizationId: string;
+  projectId: string;
+  targetId: string;
 };
 export type WithSchemaCoordinatesUsage<T> = T & {
   usage: // explorer
@@ -111,9 +111,9 @@ export type WithSchemaCoordinatesUsage<T> = T & {
           total: number;
           usedByClients: () => PromiseOrValue<Array<string>>;
           period: DateRange;
-          organization: string;
-          project: string;
-          target: string;
+          organizationId: string;
+          projectId: string;
+          targetId: string;
           typename: string;
         };
       }>
@@ -255,9 +255,9 @@ export type SchemaCoordinateUsageMapper =
       total: number;
       usedByClients: () => PromiseOrValue<Array<string>>;
       period: DateRange;
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
       coordinate: string;
     }
   | {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -67,8 +67,8 @@ export default gql`
   }
 
   input UpdateNativeFederationInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
     enabled: Boolean!
   }
 
@@ -85,8 +85,8 @@ export default gql`
   }
 
   input DisableExternalSchemaCompositionInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
   }
 
   """
@@ -98,8 +98,8 @@ export default gql`
   }
 
   input EnableExternalSchemaCompositionInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
     endpoint: String!
     secret: String!
   }
@@ -117,8 +117,8 @@ export default gql`
   }
 
   input TestExternalSchemaCompositionInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
   }
 
   """
@@ -134,8 +134,8 @@ export default gql`
   }
 
   input UpdateProjectRegistryModelInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
     model: RegistryModel!
   }
 
@@ -654,25 +654,25 @@ export default gql`
   }
 
   input SchemaCompareInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     after: ID!
     before: ID!
   }
 
   input SchemaVersionUpdateInput {
-    organization: ID!
-    project: ID!
-    target: ID!
-    version: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
+    versionId: ID!
     valid: Boolean!
   }
 
   input UpdateBaseSchemaInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     newBase: String
   }
 
@@ -1317,9 +1317,9 @@ export default gql`
   }
 
   input ApproveFailedSchemaCheckInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     schemaCheckId: ID!
     """
     Optional comment visible in the schema check.

--- a/packages/services/api/src/modules/schema/providers/contracts-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/contracts-manager.ts
@@ -52,9 +52,9 @@ export class ContractsManager {
     ]);
 
     await this.authManager.ensureTargetAccess({
-      organization: organizationId,
-      project: projectId,
-      target: targetId,
+      organizationId: organizationId,
+      projectId: projectId,
+      targetId: targetId,
       scope: TargetAccessScope.SETTINGS,
     });
 
@@ -87,9 +87,9 @@ export class ContractsManager {
     ]);
 
     await this.authManager.ensureTargetAccess({
-      organization: organizationId,
-      project: projectId,
-      target: targetId,
+      organizationId: organizationId,
+      projectId: projectId,
+      targetId: targetId,
       scope: TargetAccessScope.SETTINGS,
     });
 
@@ -118,9 +118,9 @@ export class ContractsManager {
 
     return await this.authManager
       .ensureTargetAccess({
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationId: organizationId,
+        projectId: projectId,
+        targetId: targetId,
         scope: TargetAccessScope.SETTINGS,
       })
       .then(() => true)
@@ -133,9 +133,9 @@ export class ContractsManager {
     first: number | null;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.target.orgId,
-      project: args.target.projectId,
-      target: args.target.id,
+      organizationId: args.target.orgId,
+      projectId: args.target.projectId,
+      targetId: args.target.id,
       scope: TargetAccessScope.SETTINGS,
     });
 
@@ -153,9 +153,9 @@ export class ContractsManager {
     first: number | null;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.target.orgId,
-      project: args.target.projectId,
-      target: args.target.id,
+      organizationId: args.target.orgId,
+      projectId: args.target.projectId,
+      targetId: args.target.id,
       scope: TargetAccessScope.READ,
     });
 

--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -49,9 +49,9 @@ export class CompositeLegacyModel {
       serviceName: string;
     };
     selector: {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
     latest: {
       isComposable: boolean;
@@ -68,7 +68,7 @@ export class CompositeLegacyModel {
       id: temp,
       author: temp,
       commit: temp,
-      target: selector.target,
+      target: selector.targetId,
       date: Date.now(),
       sdl: input.sdl,
       service_name: input.serviceName,
@@ -104,7 +104,7 @@ export class CompositeLegacyModel {
 
     const compositionCheck = await this.checks.composition({
       orchestrator,
-      targetId: selector.target,
+      targetId: selector.targetId,
       project,
       organization,
       schemas,
@@ -117,7 +117,7 @@ export class CompositeLegacyModel {
       version: latest,
       organization,
       project,
-      targetId: selector.target,
+      targetId: selector.targetId,
     });
 
     const diffCheck = await this.checks.diff({

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -88,9 +88,9 @@ export class CompositeModel {
 
   @traceFn('Composite modern: check', {
     initAttributes: args => ({
-      'hive.project.id': args.selector.project,
-      'hive.target.id': args.selector.target,
-      'hive.organization.id': args.selector.organization,
+      'hive.project.id': args.selector.projectId,
+      'hive.target.id': args.selector.targetId,
+      'hive.organization.id': args.selector.organizationId,
     }),
   })
   async check({
@@ -110,9 +110,9 @@ export class CompositeModel {
       serviceName: string;
     };
     selector: {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
     latest: {
       isComposable: boolean;
@@ -141,7 +141,7 @@ export class CompositeModel {
       id: temp,
       author: temp,
       commit: temp,
-      target: selector.target,
+      target: selector.targetId,
       date: Date.now(),
       sdl: input.sdl,
       service_name: input.serviceName,
@@ -156,7 +156,7 @@ export class CompositeModel {
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
 
     const compareToPreviousComposableVersion = shouldUseLatestComposableVersion(
-      selector.target,
+      selector.targetId,
       project,
       organization,
     );
@@ -190,7 +190,7 @@ export class CompositeModel {
 
     const compositionCheck = await this.checks.composition({
       orchestrator,
-      targetId: selector.target,
+      targetId: selector.targetId,
       project,
       organization,
       schemas,
@@ -212,7 +212,7 @@ export class CompositeModel {
       version: comparedVersion,
       organization,
       project,
-      targetId: selector.target,
+      targetId: selector.targetId,
     });
 
     const contractChecks = await this.getContractChecks({

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -39,9 +39,9 @@ export class SingleLegacyModel {
       sdl: string;
     };
     selector: {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
     latest: {
       isComposable: boolean;
@@ -58,7 +58,7 @@ export class SingleLegacyModel {
       id: temp,
       author: temp,
       commit: temp,
-      target: selector.target,
+      target: selector.targetId,
       date: Date.now(),
       sdl: input.sdl,
       metadata: null,
@@ -89,7 +89,7 @@ export class SingleLegacyModel {
 
     const compositionCheck = await this.checks.composition({
       orchestrator: this.orchestrator,
-      targetId: selector.target,
+      targetId: selector.targetId,
       project,
       organization,
       schemas,
@@ -102,7 +102,7 @@ export class SingleLegacyModel {
       version: latestVersion,
       organization,
       project,
-      targetId: selector.target,
+      targetId: selector.targetId,
     });
 
     const diffCheck = await this.checks.diff({

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -29,9 +29,9 @@ export class SingleModel {
 
   @traceFn('Single modern: check', {
     initAttributes: args => ({
-      'hive.project.id': args.selector.project,
-      'hive.target.id': args.selector.target,
-      'hive.organization.id': args.selector.organization,
+      'hive.project.id': args.selector.projectId,
+      'hive.target.id': args.selector.targetId,
+      'hive.organization.id': args.selector.organizationId,
     }),
   })
   async check({
@@ -49,9 +49,9 @@ export class SingleModel {
       sdl: string;
     };
     selector: {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
     latest: {
       isComposable: boolean;
@@ -74,7 +74,7 @@ export class SingleModel {
       id: temp,
       author: temp,
       commit: temp,
-      target: selector.target,
+      target: selector.targetId,
       date: Date.now(),
       sdl: input.sdl,
       metadata: null,
@@ -107,7 +107,7 @@ export class SingleModel {
 
     const compositionCheck = await this.checks.composition({
       orchestrator: this.orchestrator,
-      targetId: selector.target,
+      targetId: selector.targetId,
       project,
       organization,
       schemas,
@@ -120,7 +120,7 @@ export class SingleModel {
       version: comparedVersion,
       organization,
       project,
-      targetId: selector.target,
+      targetId: selector.targetId,
     });
 
     const [diffCheck, policyCheck] = await Promise.all([

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -362,9 +362,9 @@ export class RegistryChecks {
     modifiedSdl: string;
     incomingSdl: string | null;
     selector: {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
   }) {
     if (incomingSdl == null) {

--- a/packages/services/api/src/modules/schema/providers/schema-check-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-check-manager.ts
@@ -56,10 +56,10 @@ export class SchemaCheckManager {
       return null;
     }
     return this.schemaManager.getSchemaVersion({
-      organization: schemaCheck.selector.organizationId,
-      project: schemaCheck.selector.projectId,
-      target: schemaCheck.targetId,
-      version: schemaCheck.schemaVersionId,
+      organizationId: schemaCheck.selector.organizationId,
+      projectId: schemaCheck.selector.projectId,
+      targetId: schemaCheck.targetId,
+      versionId: schemaCheck.schemaVersionId,
     });
   }
 

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -116,16 +116,16 @@ export class SchemaManager {
 
     const [organization, project, latestSchemas] = await Promise.all([
       this.organizationManager.getOrganization({
-        organization: input.organization,
+        organizationId: input.organizationId,
       }),
       this.projectManager.getProject({
-        organization: input.organization,
-        project: input.project,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
       }),
       this.getLatestSchemas({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
         onlyComposable: input.onlyComposable,
       }),
     ]);
@@ -163,7 +163,7 @@ export class SchemaManager {
       native: this.checkProjectNativeFederationSupport({
         project,
         organization,
-        targetId: input.target,
+        targetId: input.targetId,
       }),
       contracts: null,
     });
@@ -188,7 +188,7 @@ export class SchemaManager {
   @atomic(stringifySelector)
   async getSchemasOfVersion(
     selector: {
-      version: string;
+      versionId: string;
       includeMetadata?: boolean;
     } & TargetSelector,
   ) {
@@ -209,7 +209,7 @@ export class SchemaManager {
   @atomic(stringifySelector)
   async getMaybeSchemasOfVersion(
     selector: {
-      version: string;
+      versionId: string;
       includeMetadata?: boolean;
     } & TargetSelector,
   ) {
@@ -223,7 +223,7 @@ export class SchemaManager {
 
   async getSchemasOfPreviousVersion(
     selector: {
-      version: string;
+      versionId: string;
       onlyComposable: boolean;
     } & TargetSelector,
   ) {
@@ -272,9 +272,9 @@ export class SchemaManager {
 
     return {
       ...version,
-      project: selector.project,
-      target: selector.target,
-      organization: selector.organization,
+      projectId: selector.projectId,
+      targetId: selector.targetId,
+      organizationId: selector.organizationId,
     };
   }
 
@@ -286,9 +286,9 @@ export class SchemaManager {
     });
     return {
       ...(await this.storage.getLatestValidVersion(selector)),
-      project: selector.project,
-      target: selector.target,
-      organization: selector.organization,
+      projectId: selector.projectId,
+      targetId: selector.targetId,
+      organizationId: selector.organizationId,
     };
   }
 
@@ -300,9 +300,9 @@ export class SchemaManager {
     });
     return {
       ...(await this.storage.getLatestVersion(selector)),
-      project: selector.project,
-      target: selector.target,
-      organization: selector.organization,
+      projectId: selector.projectId,
+      targetId: selector.targetId,
+      organizationId: selector.organizationId,
     };
   }
 
@@ -321,13 +321,13 @@ export class SchemaManager {
 
     return {
       ...latest,
-      project: selector.project,
-      target: selector.target,
-      organization: selector.organization,
+      projectId: selector.projectId,
+      targetId: selector.targetId,
+      organizationId: selector.organizationId,
     };
   }
 
-  async getSchemaVersion(selector: TargetSelector & { version: string }) {
+  async getSchemaVersion(selector: TargetSelector & { versionId: string }) {
     this.logger.debug('Fetching single schema version (selector=%o)', selector);
     await this.authManager.ensureTargetAccess({
       ...selector,
@@ -336,9 +336,9 @@ export class SchemaManager {
     const result = await this.storage.getVersion(selector);
 
     return {
-      project: selector.project,
-      target: selector.target,
-      organization: selector.organization,
+      projectId: selector.projectId,
+      targetId: selector.targetId,
+      organizationId: selector.organizationId,
       ...result,
     };
   }
@@ -368,16 +368,16 @@ export class SchemaManager {
         ...edge,
         node: {
           ...edge.node,
-          organization: args.organizationId,
-          project: args.projectId,
-          target: args.targetId,
+          organizationId: args.organizationId,
+          projectId: args.projectId,
+          targetId: args.targetId,
         },
       })),
     };
   }
 
   async updateSchemaVersionStatus(
-    input: TargetSelector & { version: string; valid: boolean },
+    input: TargetSelector & { versionId: string; valid: boolean },
   ): Promise<SchemaVersion> {
     this.logger.debug('Updating schema version status (input=%o)', input);
     await this.authManager.ensureTargetAccess({
@@ -386,16 +386,16 @@ export class SchemaManager {
     });
 
     const project = await this.storage.getProject({
-      organization: input.organization,
-      project: input.project,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
     });
 
     if (project.legacyRegistryModel) {
       return {
         ...(await this.storage.updateVersionStatus(input)),
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       };
     }
 
@@ -410,7 +410,7 @@ export class SchemaManager {
     });
     return this.storage.getSchemaLog({
       commit: selector.commit,
-      target: selector.target,
+      targetId: selector.targetId,
     });
   }
 
@@ -478,9 +478,9 @@ export class SchemaManager {
     );
 
     await this.authManager.ensureTargetAccess({
-      project: input.project,
-      organization: input.organization,
-      target: input.target,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      targetId: input.targetId,
       scope: TargetAccessScope.REGISTRY_WRITE,
     });
 
@@ -492,18 +492,18 @@ export class SchemaManager {
 
   async testExternalSchemaComposition(selector: { projectId: string; organizationId: string }) {
     await this.authManager.ensureProjectAccess({
-      project: selector.projectId,
-      organization: selector.organizationId,
+      projectId: selector.projectId,
+      organizationId: selector.organizationId,
       scope: ProjectAccessScope.SETTINGS,
     });
 
     const [project, organization] = await Promise.all([
       this.storage.getProject({
-        organization: selector.organizationId,
-        project: selector.projectId,
+        organizationId: selector.organizationId,
+        projectId: selector.projectId,
       }),
       this.storage.getOrganization({
-        organization: selector.organizationId,
+        organizationId: selector.organizationId,
       }),
     ]);
 
@@ -638,8 +638,8 @@ export class SchemaManager {
 
     return {
       ok: await this.projectManager.getProject({
-        organization: input.organization,
-        project: input.project,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
       }),
     };
   }
@@ -676,16 +676,16 @@ export class SchemaManager {
     const encryptedSecret = this.crypto.encrypt(input.secret);
 
     await this.storage.enableExternalSchemaComposition({
-      project: input.project,
-      organization: input.organization,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
       endpoint: input.endpoint.trim(),
       encryptedSecret,
     });
 
     return {
       ok: await this.projectManager.getProject({
-        organization: input.organization,
-        project: input.project,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
       }),
     };
   }
@@ -702,8 +702,8 @@ export class SchemaManager {
     });
 
     const project = await this.projectManager.getProject({
-      organization: input.organization,
-      project: input.project,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
     });
 
     if (project.type !== ProjectType.FEDERATION) {
@@ -711,8 +711,8 @@ export class SchemaManager {
     }
 
     return this.storage.updateNativeSchemaComposition({
-      project: input.project,
-      organization: input.organization,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
       enabled: input.enabled,
     });
   }
@@ -741,9 +741,9 @@ export class SchemaManager {
     filters: SchemaChecksFilter | null;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -766,9 +766,9 @@ export class SchemaManager {
   }) {
     this.logger.debug('Find schema check (args=%o)', args);
     await this.authManager.ensureTargetAccess({
-      target: args.targetId,
-      project: args.projectId,
-      organization: args.organizationId,
+      targetId: args.targetId,
+      projectId: args.projectId,
+      organizationId: args.organizationId,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -894,8 +894,8 @@ export class SchemaManager {
     const user = await this.authManager.getCurrentUser();
 
     const scopes = await this.authManager.getMemberTargetScopes({
-      user: user.id,
-      organization: schemaCheck.selector.organizationId,
+      userId: user.id,
+      organizationId: schemaCheck.selector.organizationId,
     });
 
     if (scopes.includes(TargetAccessScope.REGISTRY_WRITE)) {
@@ -919,9 +919,9 @@ export class SchemaManager {
     this.logger.debug('Manually approve failed schema check (args=%o)', args);
 
     await this.authManager.ensureTargetAccess({
-      target: args.targetId,
-      project: args.projectId,
-      organization: args.organizationId,
+      targetId: args.targetId,
+      projectId: args.projectId,
+      organizationId: args.organizationId,
       scope: TargetAccessScope.REGISTRY_WRITE,
     });
 
@@ -959,8 +959,8 @@ export class SchemaManager {
     if (schemaCheck.githubCheckRunId) {
       this.logger.debug('Attempt updating GitHub schema check. (args=%o).', args);
       const project = await this.projectManager.getProject({
-        organization: args.organizationId,
-        project: args.projectId,
+        organizationId: args.organizationId,
+        projectId: args.projectId,
       });
       const gitRepository = schemaCheck.githubRepository ?? project.gitRepository;
       if (!gitRepository) {
@@ -1035,9 +1035,9 @@ export class SchemaManager {
     });
 
     await this.authManager.ensureTargetAccess({
-      organization: organization.id,
-      project: target.projectId,
-      target: target.id,
+      organizationId: organization.id,
+      projectId: target.projectId,
+      targetId: target.id,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -1053,9 +1053,9 @@ export class SchemaManager {
 
     return {
       ...record,
-      project: target.projectId,
-      target: target.id,
-      organization: organization.id,
+      projectId: target.projectId,
+      targetId: target.id,
+      organizationId: organization.id,
     };
   }
 
@@ -1070,16 +1070,16 @@ export class SchemaManager {
 
     const [organization, project] = await Promise.all([
       this.organizationManager.getOrganization({
-        organization: args.organization,
+        organizationId: args.organization,
       }),
       this.projectManager.getProject({
-        organization: args.organization,
-        project: args.project,
+        organizationId: args.organization,
+        projectId: args.project,
       }),
     ]);
 
     const schemaVersion = await this.storage.getVersionBeforeVersionId({
-      target: args.target,
+      targetId: args.target,
       beforeVersionId: args.beforeVersionId,
       beforeVersionCreatedAt: args.beforeVersionCreatedAt,
       onlyComposable: shouldUseLatestComposableVersion(args.target, project, organization),
@@ -1091,9 +1091,9 @@ export class SchemaManager {
 
     return {
       ...schemaVersion,
-      organization: args.organization,
-      project: args.project,
-      target: args.target,
+      organizationId: args.organization,
+      projectId: args.project,
+      targetId: args.target,
     };
   }
 
@@ -1105,7 +1105,7 @@ export class SchemaManager {
     beforeVersionCreatedAt: string;
   }) {
     const schemaVersion = await this.storage.getVersionBeforeVersionId({
-      target: args.target,
+      targetId: args.target,
       beforeVersionId: args.beforeVersionId,
       beforeVersionCreatedAt: args.beforeVersionCreatedAt,
       onlyComposable: true,
@@ -1117,9 +1117,9 @@ export class SchemaManager {
 
     return {
       ...schemaVersion,
-      organization: args.organization,
-      project: args.project,
-      target: args.target,
+      organizationId: args.organization,
+      projectId: args.project,
+      targetId: args.target,
     };
   }
 
@@ -1174,16 +1174,16 @@ export class SchemaManager {
     }
 
     const targets = await this.targetManager.getTargets({
-      organization: project.orgId,
-      project: project.id,
+      organizationId: project.orgId,
+      projectId: project.id,
     });
 
     const possibleVersions = await Promise.all(
       targets.map(t =>
         this.getMaybeLatestValidVersion({
-          organization: project.orgId,
-          project: project.id,
-          target: t.id,
+          organizationId: project.orgId,
+          projectId: project.id,
+          targetId: t.id,
         }),
       ),
     );
@@ -1206,10 +1206,10 @@ export class SchemaManager {
     const schemasPerVersion = await Promise.all(
       versions.map(async version =>
         this.getSchemasOfVersion({
-          organization: version.organization,
-          project: version.project,
-          target: version.target,
-          version: version.id,
+          organizationId: version.organizationId,
+          projectId: version.projectId,
+          targetId: version.targetId,
+          versionId: version.id,
         }),
       ),
     );
@@ -1304,15 +1304,15 @@ export class SchemaManager {
 
     const log = await this.getSchemaLog({
       commit: schemaVersion.actionId,
-      organization: schemaVersion.organization,
-      project: schemaVersion.project,
-      target: schemaVersion.target,
+      organizationId: schemaVersion.organizationId,
+      projectId: schemaVersion.projectId,
+      targetId: schemaVersion.targetId,
     });
 
     if ('commit' in log && log.commit) {
       const project = await this.storage.getProject({
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
+        organizationId: schemaVersion.organizationId,
+        projectId: schemaVersion.projectId,
       });
 
       if (project.gitRepository) {

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -810,13 +810,13 @@ export class SchemaManager {
 
     return this.schemaModuleConfig.schemaCheckLink({
       organization: {
-        slug: breadcrumb.organization,
+        slug: breadcrumb.organizationSlug,
       },
       project: {
-        slug: breadcrumb.project,
+        slug: breadcrumb.projectSlug,
       },
       target: {
-        slug: breadcrumb.target,
+        slug: breadcrumb.targetSlug,
       },
       schemaCheckId: args.schemaCheckId,
     });

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -82,8 +82,8 @@ const schemaDeleteCount = new promClient.Counter({
 export type CheckInput = Omit<Types.SchemaCheckInput, 'project' | 'organization' | 'target'> &
   TargetSelector;
 
-export type DeleteInput = Omit<Types.SchemaDeleteInput, 'project' | 'organization' | 'target'> &
-  Omit<TargetSelector, 'target'> & {
+export type DeleteInput = Types.SchemaDeleteInput &
+  Omit<TargetSelector, 'targetId'> & {
     checksum: string;
     target: Target;
   };
@@ -185,9 +185,9 @@ export class SchemaPublisher {
     selector,
   }: {
     selector: {
-      organization: string;
-      project: string;
-      target: string;
+      organizationId: string;
+      projectId: string;
+      targetId: string;
     };
   }): Promise<ConditionalBreakingChangeConfiguration | null> {
     try {
@@ -277,9 +277,9 @@ export class SchemaPublisher {
 
   @traceFn('SchemaPublisher.check', {
     initAttributes: input => ({
-      'hive.target.id': input.target,
-      'hive.organization.id': input.organization,
-      'hive.project.id': input.project,
+      'hive.target.id': input.targetId,
+      'hive.organization.id': input.organizationId,
+      'hive.project.id': input.projectId,
     }),
     resultAttributes: result => ({
       'hive.check.result': result.__typename,
@@ -289,9 +289,9 @@ export class SchemaPublisher {
     this.logger.info('Checking schema (input=%o)', lodash.omit(input, ['sdl']));
 
     await this.authManager.ensureTargetAccess({
-      target: input.target,
-      project: input.project,
-      organization: input.organization,
+      targetId: input.targetId,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
@@ -305,37 +305,37 @@ export class SchemaPublisher {
       latestComposableSchemaVersion,
     ] = await Promise.all([
       this.targetManager.getTarget({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
       this.projectManager.getProject({
-        organization: input.organization,
-        project: input.project,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
       }),
       this.organizationManager.getOrganization({
-        organization: input.organization,
+        organizationId: input.organizationId,
       }),
       this.schemaManager.getLatestSchemas({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
       this.schemaManager.getLatestSchemas({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
         onlyComposable: true,
       }),
       this.schemaManager.getMaybeLatestVersion({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
       this.schemaManager.getMaybeLatestValidVersion({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
     ]);
 
@@ -459,20 +459,20 @@ export class SchemaPublisher {
     }
 
     await this.schemaManager.completeGetStartedCheck({
-      organization: project.orgId,
+      organizationId: project.orgId,
       step: 'checkingSchema',
     });
 
     const baseSchema = await this.schemaManager.getBaseSchema({
-      organization: input.organization,
-      project: input.project,
-      target: input.target,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      targetId: input.targetId,
     });
 
     const selector = {
-      organization: input.organization,
-      project: input.project,
-      target: input.target,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      targetId: input.targetId,
     };
 
     const sdl = tryPrettifySDL(input.sdl);
@@ -616,7 +616,7 @@ export class SchemaPublisher {
         serviceName: input.service ?? null,
         meta: input.meta ?? null,
         targetId: target.id,
-        schemaVersionId: latestVersion?.version ?? null,
+        schemaVersionId: latestVersion?.versionId ?? null,
         isSuccess: false,
         breakingSchemaChanges: checkResult.state.schemaChanges?.breaking ?? null,
         safeSchemaChanges: checkResult.state.schemaChanges?.safe ?? null,
@@ -668,7 +668,7 @@ export class SchemaPublisher {
         serviceName: input.service ?? null,
         meta: input.meta ?? null,
         targetId: target.id,
-        schemaVersionId: latestVersion?.version ?? null,
+        schemaVersionId: latestVersion?.versionId ?? null,
         isSuccess: true,
         breakingSchemaChanges: checkResult.state?.schemaChanges?.breaking ?? null,
         safeSchemaChanges: checkResult.state?.schemaChanges?.safe ?? null,
@@ -996,9 +996,9 @@ export class SchemaPublisher {
 
   @traceFn('SchemaPublisher.publish', {
     initAttributes: (input, _) => ({
-      'hive.target.id': input.target,
-      'hive.organization.id': input.organization,
-      'hive.project.id': input.project,
+      'hive.target.id': input.targetId,
+      'hive.organization.id': input.organizationId,
+      'hive.project.id': input.projectId,
     }),
     resultAttributes: result => ({
       'hive.publish.result': result.__typename,
@@ -1007,25 +1007,25 @@ export class SchemaPublisher {
   async publish(input: PublishInput, signal: AbortSignal): Promise<PublishResult> {
     this.logger.debug(
       'Schema publication (organization=%s, project=%s, target=%s)',
-      input.organization,
-      input.project,
-      input.target,
+      input.organizationId,
+      input.projectId,
+      input.targetId,
     );
 
     this.logger.debug(
       'Compute hash (organization=%s, project=%s, target=%s)',
-      input.organization,
-      input.project,
-      input.target,
+      input.organizationId,
+      input.projectId,
+      input.targetId,
     );
 
     const token = this.authManager.ensureApiToken();
     const [contracts, latestVersion] = await Promise.all([
-      this.contracts.getActiveContractsByTargetId({ targetId: input.target }),
+      this.contracts.getActiveContractsByTargetId({ targetId: input.targetId }),
       this.schemaManager.getMaybeLatestVersion({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
     ]);
 
@@ -1033,9 +1033,9 @@ export class SchemaPublisher {
       .update(
         stringify({
           ...input,
-          organization: input.organization,
-          project: input.project,
-          target: input.target,
+          organization: input.organizationId,
+          project: input.projectId,
+          target: input.targetId,
           service: input.service?.toLowerCase(),
           contracts: contracts?.map(contract => ({
             contractId: contract.id,
@@ -1052,14 +1052,14 @@ export class SchemaPublisher {
 
     this.logger.debug(
       'Hash computation finished (organization=%s, project=%s, target=%s, hash=%s)',
-      input.organization,
-      input.project,
-      input.target,
+      input.organizationId,
+      input.projectId,
+      input.targetId,
     );
 
     return this.mutex
       .perform(
-        registryLockId(input.target),
+        registryLockId(input.targetId),
         {
           /**
            * The global request timeout is 60 seconds.
@@ -1075,9 +1075,9 @@ export class SchemaPublisher {
         },
         async () => {
           await this.authManager.ensureTargetAccess({
-            target: input.target,
-            project: input.project,
-            organization: input.organization,
+            targetId: input.targetId,
+            projectId: input.projectId,
+            organizationId: input.organizationId,
             scope: TargetAccessScope.REGISTRY_WRITE,
           });
           return this.distributedCache.wrap({
@@ -1103,7 +1103,7 @@ export class SchemaPublisher {
       });
   }
 
-  public async updateVersionStatus(input: TargetSelector & { version: string; valid: boolean }) {
+  public async updateVersionStatus(input: TargetSelector & { versionId: string; valid: boolean }) {
     const updateResult = await this.schemaManager.updateSchemaVersionStatus(input);
 
     if (updateResult.isComposable === true) {
@@ -1119,22 +1119,22 @@ export class SchemaPublisher {
         this.logger.info('Version is now promoted to latest valid (version=%s)', latestVersion.id);
         const [organization, project, target, schemas] = await Promise.all([
           this.organizationManager.getOrganization({
-            organization: input.organization,
+            organizationId: input.organizationId,
           }),
           this.projectManager.getProject({
-            organization: input.organization,
-            project: input.project,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
           }),
           this.targetManager.getTarget({
-            organization: input.organization,
-            project: input.project,
-            target: input.target,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.targetId,
           }),
           this.schemaManager.getSchemasOfVersion({
-            organization: input.organization,
-            project: input.project,
-            target: input.target,
-            version: latestVersion.id,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.targetId,
+            versionId: latestVersion.id,
             includeMetadata: true,
           }),
         ]);
@@ -1173,8 +1173,8 @@ export class SchemaPublisher {
   @traceFn('SchemaPublisher.delete', {
     initAttributes: (input, _) => ({
       'hive.target.id': input.target.id,
-      'hive.organization.id': input.organization,
-      'hive.project.id': input.project,
+      'hive.organization.id': input.organizationId,
+      'hive.project.id': input.projectId,
     }),
     resultAttributes: result => ({
       'hive.delete.result': result.__typename,
@@ -1190,9 +1190,9 @@ export class SchemaPublisher {
       },
       async () => {
         await this.authManager.ensureTargetAccess({
-          organization: input.organization,
-          project: input.project,
-          target: input.target.id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          targetId: input.target.id,
           scope: TargetAccessScope.REGISTRY_WRITE,
         });
         const [
@@ -1205,37 +1205,37 @@ export class SchemaPublisher {
           latestComposableSchemaVersion,
         ] = await Promise.all([
           this.projectManager.getProject({
-            organization: input.organization,
-            project: input.project,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
           }),
           this.organizationManager.getOrganization({
-            organization: input.organization,
+            organizationId: input.organizationId,
           }),
           this.schemaManager.getLatestSchemas({
-            organization: input.organization,
-            project: input.project,
-            target: input.target.id,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.target.id,
           }),
           this.schemaManager.getLatestSchemas({
-            organization: input.organization,
-            project: input.project,
-            target: input.target.id,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.target.id,
             onlyComposable: true,
           }),
           this.schemaManager.getBaseSchema({
-            organization: input.organization,
-            project: input.project,
-            target: input.target.id,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.target.id,
           }),
           this.schemaManager.getMaybeLatestVersion({
-            organization: input.organization,
-            project: input.project,
-            target: input.target.id,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.target.id,
           }),
           this.schemaManager.getMaybeLatestValidVersion({
-            organization: input.organization,
-            project: input.project,
-            target: input.target.id,
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            targetId: input.target.id,
           }),
         ]);
 
@@ -1289,9 +1289,9 @@ export class SchemaPublisher {
         const conditionalBreakingChangeConfiguration =
           await this.getConditionalBreakingChangeConfiguration({
             selector: {
-              target: input.target.id,
-              project: input.project,
-              organization: input.organization,
+              targetId: input.target.id,
+              projectId: input.projectId,
+              organizationId: input.organizationId,
             },
           });
 
@@ -1331,8 +1331,8 @@ export class SchemaPublisher {
           organization,
           selector: {
             target: input.target.id,
-            project: input.project,
-            organization: input.organization,
+            project: input.projectId,
+            organization: input.organizationId,
           },
           conditionalBreakingChangeDiffConfig:
             conditionalBreakingChangeConfiguration?.conditionalBreakingChangeDiffConfig ?? null,
@@ -1352,9 +1352,9 @@ export class SchemaPublisher {
           this.logger.debug('Delete accepted');
           if (input.dryRun !== true) {
             const schemaVersion = await this.storage.deleteSchema({
-              organization: input.organization,
-              project: input.project,
-              target: input.target.id,
+              organizationId: input.organizationId,
+              projectId: input.projectId,
+              targetId: input.target.id,
               serviceName: input.serviceName,
               composable: deleteResult.state.composable,
               diffSchemaVersionId,
@@ -1408,8 +1408,8 @@ export class SchemaPublisher {
               },
               conditionalBreakingChangeMetadata: await this.getConditionalBreakingChangeMetadata({
                 conditionalBreakingChangeConfiguration,
-                organizationId: input.organization,
-                projectId: input.project,
+                organizationId: input.organizationId,
+                projectId: input.projectId,
                 targetId: input.target.id,
               }),
             });
@@ -1490,7 +1490,11 @@ export class SchemaPublisher {
       checksum: string;
     },
   ) {
-    const [organizationId, projectId, targetId] = [input.organization, input.project, input.target];
+    const [organizationId, projectId, targetId] = [
+      input.organizationId,
+      input.projectId,
+      input.targetId,
+    ];
     this.logger.info('Publishing schema (input=%o)', {
       ...lodash.omit(input, ['sdl', 'organization', 'project', 'target', 'metadata']),
       organization: organizationId,
@@ -1513,42 +1517,42 @@ export class SchemaPublisher {
       latestComposableSchemaVersion,
     ] = await Promise.all([
       this.organizationManager.getOrganization({
-        organization: organizationId,
+        organizationId: organizationId,
       }),
       this.projectManager.getProject({
-        organization: organizationId,
-        project: projectId,
+        organizationId: organizationId,
+        projectId: projectId,
       }),
       this.targetManager.getTarget({
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationId: organizationId,
+        projectId: projectId,
+        targetId: targetId,
       }),
       this.schemaManager.getLatestSchemas({
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationId: organizationId,
+        projectId: projectId,
+        targetId: targetId,
       }),
       this.schemaManager.getLatestSchemas({
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationId: organizationId,
+        projectId: projectId,
+        targetId: targetId,
         onlyComposable: true,
       }),
       this.schemaManager.getBaseSchema({
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationId: organizationId,
+        projectId: projectId,
+        targetId: targetId,
       }),
       this.schemaManager.getMaybeLatestVersion({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
       this.schemaManager.getMaybeLatestValidVersion({
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetId: input.targetId,
       }),
     ]);
 
@@ -1626,7 +1630,7 @@ export class SchemaPublisher {
     }
 
     await this.schemaManager.completeGetStartedCheck({
-      organization: project.orgId,
+      organizationId: project.orgId,
       step: 'publishingSchema',
     });
 
@@ -1635,9 +1639,9 @@ export class SchemaPublisher {
     const conditionalBreakingChangeConfiguration =
       await this.getConditionalBreakingChangeConfiguration({
         selector: {
-          organization: organization.id,
-          project: project.id,
-          target: target.id,
+          organizationId: organization.id,
+          projectId: project.id,
+          targetId: target.id,
         },
       });
 
@@ -1762,7 +1766,7 @@ export class SchemaPublisher {
               target: {
                 slug: target.slug,
               },
-              version: latestVersion ? { id: latestVersion.version } : undefined,
+              version: latestVersion ? { id: latestVersion.versionId } : undefined,
             })
           : null;
 
@@ -1891,9 +1895,9 @@ export class SchemaPublisher {
 
     const schemaVersion = await this.schemaManager.createVersion({
       valid: composable,
-      organization: organizationId,
-      project: project.id,
-      target: target.id,
+      organizationId: organizationId,
+      projectId: project.id,
+      targetId: target.id,
       commit: input.commit,
       logIds: schemaLogIds,
       service: input.service,
@@ -1930,7 +1934,7 @@ export class SchemaPublisher {
       changes,
       coordinatesDiff: publishResult.state.coordinatesDiff,
       diffSchemaVersionId,
-      previousSchemaVersion: latestVersion?.version ?? null,
+      previousSchemaVersion: latestVersion?.versionId ?? null,
       conditionalBreakingChangeMetadata: await this.getConditionalBreakingChangeMetadata({
         conditionalBreakingChangeConfiguration,
         organizationId,
@@ -2057,7 +2061,7 @@ export class SchemaPublisher {
         includeProjectName: args.project.useProjectNameInGithubCheck,
       }),
       sha: args.github.sha,
-      organization: args.project.orgId,
+      organizationId: args.project.orgId,
       repositoryOwner: args.github.owner,
       repositoryName: args.github.repository,
       output: {
@@ -2308,7 +2312,7 @@ export class SchemaPublisher {
     return await this.gitHubIntegrationManager.createCheckRun({
       name: 'GraphQL Hive - schema:publish',
       sha: args.github.sha,
-      organization: args.organizationId,
+      organizationId: args.organizationId,
       repositoryOwner: args.github.owner,
       repositoryName: args.github.repository,
       output: {

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -42,17 +42,17 @@ export class SchemaVersionHelper {
   private async composeSchemaVersion(schemaVersion: SchemaVersion) {
     const [schemas, project, organization] = await Promise.all([
       this.schemaManager.getMaybeSchemasOfVersion({
-        version: schemaVersion.id,
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
-        target: schemaVersion.target,
+        versionId: schemaVersion.id,
+        organizationId: schemaVersion.organizationId,
+        projectId: schemaVersion.projectId,
+        targetId: schemaVersion.targetId,
       }),
       this.projectManager.getProject({
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
+        organizationId: schemaVersion.organizationId,
+        projectId: schemaVersion.projectId,
       }),
       this.organizationManager.getOrganization({
-        organization: schemaVersion.organization,
+        organizationId: schemaVersion.organizationId,
       }),
     ]);
 
@@ -68,7 +68,7 @@ export class SchemaVersionHelper {
         native: this.schemaManager.checkProjectNativeFederationSupport({
           project,
           organization,
-          targetId: schemaVersion.target,
+          targetId: schemaVersion.targetId,
         }),
         contracts: null,
       },
@@ -156,9 +156,9 @@ export class SchemaVersionHelper {
 
     if (schemaVersion.hasPersistedSchemaChanges) {
       const changes = await this.schemaManager.getSchemaChangesForVersion({
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
-        target: schemaVersion.target,
+        organizationId: schemaVersion.organizationId,
+        projectId: schemaVersion.projectId,
+        targetId: schemaVersion.targetId,
         version: schemaVersion.id,
       });
 
@@ -190,16 +190,16 @@ export class SchemaVersionHelper {
 
     const [schemaBefore, schemasAfter] = await Promise.all([
       this.schemaManager.getMaybeSchemasOfVersion({
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
-        target: schemaVersion.target,
-        version: schemaVersion.id,
+        organizationId: schemaVersion.organizationId,
+        projectId: schemaVersion.projectId,
+        targetId: schemaVersion.targetId,
+        versionId: schemaVersion.id,
       }),
       this.schemaManager.getMaybeSchemasOfVersion({
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
-        target: schemaVersion.target,
-        version: previousVersion.id,
+        organizationId: schemaVersion.organizationId,
+        projectId: schemaVersion.projectId,
+        targetId: schemaVersion.targetId,
+        versionId: previousVersion.id,
       }),
     ]);
 
@@ -208,8 +208,8 @@ export class SchemaVersionHelper {
     }
 
     const project = await this.projectManager.getProject({
-      organization: schemaVersion.organization,
-      project: schemaVersion.project,
+      organizationId: schemaVersion.organizationId,
+      projectId: schemaVersion.projectId,
     });
 
     const diffCheck = await this.registryChecks.diff({
@@ -237,19 +237,19 @@ export class SchemaVersionHelper {
     if (schemaVersion.recordVersion === '2024-01-10') {
       if (schemaVersion.diffSchemaVersionId) {
         return await this.schemaManager.getSchemaVersion({
-          organization: schemaVersion.organization,
-          project: schemaVersion.project,
-          target: schemaVersion.target,
-          version: schemaVersion.diffSchemaVersionId,
+          organizationId: schemaVersion.organizationId,
+          projectId: schemaVersion.projectId,
+          targetId: schemaVersion.targetId,
+          versionId: schemaVersion.diffSchemaVersionId,
         });
       }
       return null;
     }
 
     return await this.schemaManager.getVersionBeforeVersionId({
-      organization: schemaVersion.organization,
-      project: schemaVersion.project,
-      target: schemaVersion.target,
+      organization: schemaVersion.organizationId,
+      project: schemaVersion.projectId,
+      target: schemaVersion.targetId,
       beforeVersionId: schemaVersion.id,
       beforeVersionCreatedAt: schemaVersion.createdAt,
     });
@@ -284,9 +284,9 @@ export class SchemaVersionHelper {
 
     const composableVersion =
       await this.schemaManager.getFirstComposableSchemaVersionBeforeVersionId({
-        organization: schemaVersion.organization,
-        project: schemaVersion.project,
-        target: schemaVersion.target,
+        organization: schemaVersion.organizationId,
+        project: schemaVersion.projectId,
+        target: schemaVersion.targetId,
         beforeVersionId: schemaVersion.id,
         beforeVersionCreatedAt: schemaVersion.createdAt,
       });

--- a/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/DeprecatedSchemaExplorer.ts
@@ -8,9 +8,9 @@ export const DeprecatedSchemaExplorer: DeprecatedSchemaExplorerResolvers = {
 
     async function getStats(typename: string) {
       const stats = await operationsManager.countCoordinatesOfTarget({
-        target: usage.target,
-        organization: usage.organization,
-        project: usage.project,
+        targetId: usage.targetId,
+        organizationId: usage.organizationId,
+        projectId: usage.projectId,
         period: usage.period,
       });
 

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/disableExternalSchemaComposition.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/disableExternalSchemaComposition.ts
@@ -12,7 +12,7 @@ export const disableExternalSchemaComposition: NonNullable<
   ]);
 
   return injector.get(SchemaManager).disableExternalSchemaComposition({
-    project,
-    organization,
+    projectId: project,
+    organizationId: organization,
   });
 };

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/enableExternalSchemaComposition.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/enableExternalSchemaComposition.ts
@@ -12,8 +12,8 @@ export const enableExternalSchemaComposition: NonNullable<
   ]);
 
   return injector.get(SchemaManager).enableExternalSchemaComposition({
-    project,
-    organization,
+    projectId: project,
+    organizationId: organization,
     endpoint: input.endpoint,
     secret: input.secret,
   });

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/schemaCheck.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/schemaCheck.ts
@@ -18,9 +18,9 @@ export const schemaCheck: NonNullable<MutationResolvers['schemaCheck']> = async 
   const result = await injector.get(SchemaPublisher).check({
     ...input,
     service: input.service?.toLowerCase(),
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 
   if ('changes' in result && result.changes) {

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/schemaCompose.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/schemaCompose.ts
@@ -18,9 +18,9 @@ export const schemaCompose: NonNullable<MutationResolvers['schemaCompose']> = as
   const result = await injector.get(SchemaManager).compose({
     onlyComposable: input.useLatestComposableVersion === true,
     services: input.services,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 
   if (result.kind === 'error') {

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/schemaDelete.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/schemaDelete.ts
@@ -12,7 +12,7 @@ export const schemaDelete: NonNullable<MutationResolvers['schemaDelete']> = asyn
   { input },
   { injector, request },
 ) => {
-  const [organization, project, target] = await Promise.all([
+  const [organizationId, projectId, target] = await Promise.all([
     injector.get(OrganizationManager).getOrganizationIdByToken(),
     injector.get(ProjectManager).getProjectIdByToken(),
     injector.get(TargetManager).getTargetFromToken(),
@@ -34,8 +34,8 @@ export const schemaDelete: NonNullable<MutationResolvers['schemaDelete']> = asyn
     {
       dryRun: input.dryRun,
       serviceName: input.serviceName.toLowerCase(),
-      organization,
-      project,
+      organizationId,
+      projectId,
       target,
       checksum,
     },

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/schemaPublish.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/schemaPublish.ts
@@ -27,9 +27,9 @@ export const schemaPublish: NonNullable<MutationResolvers['schemaPublish']> = as
     {
       ...input,
       service: input.service?.toLowerCase(),
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       isSchemaPublishMissingUrlErrorSelected,
     },
     request.signal,

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/updateBaseSchema.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/updateBaseSchema.ts
@@ -28,21 +28,21 @@ export const updateBaseSchema: NonNullable<MutationResolvers['updateBaseSchema']
 
   const schemaManager = injector.get(SchemaManager);
   const translator = injector.get(IdTranslator);
-  const [organization, project, target] = await Promise.all([
+  const [organizationId, projectId, targetId] = await Promise.all([
     translator.translateOrganizationId(input),
     translator.translateProjectId(input),
     translator.translateTargetId(input),
   ]);
 
-  const selector = { organization, project, target };
+  const selector = { organizationId, projectId, targetId };
   await schemaManager.updateBaseSchema(selector, input.newBase ? input.newBase : null);
 
   return {
     ok: {
       updatedTarget: await injector.get(TargetManager).getTarget({
-        organization,
-        target,
-        project,
+        organizationId,
+        projectId,
+        targetId,
       }),
     },
   };

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/updateNativeFederation.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/updateNativeFederation.ts
@@ -13,8 +13,8 @@ export const updateNativeFederation: NonNullable<
 
   return {
     ok: await injector.get(SchemaManager).updateNativeSchemaComposition({
-      project,
-      organization,
+      projectId: project,
+      organizationId: organization,
       enabled: input.enabled,
     }),
   };

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/updateProjectRegistryModel.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/updateProjectRegistryModel.ts
@@ -13,8 +13,8 @@ export const updateProjectRegistryModel: NonNullable<
 
   return {
     ok: await injector.get(SchemaManager).updateRegistryModel({
-      project,
-      organization,
+      projectId: project,
+      organizationId: organization,
       model: input.model,
     }),
   };

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/updateSchemaVersionStatus.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/updateSchemaVersionStatus.ts
@@ -13,10 +13,10 @@ export const updateSchemaVersionStatus: NonNullable<
   ]);
 
   return injector.get(SchemaPublisher).updateVersionStatus({
-    version: input.versionId,
+    versionId: input.versionId,
     valid: input.valid,
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 };

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/updateSchemaVersionStatus.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/updateSchemaVersionStatus.ts
@@ -13,7 +13,7 @@ export const updateSchemaVersionStatus: NonNullable<
   ]);
 
   return injector.get(SchemaPublisher).updateVersionStatus({
-    version: input.version,
+    version: input.versionId,
     valid: input.valid,
     organization,
     project,

--- a/packages/services/api/src/modules/schema/resolvers/Project.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Project.ts
@@ -25,8 +25,8 @@ export const Project: Pick<
   },
   schemaVersionsCount: (project, { period }, { injector }) => {
     return injector.get(SchemaManager).countSchemaVersionsOfProject({
-      organization: project.orgId,
-      project: project.id,
+      organizationId: project.orgId,
+      projectId: project.id,
       period: period ? parseDateRangeInput(period) : null,
     });
   },

--- a/packages/services/api/src/modules/schema/resolvers/Query/latestValidVersion.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Query/latestValidVersion.ts
@@ -10,8 +10,8 @@ export const latestValidVersion: NonNullable<QueryResolvers['latestValidVersion'
   const target = await injector.get(TargetManager).getTargetFromToken();
 
   return injector.get(SchemaManager).getMaybeLatestValidVersion({
-    organization: target.orgId,
-    project: target.projectId,
-    target: target.id,
+    organizationId: target.orgId,
+    projectId: target.projectId,
+    targetId: target.id,
   });
 };

--- a/packages/services/api/src/modules/schema/resolvers/Query/latestVersion.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Query/latestVersion.ts
@@ -10,8 +10,8 @@ export const latestVersion: NonNullable<QueryResolvers['latestVersion']> = async
   const target = await injector.get(TargetManager).getTargetFromToken();
 
   return injector.get(SchemaManager).getMaybeLatestVersion({
-    organization: target.orgId,
-    project: target.projectId,
-    target: target.id,
+    organizationId: target.orgId,
+    projectId: target.projectId,
+    targetId: target.id,
   });
 };

--- a/packages/services/api/src/modules/schema/resolvers/SchemaCoordinateUsage.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaCoordinateUsage.ts
@@ -10,9 +10,9 @@ export const SchemaCoordinateUsage: SchemaCoordinateUsageResolvers = {
     return injector
       .get(OperationsManager)
       .getTopOperationForCoordinate({
-        organizationId: source.organization,
-        projectId: source.project,
-        targetId: source.target,
+        organizationId: source.organizationId,
+        projectId: source.projectId,
+        targetId: source.targetId,
         coordinate: source.coordinate,
         period: source.period,
         limit,

--- a/packages/services/api/src/modules/schema/resolvers/SchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaExplorer.ts
@@ -40,9 +40,9 @@ export const SchemaExplorer: SchemaExplorerResolvers = {
         .get(OperationsManager)
         .countCoordinatesOfType({
           typename: entity.name,
-          organization: source.usage.organization,
-          project: source.usage.project,
-          target: source.usage.target,
+          organizationId: source.usage.organizationId,
+          projectId: source.usage.projectId,
+          targetId: source.usage.targetId,
           period: source.usage.period,
         })
         .then(usage =>
@@ -158,9 +158,9 @@ export const SchemaExplorer: SchemaExplorerResolvers = {
 
     async function getStats(typename: string) {
       const stats = await operationsManager.countCoordinatesOfTarget({
-        target: usage.target,
-        organization: usage.organization,
-        project: usage.project,
+        targetId: usage.targetId,
+        organizationId: usage.organizationId,
+        projectId: usage.projectId,
         period: usage.period,
       });
 
@@ -294,9 +294,9 @@ export const SchemaExplorer: SchemaExplorerResolvers = {
         return operationsManager
           .countCoordinatesOfType({
             typename: entity.name,
-            organization: usage.organization,
-            project: usage.project,
-            target: usage.target,
+            organizationId: usage.organizationId,
+            projectId: usage.projectId,
+            targetId: usage.targetId,
             period: usage.period,
           })
           .then(stats =>
@@ -334,9 +334,9 @@ export const SchemaExplorer: SchemaExplorerResolvers = {
         return operationsManager
           .countCoordinatesOfType({
             typename: entity.name,
-            organization: usage.organization,
-            project: usage.project,
-            target: usage.target,
+            organizationId: usage.organizationId,
+            projectId: usage.projectId,
+            targetId: usage.targetId,
             period: usage.period,
           })
           .then(stats =>
@@ -374,9 +374,9 @@ export const SchemaExplorer: SchemaExplorerResolvers = {
         return operationsManager
           .countCoordinatesOfType({
             typename: entity.name,
-            organization: usage.organization,
-            project: usage.project,
-            target: usage.target,
+            organizationId: usage.organizationId,
+            projectId: usage.projectId,
+            targetId: usage.targetId,
             period: usage.period,
           })
           .then(stats =>

--- a/packages/services/api/src/modules/schema/resolvers/SchemaVersion.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaVersion.ts
@@ -19,9 +19,9 @@ export const SchemaVersion: SchemaVersionResolvers = {
   log: async (version, _, { injector }) => {
     const log = await injector.get(SchemaManager).getSchemaLog({
       commit: version.actionId,
-      organization: version.organization,
-      project: version.project,
-      target: version.target,
+      organizationId: version.organizationId,
+      projectId: version.projectId,
+      targetId: version.targetId,
     });
 
     if (log.kind === 'single') {
@@ -65,10 +65,10 @@ export const SchemaVersion: SchemaVersionResolvers = {
   },
   schemas: (version, _, { injector }) => {
     return injector.get(SchemaManager).getMaybeSchemasOfVersion({
-      version: version.id,
-      organization: version.organization,
-      project: version.project,
-      target: version.target,
+      versionId: version.id,
+      organizationId: version.organizationId,
+      projectId: version.projectId,
+      targetId: version.targetId,
     });
   },
   schemaCompositionErrors: async (version, _, { injector }) => {
@@ -105,9 +105,9 @@ export const SchemaVersion: SchemaVersionResolvers = {
       schema: buildASTSchema(schemaAst),
       usage: {
         period: usage?.period ? parseDateRangeInput(usage.period) : createPeriod('30d'),
-        organization: version.organization,
-        project: version.project,
-        target: version.target,
+        organizationId: version.organizationId,
+        projectId: version.projectId,
+        targetId: version.targetId,
       },
       supergraph,
     };
@@ -123,9 +123,9 @@ export const SchemaVersion: SchemaVersionResolvers = {
     }
 
     const usedCoordinates = await injector.get(OperationsManager).getReportedSchemaCoordinates({
-      targetId: version.target,
-      projectId: version.project,
-      organizationId: version.organization,
+      targetId: version.targetId,
+      projectId: version.projectId,
+      organizationId: version.organizationId,
       period: usage?.period ? parseDateRangeInput(usage.period) : createPeriod('30d'),
     });
 
@@ -135,9 +135,9 @@ export const SchemaVersion: SchemaVersionResolvers = {
       sdl: stripUsedSchemaCoordinatesFromDocumentNode(schemaAst, usedCoordinates),
       usage: {
         period: usage?.period ? parseDateRangeInput(usage.period) : createPeriod('30d'),
-        organization: version.organization,
-        project: version.project,
-        target: version.target,
+        organizationId: version.organizationId,
+        projectId: version.projectId,
+        targetId: version.targetId,
         usedCoordinates,
       },
       supergraph,
@@ -159,9 +159,9 @@ export const SchemaVersion: SchemaVersionResolvers = {
       sdl: onlyDeprecatedDocumentNode(schemaAst),
       usage: {
         period: usage?.period ? parseDateRangeInput(usage.period) : createPeriod('30d'),
-        organization: version.organization,
-        project: version.project,
-        target: version.target,
+        organizationId: version.organizationId,
+        projectId: version.projectId,
+        targetId: version.targetId,
       },
       supergraph,
     };

--- a/packages/services/api/src/modules/schema/resolvers/Target.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Target.ts
@@ -32,10 +32,10 @@ export const Target: Pick<
   },
   schemaVersion: async (target, args, { injector }) => {
     const schemaVersion = await injector.get(SchemaManager).getSchemaVersion({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
-      version: args.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
+      versionId: args.id,
     });
 
     if (schemaVersion === null) {
@@ -44,37 +44,37 @@ export const Target: Pick<
 
     return {
       ...schemaVersion,
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
     };
   },
   latestSchemaVersion: (target, _, { injector }) => {
     return injector.get(SchemaManager).getMaybeLatestVersion({
-      target: target.id,
-      project: target.projectId,
-      organization: target.orgId,
+      targetId: target.id,
+      projectId: target.projectId,
+      organizationId: target.orgId,
     });
   },
   latestValidSchemaVersion: async (target, __, { injector }) => {
     return injector.get(SchemaManager).getMaybeLatestValidVersion({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
     });
   },
   baseSchema: (target, _, { injector }) => {
     return injector.get(SchemaManager).getBaseSchema({
-      target: target.id,
-      project: target.projectId,
-      organization: target.orgId,
+      targetId: target.id,
+      projectId: target.projectId,
+      organizationId: target.orgId,
     });
   },
   hasSchema: (target, _, { injector }) => {
     return injector.get(SchemaManager).hasSchema({
-      target: target.id,
-      project: target.projectId,
-      organization: target.orgId,
+      targetId: target.id,
+      projectId: target.projectId,
+      organizationId: target.orgId,
     });
   },
   schemaCheck: async (target, args, { injector }) => {
@@ -118,9 +118,9 @@ export const Target: Pick<
   },
   schemaVersionsCount: (target, { period }, { injector }) => {
     return injector.get(SchemaManager).countSchemaVersionsOfTarget({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
       period: period ? parseDateRangeInput(period) : null,
     });
   },
@@ -140,9 +140,9 @@ export const Target: Pick<
   },
   hasCollectedSubscriptionOperations: async (target, _, { injector }) => {
     return await injector.get(OperationsManager).hasCollectedSubscriptionOperations({
-      target: target.id,
-      project: target.projectId,
-      organization: target.orgId,
+      targetId: target.id,
+      projectId: target.projectId,
+      organizationId: target.orgId,
     });
   },
 };

--- a/packages/services/api/src/modules/schema/resolvers/UnusedSchemaExplorer.ts
+++ b/packages/services/api/src/modules/schema/resolvers/UnusedSchemaExplorer.ts
@@ -8,9 +8,9 @@ export const UnusedSchemaExplorer: UnusedSchemaExplorerResolvers = {
         isUsed: false,
         usedCoordinates: usage.usedCoordinates,
         period: usage.period,
-        organization: usage.organization,
-        project: usage.project,
-        target: usage.target,
+        organizationId: usage.organizationId,
+        projectId: usage.projectId,
+        targetId: usage.targetId,
       }) as const;
 
     return buildGraphQLTypesFromSDL(sdl, unused, supergraph).sort((a, b) =>

--- a/packages/services/api/src/modules/schema/utils.ts
+++ b/packages/services/api/src/modules/schema/utils.ts
@@ -36,9 +36,9 @@ export function withUsedByClients<
   T & {
     usedByClients: () => PromiseOrValue<Array<string>>;
     period: DateRange;
-    organization: string;
-    project: string;
-    target: string;
+    organizationId: string;
+    projectId: string;
+    targetId: string;
     typename: string;
   }
 > {
@@ -49,9 +49,9 @@ export function withUsedByClients<
         selector: deps.selector,
         period: deps.period,
         typename: deps.typename,
-        organization: deps.selector.organization,
-        project: deps.selector.project,
-        target: deps.selector.target,
+        organizationId: deps.selector.organizationId,
+        projectId: deps.selector.projectId,
+        targetId: deps.selector.targetId,
         ...record,
         usedByClients() {
           if (record.isUsed === false) {
@@ -335,9 +335,9 @@ export function usage(
         isUsed: true,
         usedByClients: () => [],
         period: usage.period,
-        organization: usage.organization,
-        project: usage.project,
-        target: usage.target,
+        organizationId: usage.organizationId,
+        projectId: usage.projectId,
+        targetId: usage.targetId,
         coordinate: coordinate,
       };
     }
@@ -358,9 +358,9 @@ export function usage(
           isUsed: true,
           usedByClients: coordinateUsage.usedByClients,
           period: coordinateUsage.period,
-          organization: coordinateUsage.organization,
-          project: coordinateUsage.project,
-          target: coordinateUsage.target,
+          organizationId: coordinateUsage.organizationId,
+          projectId: coordinateUsage.projectId,
+          targetId: coordinateUsage.targetId,
           coordinate: coordinate,
         }
       : {

--- a/packages/services/api/src/modules/shared/providers/activity-manager.ts
+++ b/packages/services/api/src/modules/shared/providers/activity-manager.ts
@@ -27,10 +27,10 @@ export class ActivityManager {
       const user = activity.user ? activity.user.id : (await this.authManager.getCurrentUser()).id;
 
       await this.storage.createActivity({
-        organization: activity.selector.organization,
-        project: 'project' in activity.selector ? activity.selector.project : undefined,
-        target: 'target' in activity.selector ? activity.selector.target : undefined,
-        user,
+        organizationId: activity.selector.organizationId,
+        projectId: 'projectId' in activity.selector ? activity.selector.projectId : undefined,
+        targetId: 'targetId' in activity.selector ? activity.selector.targetId : undefined,
+        userId: user,
         type: activity.type,
         meta: 'meta' in activity ? activity.meta : {},
       });
@@ -54,25 +54,25 @@ interface BaseActivity {
 }
 
 interface UserSelector {
-  user: string;
+  userId: string;
 }
 
 interface OrganizationSelector {
-  organization: string;
+  organizationId: string;
 }
 
 interface ProjectSelector extends OrganizationSelector {
-  project: string;
+  projectId: string;
 }
 
 interface PersistedOperationSelector extends ProjectSelector {
-  organization: string;
-  project: string;
+  organizationId: string;
+  projectId: string;
   operation: string;
 }
 
 interface TargetSelector extends ProjectSelector {
-  target: string;
+  targetId: string;
 }
 
 interface OrganizationCreatedActivity extends BaseActivity {

--- a/packages/services/api/src/modules/shared/providers/id-translator.ts
+++ b/packages/services/api/src/modules/shared/providers/id-translator.ts
@@ -34,7 +34,7 @@ export class IdTranslator {
       filterSelector('organization', selector),
     );
     const organizationId = await this.storage.getOrganizationId({
-      organization: selector.organizationSlug,
+      organizationSlug: selector.organizationSlug,
     });
 
     if (!organizationId) {
@@ -51,7 +51,7 @@ export class IdTranslator {
       filterSelector('organization', selector),
     );
     return this.storage.getOrganizationId({
-      organization: selector.organizationSlug,
+      organizationSlug: selector.organizationSlug,
     });
   }
 
@@ -64,34 +64,24 @@ export class IdTranslator {
       filterSelector('project', selector),
     );
     return this.storage.getProjectId({
-      organization: selector.organizationSlug,
-      project: selector.projectSlug,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
     });
   }
 
-  @cache<
-    TargetSelectorInput & {
-      useIds?: boolean;
-    }
-  >(selector =>
-    [selector.organizationSlug, selector.projectSlug, selector.targetSlug, selector.useIds].join(
-      ',',
-    ),
+  @cache<TargetSelectorInput>(selector =>
+    [selector.organizationSlug, selector.projectSlug, selector.targetSlug].join(','),
   )
-  translateTargetId(
-    selector: TargetSelectorInput & {
-      useIds?: boolean;
-    },
-  ) {
+  translateTargetId(selector: TargetSelectorInput) {
     this.logger.debug(
       'Translating Target Clean ID (selector=%o)',
       filterSelector('target', selector),
     );
+
     return this.storage.getTargetId({
-      organization: selector.organizationSlug,
-      project: selector.projectSlug,
-      target: selector.targetSlug,
-      useIds: selector.useIds,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
+      targetSlug: selector.targetSlug,
     });
   }
 }

--- a/packages/services/api/src/modules/shared/providers/id-translator.ts
+++ b/packages/services/api/src/modules/shared/providers/id-translator.ts
@@ -1,8 +1,19 @@
 import { Injectable, Scope } from 'graphql-modules';
-import { cache, filterSelector } from '../../../shared/helpers';
+import { cache } from '../../../shared/helpers';
 import { Logger } from './logger';
-import type { OrganizationSelector, ProjectSelector, TargetSelector } from './storage';
 import { Storage } from './storage';
+
+interface OrganizationSelectorInput {
+  organizationSlug: string;
+}
+
+interface ProjectSelectorInput extends OrganizationSelectorInput {
+  projectSlug: string;
+}
+
+interface TargetSelectorInput extends ProjectSelectorInput {
+  targetSlug: string;
+}
 
 @Injectable({
   scope: Scope.Operation,
@@ -16,13 +27,15 @@ export class IdTranslator {
     this.logger = logger.child({ service: 'IdTranslator' });
   }
 
-  @cache<OrganizationSelector>(selector => selector.organization)
-  async translateOrganizationId(selector: OrganizationSelector) {
+  @cache<OrganizationSelectorInput>(selector => selector.organizationSlug)
+  async translateOrganizationId(selector: OrganizationSelectorInput) {
     this.logger.debug(
       'Translating Organization Clean ID (selector=%o)',
       filterSelector('organization', selector),
     );
-    const organizationId = await this.storage.getOrganizationId(selector);
+    const organizationId = await this.storage.getOrganizationId({
+      organization: selector.organizationSlug,
+    });
 
     if (!organizationId) {
       throw new Error('Organization not found');
@@ -31,33 +44,42 @@ export class IdTranslator {
     return organizationId;
   }
 
-  @cache<OrganizationSelector>(selector => selector.organization)
-  translateOrganizationIdSafe(selector: OrganizationSelector) {
+  @cache<OrganizationSelectorInput>(selector => selector.organizationSlug)
+  translateOrganizationIdSafe(selector: OrganizationSelectorInput) {
     this.logger.debug(
       'Translating Organization Clean ID (selector=%o)',
       filterSelector('organization', selector),
     );
-    return this.storage.getOrganizationId(selector);
+    return this.storage.getOrganizationId({
+      organization: selector.organizationSlug,
+    });
   }
 
-  @cache<ProjectSelector>(selector => [selector.organization, selector.project].join(','))
-  translateProjectId(selector: ProjectSelector) {
+  @cache<ProjectSelectorInput>(selector =>
+    [selector.organizationSlug, selector.projectSlug].join(','),
+  )
+  translateProjectId(selector: ProjectSelectorInput) {
     this.logger.debug(
       'Translating Project Clean ID (selector=%o)',
       filterSelector('project', selector),
     );
-    return this.storage.getProjectId(selector);
+    return this.storage.getProjectId({
+      organization: selector.organizationSlug,
+      project: selector.projectSlug,
+    });
   }
 
   @cache<
-    TargetSelector & {
+    TargetSelectorInput & {
       useIds?: boolean;
     }
   >(selector =>
-    [selector.organization, selector.project, selector.target, selector.useIds].join(','),
+    [selector.organizationSlug, selector.projectSlug, selector.targetSlug, selector.useIds].join(
+      ',',
+    ),
   )
   translateTargetId(
-    selector: TargetSelector & {
+    selector: TargetSelectorInput & {
       useIds?: boolean;
     },
   ) {
@@ -65,6 +87,37 @@ export class IdTranslator {
       'Translating Target Clean ID (selector=%o)',
       filterSelector('target', selector),
     );
-    return this.storage.getTargetId(selector);
+    return this.storage.getTargetId({
+      organization: selector.organizationSlug,
+      project: selector.projectSlug,
+      target: selector.targetSlug,
+      useIds: selector.useIds,
+    });
+  }
+}
+
+function filterSelector(
+  kind: 'organization',
+  selector: OrganizationSelectorInput,
+): OrganizationSelectorInput;
+function filterSelector(kind: 'project', selector: ProjectSelectorInput): ProjectSelectorInput;
+function filterSelector(kind: 'target', selector: TargetSelectorInput): TargetSelectorInput;
+function filterSelector(kind: 'organization' | 'project' | 'target', selector: any): any {
+  switch (kind) {
+    case 'organization':
+      return {
+        organizationSlug: selector.organizationSlug,
+      };
+    case 'project':
+      return {
+        organizationSlug: selector.organizationSlug,
+        projectSlug: selector.projectSlug,
+      };
+    case 'target':
+      return {
+        organizationSlug: selector.organizationSlug,
+        projectSlug: selector.projectSlug,
+        targetSlug: selector.targetSlug,
+      };
   }
 }

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -573,17 +573,30 @@ export interface Storage {
 
   getGitHubIntegrationInstallationId(_: OrganizationSelector): Promise<string | null | undefined>;
 
-  addAlertChannel(_: AddAlertChannelInput): Promise<AlertChannel>;
+  addAlertChannel(_: {
+    name: string;
+    organizationId: string;
+    projectId: string;
+    type: AlertChannel['type'];
+    slackChannel?: string | null;
+    webhookEndpoint?: string | null;
+  }): Promise<AlertChannel>;
 
-  deleteAlertChannels(
-    _: ProjectSelector & {
-      channels: readonly string[];
-    },
-  ): Promise<readonly AlertChannel[]>;
+  deleteAlertChannels(_: {
+    channelIds: readonly string[];
+    projectId: string;
+    organizationId: string;
+  }): Promise<readonly AlertChannel[]>;
 
   getAlertChannels(_: ProjectSelector): Promise<readonly AlertChannel[]>;
 
-  addAlert(_: AddAlertInput): Promise<Alert>;
+  addAlert(_: {
+    channelId: string;
+    organizationId: string;
+    projectId: string;
+    targetId: string;
+    type: Alert['type'];
+  }): Promise<Alert>;
 
   deleteAlerts(
     _: ProjectSelector & {

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -11,12 +11,7 @@ import type {
   SchemaVersion,
   TargetBreadcrumb,
 } from '@hive/storage';
-import type {
-  AddAlertChannelInput,
-  AddAlertInput,
-  RegistryModel,
-  SchemaChecksFilter,
-} from '../../../__generated__/types';
+import type { RegistryModel, SchemaChecksFilter } from '../../../__generated__/types';
 import type {
   Alert,
   AlertChannel,

--- a/packages/services/api/src/modules/support/module.graphql.ts
+++ b/packages/services/api/src/modules/support/module.graphql.ts
@@ -28,7 +28,7 @@ export default gql`
   }
 
   input SupportTicketCreateInput {
-    organization: String!
+    organizationSlug: String!
     subject: String!
     description: String!
     priority: SupportTicketPriority!
@@ -51,7 +51,7 @@ export default gql`
   }
 
   input SupportTicketReplyInput {
-    organization: String!
+    organizationSlug: String!
     ticketId: String!
     body: String!
   }

--- a/packages/services/api/src/modules/support/providers/support-manager.ts
+++ b/packages/services/api/src/modules/support/providers/support-manager.ts
@@ -144,7 +144,7 @@ export class SupportManager {
   @atomic((organizationId: string) => organizationId)
   private async ensureZendeskOrganizationId(organizationId: string): Promise<string> {
     const organization = await this.organizationManager.getOrganization({
-      organization: organizationId,
+      organizationId: organizationId,
     });
 
     if (organization.zendeskId) {
@@ -196,8 +196,8 @@ export class SupportManager {
   }): Promise<string> {
     const organizationZendeskId = await this.ensureZendeskOrganizationId(input.organizationId);
     const userAsMember = await this.organizationManager.getOrganizationMember({
-      organization: input.organizationId,
-      user: input.userId,
+      organizationId: input.organizationId,
+      userId: input.userId,
     });
 
     if (!userAsMember.user.zendeskId) {
@@ -377,7 +377,7 @@ export class SupportManager {
   async getTickets(organizationId: string) {
     this.logger.info('Fetching support tickets (id: %s)', organizationId);
     await this.authManager.ensureOrganizationAccess({
-      organization: organizationId,
+      organizationId: organizationId,
       scope: OrganizationAccessScope.READ,
     });
     const internalOrganizationId = await this.ensureZendeskOrganizationId(organizationId);
@@ -418,7 +418,7 @@ export class SupportManager {
       ticketId,
     );
     await this.authManager.ensureOrganizationAccess({
-      organization: organizationId,
+      organizationId: organizationId,
       scope: OrganizationAccessScope.READ,
     });
     const zendeskOrganizationId = await this.ensureZendeskOrganizationId(organizationId);
@@ -516,7 +516,7 @@ export class SupportManager {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.READ,
     });
     const currentUser = await this.authManager.getCurrentUser();
@@ -541,7 +541,7 @@ export class SupportManager {
       .digest('hex');
 
     const organization = await this.organizationManager.getOrganization({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
     });
     const customerType = this.resolveCustomerType(organization);
 
@@ -604,7 +604,7 @@ export class SupportManager {
     }
 
     await this.authManager.ensureOrganizationAccess({
-      organization: input.organizationId,
+      organizationId: input.organizationId,
       scope: OrganizationAccessScope.READ,
     });
     const currentUser = await this.authManager.getCurrentUser();

--- a/packages/services/api/src/modules/target/module.graphql.ts
+++ b/packages/services/api/src/modules/target/module.graphql.ts
@@ -32,16 +32,16 @@ export default gql`
   }
 
   input Experimental__UpdateTargetSchemaCompositionInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     nativeComposition: Boolean!
   }
 
   input UpdateTargetGraphQLEndpointUrlInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     graphqlEndpointUrl: String
   }
 
@@ -59,9 +59,9 @@ export default gql`
   }
 
   input UpdateTargetSlugInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     slug: String!
   }
 
@@ -99,18 +99,18 @@ export default gql`
   }
 
   input TargetSelectorInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
   }
 
   input UpdateTargetValidationSettingsInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     period: Int!
     percentage: Float!
-    targets: [ID!]!
+    targetIds: [ID!]!
     excludedClients: [String!]
   }
 
@@ -134,16 +134,16 @@ export default gql`
   }
 
   input SetTargetValidationInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     enabled: Boolean!
   }
 
   type TargetSelector {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
   }
 
   extend type Project {
@@ -157,7 +157,7 @@ export default gql`
 
   type Target {
     id: ID!
-    slug: ID!
+    slug: String!
     cleanId: ID! @deprecated(reason: "Use the 'slug' field instead.")
     name: String! @deprecated(reason: "Use the 'slug' field instead.")
     project: Project!
@@ -178,8 +178,8 @@ export default gql`
   }
 
   input CreateTargetInput {
-    organization: ID!
-    project: ID!
+    organizationSlug: String!
+    projectSlug: String!
     slug: String!
   }
 

--- a/packages/services/api/src/modules/target/providers/target-manager.ts
+++ b/packages/services/api/src/modules/target/providers/target-manager.ts
@@ -38,8 +38,8 @@ export class TargetManager {
 
   async createTarget({
     slug,
-    project,
-    organization,
+    projectId: project,
+    organizationId: organization,
   }: {
     slug: string;
   } & ProjectSelector): Promise<
@@ -59,8 +59,8 @@ export class TargetManager {
       organization,
     );
     await this.authManager.ensureProjectAccess({
-      project,
-      organization,
+      projectId: project,
+      organizationId: organization,
       scope: ProjectAccessScope.READ,
     });
 
@@ -74,17 +74,17 @@ export class TargetManager {
     // create target
     const result = await this.storage.createTarget({
       slug,
-      project,
-      organization,
+      projectId: project,
+      organizationId: organization,
     });
 
     if (result.ok) {
       await this.activityManager.create({
         type: 'TARGET_CREATED',
         selector: {
-          organization,
-          project,
-          target: result.target.id,
+          organizationId: organization,
+          projectId: project,
+          targetId: result.target.id,
         },
       });
     }
@@ -92,7 +92,11 @@ export class TargetManager {
     return result;
   }
 
-  async deleteTarget({ organization, project, target }: TargetSelector): Promise<Target> {
+  async deleteTarget({
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
+  }: TargetSelector): Promise<Target> {
     this.logger.info(
       'Deleting a target (target=%s, project=%s, organization=%s)',
       target,
@@ -100,24 +104,24 @@ export class TargetManager {
       organization,
     );
     await this.authManager.ensureTargetAccess({
-      project,
-      organization,
-      target,
+      projectId: project,
+      organizationId: organization,
+      targetId: target,
       scope: TargetAccessScope.DELETE,
     });
 
     const deletedTarget = await this.storage.deleteTarget({
-      target,
-      project,
-      organization,
+      targetId: target,
+      projectId: project,
+      organizationId: organization,
     });
     await this.tokenStorage.invalidateTokens(deletedTarget.tokens);
 
     await this.activityManager.create({
       type: 'TARGET_DELETED',
       selector: {
-        organization,
-        project,
+        organizationId: organization,
+        projectId: project,
       },
       meta: {
         name: deletedTarget.name,
@@ -160,16 +164,16 @@ export class TargetManager {
     });
 
     await this.authManager.ensureTargetAccess({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
       scope: TargetAccessScope.READ,
     });
 
     return this.storage.getTarget({
-      organization,
-      project,
-      target,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
     });
   });
 
@@ -195,7 +199,7 @@ export class TargetManager {
     });
 
     await this.storage.completeGetStartedStep({
-      organization: input.organization,
+      organizationId: input.organizationId,
       step: 'enablingUsageBasedBreakingChanges',
     });
 
@@ -232,7 +236,7 @@ export class TargetManager {
         message: string;
       }
   > {
-    const { slug, organization, project, target } = input;
+    const { slug, organizationId: organization, projectId: project, targetId: target } = input;
     this.logger.info('Updating a target slug (input=%o)', input);
     await this.authManager.ensureTargetAccess({
       ...input,
@@ -249,19 +253,19 @@ export class TargetManager {
 
     const result = await this.storage.updateTargetSlug({
       slug,
-      organization,
-      project,
-      target,
-      user: user.id,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
+      userId: user.id,
     });
 
     if (result.ok) {
       await this.activityManager.create({
         type: 'TARGET_ID_UPDATED',
         selector: {
-          organization,
-          project,
-          target,
+          organizationId: organization,
+          projectId: project,
+          targetId: target,
         },
         meta: {
           value: slug,
@@ -279,9 +283,9 @@ export class TargetManager {
     graphqlEndpointUrl: string | null;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.SETTINGS,
     });
 
@@ -328,9 +332,9 @@ export class TargetManager {
     ]);
 
     return this.storage.getTarget({
-      organization: organizationId,
-      project: projectId,
-      target: args.targetId,
+      organizationId: organizationId,
+      projectId: projectId,
+      targetId: args.targetId,
     });
   }
 
@@ -344,9 +348,9 @@ export class TargetManager {
     nativeComposition: boolean;
   }) {
     await this.authManager.ensureTargetAccess({
-      organization: args.organizationId,
-      project: args.projectId,
-      target: args.targetId,
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      targetId: args.targetId,
       scope: TargetAccessScope.SETTINGS,
     });
 

--- a/packages/services/api/src/modules/target/resolvers/Mutation/createTarget.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/createTarget.ts
@@ -36,8 +36,8 @@ export const createTarget: NonNullable<MutationResolvers['createTarget']> = asyn
     }),
   ]);
   const result = await injector.get(TargetManager).createTarget({
-    organization: organizationId,
-    project: projectId,
+    organizationId: organizationId,
+    projectId: projectId,
     slug: inputParseResult.data.slug,
   });
 

--- a/packages/services/api/src/modules/target/resolvers/Mutation/createTarget.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/createTarget.ts
@@ -26,18 +26,18 @@ export const createTarget: NonNullable<MutationResolvers['createTarget']> = asyn
   }
 
   const translator = injector.get(IdTranslator);
-  const [organization, project] = await Promise.all([
+  const [organizationId, projectId] = await Promise.all([
     translator.translateOrganizationId({
-      organization: input.organization,
+      organizationSlug: input.organizationSlug,
     }),
     translator.translateProjectId({
-      organization: input.organization,
-      project: input.project,
+      organizationSlug: input.organizationSlug,
+      projectSlug: input.projectSlug,
     }),
   ]);
   const result = await injector.get(TargetManager).createTarget({
-    organization,
-    project,
+    organization: organizationId,
+    project: projectId,
     slug: inputParseResult.data.slug,
   });
 
@@ -45,9 +45,9 @@ export const createTarget: NonNullable<MutationResolvers['createTarget']> = asyn
     return {
       ok: {
         selector: {
-          organization: input.organization,
-          project: input.project,
-          target: result.target.slug,
+          organizationSlug: input.organizationSlug,
+          projectSlug: input.projectSlug,
+          targetSlug: result.target.slug,
         },
         createdTarget: result.target,
       },

--- a/packages/services/api/src/modules/target/resolvers/Mutation/deleteTarget.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/deleteTarget.ts
@@ -23,9 +23,9 @@ export const deleteTarget: NonNullable<MutationResolvers['deleteTarget']> = asyn
     }),
   ]);
   const target = await injector.get(TargetManager).deleteTarget({
-    organization: organizationId,
-    project: projectId,
-    target: targetId,
+    organizationId: organizationId,
+    projectId: projectId,
+    targetId: targetId,
   });
   return {
     selector: {

--- a/packages/services/api/src/modules/target/resolvers/Mutation/deleteTarget.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/deleteTarget.ts
@@ -10,16 +10,16 @@ export const deleteTarget: NonNullable<MutationResolvers['deleteTarget']> = asyn
   const translator = injector.get(IdTranslator);
   const [organizationId, projectId, targetId] = await Promise.all([
     translator.translateOrganizationId({
-      organization: selector.organization,
+      organizationSlug: selector.organizationSlug,
     }),
     translator.translateProjectId({
-      organization: selector.organization,
-      project: selector.project,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
     }),
     translator.translateTargetId({
-      organization: selector.organization,
-      project: selector.project,
-      target: selector.target,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
+      targetSlug: selector.targetSlug,
     }),
   ]);
   const target = await injector.get(TargetManager).deleteTarget({
@@ -29,9 +29,9 @@ export const deleteTarget: NonNullable<MutationResolvers['deleteTarget']> = asyn
   });
   return {
     selector: {
-      organization: organizationId,
-      project: projectId,
-      target: targetId,
+      organizationSlug: selector.organizationSlug,
+      projectSlug: selector.projectSlug,
+      targetSlug: selector.targetSlug,
     },
     deletedTarget: target,
   };

--- a/packages/services/api/src/modules/target/resolvers/Mutation/setTargetValidation.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/setTargetValidation.ts
@@ -16,15 +16,15 @@ export const setTargetValidation: NonNullable<MutationResolvers['setTargetValida
 
   const targetManager = injector.get(TargetManager);
   await targetManager.setTargetValidation({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
     enabled: input.enabled,
   });
 
   return targetManager.getTarget({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 };

--- a/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetSlug.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetSlug.ts
@@ -41,9 +41,9 @@ export const updateTargetSlug: NonNullable<MutationResolvers['updateTargetSlug']
 
   const result = await injector.get(TargetManager).updateSlug({
     slug: input.slug,
-    organization: organizationId,
-    project: projectId,
-    target: targetId,
+    organizationId: organizationId,
+    projectId: projectId,
+    targetId: targetId,
   });
 
   if (result.ok) {

--- a/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetSlug.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetSlug.ts
@@ -26,16 +26,16 @@ export const updateTargetSlug: NonNullable<MutationResolvers['updateTargetSlug']
   const translator = injector.get(IdTranslator);
   const [organizationId, projectId, targetId] = await Promise.all([
     translator.translateOrganizationId({
-      organization: input.organization,
+      organizationSlug: input.organizationSlug,
     }),
     translator.translateProjectId({
-      organization: input.organization,
-      project: input.project,
+      organizationSlug: input.organizationSlug,
+      projectSlug: input.projectSlug,
     }),
     translator.translateTargetId({
-      organization: input.organization,
-      project: input.project,
-      target: input.target,
+      organizationSlug: input.organizationSlug,
+      projectSlug: input.projectSlug,
+      targetSlug: input.targetSlug,
     }),
   ]);
 
@@ -50,9 +50,9 @@ export const updateTargetSlug: NonNullable<MutationResolvers['updateTargetSlug']
     return {
       ok: {
         selector: {
-          organization: input.organization,
-          project: input.project,
-          target: result.target.slug,
+          organizationSlug: input.organizationSlug,
+          projectSlug: input.projectSlug,
+          targetSlug: result.target.slug,
         },
         target: result.target,
       },

--- a/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetValidationSettings.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetValidationSettings.ts
@@ -15,7 +15,9 @@ export const updateTargetValidationSettings: NonNullable<
     translator.translateTargetId(input),
   ]);
 
-  const org = await injector.get(OrganizationManager).getOrganization({ organization });
+  const org = await injector
+    .get(OrganizationManager)
+    .getOrganization({ organizationId: organization });
 
   const UpdateTargetValidationSettingsModel = z.object({
     percentage: PercentageModel,
@@ -42,9 +44,9 @@ export const updateTargetValidationSettings: NonNullable<
   await targetManager.updateTargetValidationSettings({
     period: input.period,
     percentage: input.percentage,
-    target,
-    project,
-    organization,
+    targetId: target,
+    projectId: project,
+    organizationId: organization,
     targets: result.data.targetIds,
     excludedClients: result.data.excludedClients ?? [],
   });
@@ -52,9 +54,9 @@ export const updateTargetValidationSettings: NonNullable<
   return {
     ok: {
       target: await targetManager.getTarget({
-        organization,
-        project,
-        target,
+        organizationId: organization,
+        projectId: project,
+        targetId: target,
       }),
     },
   };

--- a/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetValidationSettings.ts
+++ b/packages/services/api/src/modules/target/resolvers/Mutation/updateTargetValidationSettings.ts
@@ -20,7 +20,7 @@ export const updateTargetValidationSettings: NonNullable<
   const UpdateTargetValidationSettingsModel = z.object({
     percentage: PercentageModel,
     period: z.number().min(1).max(org.monthlyRateLimit.retentionInDays).int(),
-    targets: z.array(z.string()).min(1),
+    targetIds: z.array(z.string()).min(1),
     excludedClients: z.optional(z.array(z.string())),
   });
 
@@ -45,7 +45,7 @@ export const updateTargetValidationSettings: NonNullable<
     target,
     project,
     organization,
-    targets: result.data.targets,
+    targets: result.data.targetIds,
     excludedClients: result.data.excludedClients ?? [],
   });
 

--- a/packages/services/api/src/modules/target/resolvers/Project.ts
+++ b/packages/services/api/src/modules/target/resolvers/Project.ts
@@ -4,8 +4,8 @@ import type { ProjectResolvers } from './../../../__generated__/types.next';
 export const Project: Pick<ProjectResolvers, 'targets' | '__isTypeOf'> = {
   targets: (project, _, { injector }) => {
     return injector.get(TargetManager).getTargets({
-      project: project.id,
-      organization: project.orgId,
+      projectId: project.id,
+      organizationId: project.orgId,
     });
   },
 };

--- a/packages/services/api/src/modules/target/resolvers/Query/target.ts
+++ b/packages/services/api/src/modules/target/resolvers/Query/target.ts
@@ -15,8 +15,8 @@ export const target: NonNullable<QueryResolvers['target']> = async (
   ]);
 
   return injector.get(TargetManager).getTarget({
-    organization,
-    target,
-    project,
+    organizationId: organization,
+    targetId: target,
+    projectId: project,
   });
 };

--- a/packages/services/api/src/modules/target/resolvers/Query/targets.ts
+++ b/packages/services/api/src/modules/target/resolvers/Query/targets.ts
@@ -14,7 +14,7 @@ export const targets: NonNullable<QueryResolvers['targets']> = async (
   ]);
 
   return injector.get(TargetManager).getTargets({
-    organization,
-    project,
+    organizationId: organization,
+    projectId: project,
   });
 };

--- a/packages/services/api/src/modules/target/resolvers/Target.ts
+++ b/packages/services/api/src/modules/target/resolvers/Target.ts
@@ -17,16 +17,16 @@ export const Target: Pick<
 > = {
   project: (target, _args, { injector }) =>
     injector.get(ProjectManager).getProject({
-      project: target.projectId,
-      organization: target.orgId,
+      projectId: target.projectId,
+      organizationId: target.orgId,
     }),
   validationSettings: async (target, _args, { injector }) => {
     const targetManager = injector.get(TargetManager);
 
     const settings = await targetManager.getTargetSettings({
-      organization: target.orgId,
-      project: target.projectId,
-      target: target.id,
+      organizationId: target.orgId,
+      projectId: target.projectId,
+      targetId: target.id,
     });
 
     return {
@@ -34,9 +34,9 @@ export const Target: Pick<
       targets: await Promise.all(
         settings.validation.targets.map(tid =>
           targetManager.getTarget({
-            organization: target.orgId,
-            project: target.projectId,
-            target: tid,
+            organizationId: target.orgId,
+            projectId: target.projectId,
+            targetId: tid,
           }),
         ),
       ),
@@ -46,7 +46,7 @@ export const Target: Pick<
     return injector
       .get(OrganizationManager)
       .getFeatureFlags({
-        organization: target.orgId,
+        organizationId: target.orgId,
       })
       .then(flags => flags.forceLegacyCompositionInTargets.includes(target.id));
   },

--- a/packages/services/api/src/modules/token/module.graphql.ts
+++ b/packages/services/api/src/modules/token/module.graphql.ts
@@ -56,9 +56,9 @@ export default gql`
   }
 
   input CreateTokenInput {
-    organization: ID!
-    project: ID!
-    target: ID!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
     name: String!
     organizationScopes: [OrganizationAccessScope!]!
     projectScopes: [ProjectAccessScope!]!
@@ -66,10 +66,10 @@ export default gql`
   }
 
   input DeleteTokensInput {
-    organization: ID!
-    project: ID!
-    target: ID!
-    tokens: [ID!]!
+    organizationSlug: String!
+    projectSlug: String!
+    targetSlug: String!
+    tokenIds: [ID!]!
   }
 
   type DeleteTokensPayload {

--- a/packages/services/api/src/modules/token/providers/token-manager.ts
+++ b/packages/services/api/src/modules/token/providers/token-manager.ts
@@ -42,9 +42,9 @@ export class TokenManager {
 
   async createToken(input: CreateTokenInput): Promise<CreateTokenResult> {
     await this.authManager.ensureTargetAccess({
-      project: input.project,
-      organization: input.organization,
-      target: input.target,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      targetId: input.targetId,
       scope: TargetAccessScope.TOKENS_WRITE,
     });
 
@@ -52,8 +52,8 @@ export class TokenManager {
 
     const currentUser = await this.authManager.getCurrentUser();
     const currentMember = await this.storage.getOrganizationMember({
-      organization: input.organization,
-      user: currentUser.id,
+      organizationId: input.organizationId,
+      userId: currentUser.id,
     });
 
     if (!currentMember) {
@@ -80,9 +80,9 @@ export class TokenManager {
     pushIfMissing(scopes, OrganizationAccessScope.READ);
 
     return this.tokenStorage.createToken({
-      organization: input.organization,
-      project: input.project,
-      target: input.target,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      targetId: input.targetId,
       name: input.name,
       scopes,
     });
@@ -95,9 +95,9 @@ export class TokenManager {
     targetId: string;
   }): Promise<readonly string[]> {
     await this.authManager.ensureTargetAccess({
-      project: input.projectId,
-      organization: input.organizationId,
-      target: input.targetId,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      targetId: input.targetId,
       scope: TargetAccessScope.TOKENS_WRITE,
     });
 

--- a/packages/services/api/src/modules/token/providers/token-manager.ts
+++ b/packages/services/api/src/modules/token/providers/token-manager.ts
@@ -88,15 +88,16 @@ export class TokenManager {
     });
   }
 
-  async deleteTokens(
-    input: {
-      tokens: readonly string[];
-    } & TargetSelector,
-  ): Promise<readonly string[]> {
+  async deleteTokens(input: {
+    tokenIds: readonly string[];
+    organizationId: string;
+    projectId: string;
+    targetId: string;
+  }): Promise<readonly string[]> {
     await this.authManager.ensureTargetAccess({
-      project: input.project,
-      organization: input.organization,
-      target: input.target,
+      project: input.projectId,
+      organization: input.organizationId,
+      target: input.targetId,
       scope: TargetAccessScope.TOKENS_WRITE,
     });
 

--- a/packages/services/api/src/modules/token/providers/token-storage.ts
+++ b/packages/services/api/src/modules/token/providers/token-storage.ts
@@ -61,9 +61,9 @@ export class TokenStorage {
 
     const response = await this.tokensService.createToken.mutate({
       name: input.name,
-      target: input.target,
-      project: input.project,
-      organization: input.organization,
+      target: input.targetId,
+      project: input.projectId,
+      organization: input.organizationId,
       scopes: input.scopes,
     });
 
@@ -96,7 +96,7 @@ export class TokenStorage {
     this.logger.debug('Fetching tokens (selector=%o)', selector);
 
     const response = await this.tokensService.targetTokens.query({
-      targetId: selector.target,
+      targetId: selector.targetId,
     });
 
     return response || [];

--- a/packages/services/api/src/modules/token/providers/token-storage.ts
+++ b/packages/services/api/src/modules/token/providers/token-storage.ts
@@ -70,16 +70,14 @@ export class TokenStorage {
     return response;
   }
 
-  async deleteTokens(
-    input: {
-      tokens: readonly string[];
-    } & TargetSelector,
-  ): Promise<readonly string[]> {
+  async deleteTokens(input: { tokenIds: readonly string[] }): Promise<readonly string[]> {
     this.logger.debug('Deleting tokens (input=%o)', input);
 
-    await Promise.all(input.tokens.map(token => this.tokensService.deleteToken.mutate({ token })));
+    await Promise.all(
+      input.tokenIds.map(token => this.tokensService.deleteToken.mutate({ token })),
+    );
 
-    return input.tokens;
+    return input.tokenIds;
   }
 
   async invalidateTokens(tokens: string[]) {

--- a/packages/services/api/src/modules/token/resolvers/Mutation/createToken.ts
+++ b/packages/services/api/src/modules/token/resolvers/Mutation/createToken.ts
@@ -32,9 +32,9 @@ export const createToken: NonNullable<MutationResolvers['createToken']> = async 
   ]);
   const token = await injector.get(TokenManager).createToken({
     name: input.name,
-    target,
-    project,
-    organization,
+    targetId: target,
+    projectId: project,
+    organizationId: organization,
     organizationScopes: input.organizationScopes,
     projectScopes: input.projectScopes,
     targetScopes: input.targetScopes,

--- a/packages/services/api/src/modules/token/resolvers/Mutation/createToken.ts
+++ b/packages/services/api/src/modules/token/resolvers/Mutation/createToken.ts
@@ -43,9 +43,9 @@ export const createToken: NonNullable<MutationResolvers['createToken']> = async 
   return {
     ok: {
       selector: {
-        organization: input.organization,
-        project: input.project,
-        target: input.target,
+        organizationSlug: input.organizationSlug,
+        projectSlug: input.projectSlug,
+        targetSlug: input.targetSlug,
       },
       createdToken: token,
       secret: token.secret,

--- a/packages/services/api/src/modules/token/resolvers/Mutation/deleteTokens.ts
+++ b/packages/services/api/src/modules/token/resolvers/Mutation/deleteTokens.ts
@@ -8,22 +8,22 @@ export const deleteTokens: NonNullable<MutationResolvers['deleteTokens']> = asyn
   { injector },
 ) => {
   const translator = injector.get(IdTranslator);
-  const [organization, project, target] = await Promise.all([
+  const [organizationId, projectId, targetId] = await Promise.all([
     translator.translateOrganizationId(input),
     translator.translateProjectId(input),
     translator.translateTargetId(input),
   ]);
   return {
     selector: {
-      organization: input.organization,
-      project: input.project,
-      target: input.target,
+      organizationSlug: input.organizationSlug,
+      projectSlug: input.projectSlug,
+      targetSlug: input.targetSlug,
     },
     deletedTokens: await injector.get(TokenManager).deleteTokens({
-      target,
-      project,
-      organization,
-      tokens: input.tokens,
+      targetId,
+      projectId,
+      organizationId,
+      tokenIds: input.tokenIds,
     }),
   };
 };

--- a/packages/services/api/src/modules/token/resolvers/Query/tokens.ts
+++ b/packages/services/api/src/modules/token/resolvers/Query/tokens.ts
@@ -15,8 +15,8 @@ export const tokens: NonNullable<QueryResolvers['tokens']> = async (
   ]);
 
   return injector.get(TokenManager).getTokens({
-    organization,
-    project,
-    target,
+    organizationId: organization,
+    projectId: project,
+    targetId: target,
   });
 };

--- a/packages/services/api/src/modules/token/resolvers/Target.ts
+++ b/packages/services/api/src/modules/token/resolvers/Target.ts
@@ -4,9 +4,9 @@ import type { TargetResolvers } from './../../../__generated__/types.next';
 export const Target: Pick<TargetResolvers, 'tokens' | '__isTypeOf'> = {
   tokens(target, _, { injector }) {
     return injector.get(TokenManager).getTokens({
-      target: target.id,
-      project: target.projectId,
-      organization: target.orgId,
+      targetId: target.id,
+      projectId: target.projectId,
+      organizationId: target.orgId,
     });
   },
 };

--- a/packages/services/api/src/modules/token/resolvers/TokenInfo.ts
+++ b/packages/services/api/src/modules/token/resolvers/TokenInfo.ts
@@ -12,20 +12,20 @@ export const TokenInfo: TokenInfoResolvers = {
   },
   organization(token, _, { injector }) {
     return injector.get(OrganizationManager).getOrganization({
-      organization: token.organization,
+      organizationId: token.organization,
     });
   },
   project(token, _, { injector }) {
     return injector.get(ProjectManager).getProject({
-      organization: token.organization,
-      project: token.project,
+      organizationId: token.organization,
+      projectId: token.project,
     });
   },
   target(token, _, { injector }) {
     return injector.get(TargetManager).getTarget({
-      organization: token.organization,
-      project: token.project,
-      target: token.target,
+      organizationId: token.organization,
+      projectId: token.project,
+      targetId: token.target,
     });
   },
   hasOrganizationScope(token, { scope }) {

--- a/packages/services/api/src/modules/usage-estimation/module.graphql.ts
+++ b/packages/services/api/src/modules/usage-estimation/module.graphql.ts
@@ -8,7 +8,7 @@ export default gql`
   input UsageEstimationInput {
     year: Int!
     month: Int!
-    organization: String!
+    organizationSlug: String!
   }
 
   type UsageEstimation {

--- a/packages/services/api/src/modules/usage-estimation/resolvers/Query/usageEstimation.ts
+++ b/packages/services/api/src/modules/usage-estimation/resolvers/Query/usageEstimation.ts
@@ -17,7 +17,7 @@ export const usageEstimation: NonNullable<QueryResolvers['usageEstimation']> = a
   });
 
   await injector.get(AuthManager).ensureOrganizationAccess({
-    organization: organizationId,
+    organizationId: organizationId,
     scope: OrganizationAccessScope.SETTINGS,
   });
 

--- a/packages/services/api/src/modules/usage-estimation/resolvers/Query/usageEstimation.ts
+++ b/packages/services/api/src/modules/usage-estimation/resolvers/Query/usageEstimation.ts
@@ -13,7 +13,7 @@ export const usageEstimation: NonNullable<QueryResolvers['usageEstimation']> = a
   { injector },
 ) => {
   const organizationId = await injector.get(IdTranslator).translateOrganizationId({
-    organization: args.input.organization,
+    organizationSlug: args.input.organizationSlug,
   });
 
   await injector.get(AuthManager).ensureOrganizationAccess({

--- a/packages/services/api/src/shared/helpers.ts
+++ b/packages/services/api/src/shared/helpers.ts
@@ -2,12 +2,7 @@ import { createHash } from 'node:crypto';
 import type { InjectionToken } from 'graphql-modules';
 import ms from 'ms';
 import { UTCDate } from '@date-fns/utc';
-import type {
-  DateRangeInput,
-  OrganizationSelector,
-  ProjectSelector,
-  TargetSelector,
-} from '../__generated__/types.next';
+import type { DateRangeInput } from '../__generated__/types.next';
 import { DateRange } from './entities';
 
 export {

--- a/packages/services/api/src/shared/helpers.ts
+++ b/packages/services/api/src/shared/helpers.ts
@@ -35,32 +35,6 @@ export function uuid(len = 13) {
   return Math.random().toString(16).substr(2, len);
 }
 
-export function filterSelector(
-  kind: 'organization',
-  selector: OrganizationSelector,
-): OrganizationSelector;
-export function filterSelector(kind: 'project', selector: ProjectSelector): ProjectSelector;
-export function filterSelector(kind: 'target', selector: TargetSelector): TargetSelector;
-export function filterSelector(kind: 'organization' | 'project' | 'target', selector: any): any {
-  switch (kind) {
-    case 'organization':
-      return {
-        organization: selector.organization,
-      };
-    case 'project':
-      return {
-        organization: selector.organization,
-        project: selector.project,
-      };
-    case 'target':
-      return {
-        organization: selector.organization,
-        project: selector.project,
-        target: selector.target,
-      };
-  }
-}
-
 export function stringifySelector<
   T extends {
     [key: string]: any;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -764,7 +764,7 @@ export async function createStorage(
           INSERT INTO organizations
             ("name", "clean_id", "user_id")
           VALUES
-            (${input.slug}, ${input.slug}, ${input.user})
+            (${input.slug}, ${input.slug}, ${input.userId})
           RETURNING *
         `,
         );
@@ -809,7 +809,7 @@ export async function createStorage(
             INSERT INTO organization_member
               ("organization_id", "user_id", "role_id")
             VALUES
-              (${org.id}, ${input.user}, ${adminRole.id})
+              (${org.id}, ${input.userId}, ${adminRole.id})
           `,
         );
 
@@ -819,7 +819,7 @@ export async function createStorage(
         };
       });
     },
-    async deleteOrganization({ organization }) {
+    async deleteOrganization({ organizationId: organization }) {
       const result = await tracedTransaction('DeleteOrganization', pool, async t => {
         const tokensResult = await t.query<Pick<tokens, 'token'>>(sql`/* findTokensForDeletion */
           SELECT token FROM tokens WHERE organization_id = ${organization} AND deleted_at IS NULL
@@ -842,7 +842,7 @@ export async function createStorage(
         tokens: result.tokens,
       };
     },
-    async createProject({ organization, slug, type }) {
+    async createProject({ organizationId: organization, slug, type }) {
       // Native Composition is enabled by default for fresh Federation-type projects
       return pool.transaction(async t => {
         const projectSlugExists = await t.exists(
@@ -872,11 +872,11 @@ export async function createStorage(
         };
       });
     },
-    async getOrganizationId({ organization }) {
+    async getOrganizationId({ organizationSlug }) {
       // Based on clean_id, resolve id
       const result = await pool.maybeOne<Pick<organizations, 'id'>>(
         sql`/* getOrganizationId */
-          SELECT id FROM organizations WHERE clean_id = ${organization} LIMIT 1
+          SELECT id FROM organizations WHERE clean_id = ${organizationSlug} LIMIT 1
         `,
       );
 
@@ -887,7 +887,7 @@ export async function createStorage(
       return result.id;
     },
     getOrganizationOwnerId: batch(async selectors => {
-      const organizations = selectors.map(s => s.organization);
+      const organizations = selectors.map(s => s.organizationId);
       const owners = await pool.query<Slonik<Pick<organizations, 'user_id' | 'id'>>>(
         sql`/* getOrganizationOwnerId */
         SELECT id, user_id
@@ -906,7 +906,7 @@ export async function createStorage(
       });
     }),
     getOrganizationOwner: batch(async selectors => {
-      const organizations = selectors.map(s => s.organization);
+      const organizations = selectors.map(s => s.organizationId);
       const owners = await pool.query<
         users &
           Pick<organization_member, 'scopes' | 'organization_id' | 'connected_to_zendesk'> &
@@ -949,7 +949,7 @@ export async function createStorage(
         return Promise.reject(new Error(`Owner not found (organization=${organization})`));
       });
     }),
-    async countOrganizationMembers({ organization }) {
+    async countOrganizationMembers({ organizationId: organization }) {
       const { total } = await pool.one<{ total: number }>(
         sql`/* countOrganizationMembers */ SELECT COUNT(*) as total FROM organization_member WHERE organization_id = ${organization}`,
       );
@@ -957,7 +957,7 @@ export async function createStorage(
       return total;
     },
     getOrganizationMembers: batch(async selectors => {
-      const organizations = selectors.map(s => s.organization);
+      const organizations = selectors.map(s => s.organizationId);
       const allMembers = await pool.query<
         users &
           Pick<organization_member, 'scopes' | 'organization_id' | 'connected_to_zendesk'> & {
@@ -1028,7 +1028,7 @@ export async function createStorage(
           LEFT JOIN organization_member_roles as omr ON (omr.organization_id = o.id AND omr.id = om.role_id)
           LEFT JOIN supertokens_thirdparty_users as stu ON (stu.user_id = u.supertoken_user_id)
           WHERE (om.organization_id, om.user_id) IN ((${sql.join(
-            selectors.map(s => sql`${s.organization}, ${s.user}`),
+            selectors.map(s => sql`${s.organizationId}, ${s.userId}`),
             sql`), (`,
           )}))
           ORDER BY u.created_at DESC
@@ -1037,7 +1037,7 @@ export async function createStorage(
 
       return selectors.map(selector => {
         const member = membersResult.rows.find(
-          row => row.organization_id === selector.organization && row.id === selector.user,
+          row => row.organization_id === selector.organizationId && row.id === selector.userId,
         );
 
         if (member) {
@@ -1114,7 +1114,7 @@ export async function createStorage(
       `);
     },
     getOrganizationInvitations: batch(async selectors => {
-      const organizations = selectors.map(s => s.organization);
+      const organizations = selectors.map(s => s.organizationId);
       const allInvitations = await pool.query<
         organization_invitations & {
           role: organization_member_roles;
@@ -1209,13 +1209,13 @@ export async function createStorage(
           FROM organization_member as om
           LEFT JOIN organization_member_roles as omr ON (omr.organization_id = om.organization_id AND omr.id = om.role_id)
           WHERE (om.organization_id, om.user_id) IN ((${sql.join(
-            pairs.map(p => sql`${p.organization}, ${p.user}`),
+            pairs.map(p => sql`${p.organizationId}, ${p.userId}`),
             sql`), (`,
           )}))
         `,
       );
 
-      return pairs.map(({ organization, user }) => {
+      return pairs.map(({ organizationId: organization, userId: user }) => {
         return (results.rows.find(
           row => row.organization_id === organization && row.user_id === user,
         )?.scopes || []) as Member['scopes'];
@@ -1227,13 +1227,13 @@ export async function createStorage(
           SELECT organization_id, user_id
           FROM organization_member
           WHERE (organization_id, user_id) IN ((${sql.join(
-            pairs.map(p => sql`${p.organization}, ${p.user}`),
+            pairs.map(p => sql`${p.organizationId}, ${p.userId}`),
             sql`), (`,
           )}))
         `,
       );
 
-      return pairs.map(({ organization, user }) =>
+      return pairs.map(({ organizationId: organization, userId: user }) =>
         results.rows.some(row => row.organization_id === organization && row.user_id === user),
       );
     },
@@ -1244,13 +1244,13 @@ export async function createStorage(
           FROM projects as p
           LEFT JOIN organization_member as om ON (p.org_id = om.organization_id)
           WHERE (om.organization_id, om.user_id, p.id) IN ((${sql.join(
-            pairs.map(p => sql`${p.organization}, ${p.user}, ${p.project}`),
+            pairs.map(p => sql`${p.organizationId}, ${p.userId}, ${p.projectId}`),
             sql`), (`,
           )}))
         `,
       );
 
-      return pairs.map(({ organization, user, project }) =>
+      return pairs.map(({ organizationId: organization, userId: user, projectId: project }) =>
         results.rows.some(
           row =>
             row.organization_id === organization &&
@@ -1259,7 +1259,7 @@ export async function createStorage(
         ),
       );
     },
-    async updateOrganizationSlug({ slug, organization, reservedSlugs }) {
+    async updateOrganizationSlug({ slug, organizationId: organization, reservedSlugs }) {
       return pool.transaction(async t => {
         if (reservedSlugs.includes(slug)) {
           return {
@@ -1293,7 +1293,7 @@ export async function createStorage(
       });
     },
 
-    async updateOrganizationPlan({ billingPlan, organization }) {
+    async updateOrganizationPlan({ billingPlan, organizationId: organization }) {
       return transformOrganization(
         await pool.one<Slonik<organizations>>(sql`/* updateOrganizationPlan */
           UPDATE organizations
@@ -1303,7 +1303,7 @@ export async function createStorage(
         `),
       );
     },
-    async updateOrganizationRateLimits({ monthlyRateLimit, organization }) {
+    async updateOrganizationRateLimits({ monthlyRateLimit, organizationId: organization }) {
       return transformOrganization(
         await pool.one<Slonik<organizations>>(sql`/* updateOrganizationRateLimits */ 
           UPDATE organizations
@@ -1313,7 +1313,7 @@ export async function createStorage(
         `),
       );
     },
-    async createOrganizationInvitation({ organization, email, roleId }) {
+    async createOrganizationInvitation({ organizationId: organization, email, roleId }) {
       return transformOrganizationInvitation(
         await tracedTransaction('createOrganizationInvitation', pool, async trx => {
           const invitation =
@@ -1334,7 +1334,7 @@ export async function createStorage(
         }),
       );
     },
-    async deleteOrganizationInvitationByEmail({ organization, email }) {
+    async deleteOrganizationInvitationByEmail({ organizationId: organization, email }) {
       const result = await tracedTransaction(
         'deleteOrganizationInvitationByEmail',
         pool,
@@ -1367,7 +1367,11 @@ export async function createStorage(
 
       return transformOrganizationInvitation(result);
     },
-    async addOrganizationMemberViaInvitationCode({ code, user, organization }) {
+    async addOrganizationMemberViaInvitationCode({
+      code,
+      userId: user,
+      organizationId: organization,
+    }) {
       await tracedTransaction('addOrganizationMemberViaInvitationCode', pool, async trx => {
         const roleId = await trx.oneFirst<string>(sql`/* deleteInviteAndGetRoleId */
           DELETE FROM organization_invitations
@@ -1385,7 +1389,7 @@ export async function createStorage(
         );
       });
     },
-    async createOrganizationTransferRequest({ organization, user }) {
+    async createOrganizationTransferRequest({ organizationId: organization, userId: user }) {
       const code = Math.random().toString(16).substring(2, 12);
 
       await pool.query<Slonik<Pick<organizations, 'ownership_transfer_code'>>>(
@@ -1403,7 +1407,7 @@ export async function createStorage(
         code,
       };
     },
-    async getOrganizationTransferRequest({ code, user, organization }) {
+    async getOrganizationTransferRequest({ code, userId: user, organizationId: organization }) {
       return pool.maybeOne<{
         code: string;
       }>(sql`/* getOrganizationTransferRequest */
@@ -1415,7 +1419,12 @@ export async function createStorage(
           AND ownership_transfer_expires_at > NOW()
       `);
     },
-    async answerOrganizationTransferRequest({ organization, user, code, accept }) {
+    async answerOrganizationTransferRequest({
+      organizationId: organization,
+      userId: user,
+      code,
+      accept,
+    }) {
       await tracedTransaction('answerOrganizationTransferRequest', pool, async tsx => {
         const owner = await tsx.maybeOne<
           Slonik<Pick<organizations, 'user_id'>>
@@ -1476,7 +1485,7 @@ export async function createStorage(
         `);
       });
     },
-    async deleteOrganizationMember({ user, organization }) {
+    async deleteOrganizationMember({ userId: user, organizationId: organization }) {
       await pool.query<organization_member>(
         sql`/* deleteOrganizationMember */
           DELETE FROM organization_member
@@ -1484,7 +1493,7 @@ export async function createStorage(
         `,
       );
     },
-    async updateOrganizationMemberAccess({ user, organization, scopes }) {
+    async updateOrganizationMemberAccess({ userId: user, organizationId: organization, scopes }) {
       await pool.query<Slonik<organization_member>>(
         sql`/* updateOrganizationMemberAccess */
           UPDATE organization_member
@@ -1539,59 +1548,49 @@ export async function createStorage(
         `,
       );
     },
-    async getProjectId({ project, organization }) {
+    async getProjectId({ projectSlug, organizationSlug }) {
       // Based on project's clean_id and organization's clean_id, resolve the actual uuid of the project
       const result = await pool.one<Pick<projects, 'id'>>(
         sql`/* getProjectId */
         SELECT p.id as id
         FROM projects as p
         LEFT JOIN organizations as org ON (p.org_id = org.id)
-        WHERE p.clean_id = ${project} AND org.clean_id = ${organization} AND p.type != 'CUSTOM' LIMIT 1`,
+        WHERE p.clean_id = ${projectSlug} AND org.clean_id = ${organizationSlug} AND p.type != 'CUSTOM' LIMIT 1`,
       );
 
       return result.id;
     },
-    async getTargetId({ project, target, organization, useIds }) {
-      if (useIds) {
-        const result = await pool.one<Pick<targets, 'id'>>(
-          sql`/* getTargetId (ids) */
-          SELECT t.id FROM targets as t
-          LEFT JOIN projects AS p ON (p.id = t.project_id)
-          LEFT JOIN organizations AS o ON (o.id = p.org_id)
-          WHERE t.clean_id = ${target} AND p.id = ${project} AND o.id = ${organization} AND p.type != 'CUSTOM'
-          LIMIT 1`,
-        );
-
-        return result.id;
-      }
-
-      // Based on clean_id, resolve id
+    async getTargetId(selector) {
       const result = await pool.one<Pick<targets, 'id'>>(
         sql`/* getTargetId (slug) */
           SELECT t.id FROM targets as t
           LEFT JOIN projects AS p ON (p.id = t.project_id)
           LEFT JOIN organizations AS o ON (o.id = p.org_id)
-          WHERE t.clean_id = ${target} AND p.clean_id = ${project} AND o.clean_id = ${organization} AND p.type != 'CUSTOM'
+          WHERE 
+            t.clean_id = ${selector.targetSlug} AND
+            p.clean_id = ${selector.projectSlug} AND
+            o.clean_id = ${selector.organizationSlug} AND
+            p.type != 'CUSTOM'
           LIMIT 1`,
       );
 
       return result.id;
     },
-    async getOrganization({ organization }) {
+    async getOrganization({ organizationId }) {
       return transformOrganization(
         await pool.one<Slonik<organizations>>(
-          sql`/* getOrganization */ SELECT * FROM organizations WHERE id = ${organization} LIMIT 1`,
+          sql`/* getOrganization */ SELECT * FROM organizations WHERE id = ${organizationId} LIMIT 1`,
         ),
       );
     },
-    async getMyOrganization({ user }) {
+    async getMyOrganization({ userId: user }) {
       const org = await pool.maybeOne<Slonik<organizations>>(
         sql`/* getMyOrganization */ SELECT * FROM organizations WHERE user_id = ${user} AND type = ${'PERSONAL'} LIMIT 1`,
       );
 
       return org ? transformOrganization(org) : null;
     },
-    async getOrganizations({ user }) {
+    async getOrganizations({ userId: user }) {
       const results = await pool.query<Slonik<organizations>>(
         sql`/* getOrganizations */
           SELECT o.*
@@ -1647,14 +1646,14 @@ export async function createStorage(
 
       return null;
     },
-    async getProject({ project }) {
+    async getProject({ projectId: project }) {
       return transformProject(
         await pool.one<Slonik<projects>>(
           sql`/* getProject */ SELECT * FROM projects WHERE id = ${project} AND type != 'CUSTOM' LIMIT 1`,
         ),
       );
     },
-    async getProjectBySlug({ slug, organization }) {
+    async getProjectBySlug({ slug, organizationId: organization }) {
       const result = await pool.maybeOne<Slonik<projects>>(
         sql`/* getProjectBySlug */ SELECT * FROM projects WHERE clean_id = ${slug} AND org_id = ${organization} AND type != 'CUSTOM' LIMIT 1`,
       );
@@ -1665,14 +1664,14 @@ export async function createStorage(
 
       return transformProject(result);
     },
-    async getProjects({ organization }) {
+    async getProjects({ organizationId: organization }) {
       const result = await pool.query<Slonik<projects>>(
         sql`/* getProjects */ SELECT * FROM projects WHERE org_id = ${organization} AND type != 'CUSTOM' ORDER BY created_at DESC`,
       );
 
       return result.rows.map(transformProject);
     },
-    async updateProjectSlug({ slug, organization, project }) {
+    async updateProjectSlug({ slug, organizationId: organization, projectId: project }) {
       return pool.transaction(async t => {
         const projectSlugExists = await t.exists(
           sql`/* projectSlugExists */ SELECT 1 FROM projects WHERE clean_id = ${slug} AND id != ${project} AND org_id = ${organization} LIMIT 1`,
@@ -1698,7 +1697,7 @@ export async function createStorage(
         };
       });
     },
-    async updateNativeSchemaComposition({ project, enabled }) {
+    async updateNativeSchemaComposition({ projectId: project, enabled }) {
       return transformProject(
         await pool.one<projects>(sql`/* updateNativeSchemaComposition */
           UPDATE projects
@@ -1709,7 +1708,7 @@ export async function createStorage(
         `),
       );
     },
-    async enableExternalSchemaComposition({ project, endpoint, encryptedSecret }) {
+    async enableExternalSchemaComposition({ projectId: project, endpoint, encryptedSecret }) {
       return transformProject(
         await pool.one<Slonik<projects>>(sql`/* enableExternalSchemaComposition */
           UPDATE projects
@@ -1722,7 +1721,7 @@ export async function createStorage(
         `),
       );
     },
-    async disableExternalSchemaComposition({ project }) {
+    async disableExternalSchemaComposition({ projectId: project }) {
       return transformProject(
         await pool.one<Slonik<projects>>(sql`/* disableExternalSchemaComposition */
           UPDATE projects
@@ -1735,7 +1734,7 @@ export async function createStorage(
         `),
       );
     },
-    async enableProjectNameInGithubCheck({ project }) {
+    async enableProjectNameInGithubCheck({ projectId: project }) {
       return transformProject(
         await pool.one<projects>(sql`/* enableProjectNameInGithubCheck */
           UPDATE projects
@@ -1745,7 +1744,7 @@ export async function createStorage(
         `),
       );
     },
-    async updateProjectRegistryModel({ project, model }) {
+    async updateProjectRegistryModel({ projectId: project, model }) {
       const isLegacyModel = model === 'LEGACY';
 
       return transformProject(
@@ -1758,7 +1757,7 @@ export async function createStorage(
       );
     },
 
-    async deleteProject({ organization, project }) {
+    async deleteProject({ organizationId: organization, projectId: project }) {
       const result = await tracedTransaction('deleteProject', pool, async t => {
         const tokensResult = await t.query<Pick<tokens, 'token'>>(sql`/* deleteProject */
           SELECT token FROM tokens WHERE project_id = ${project} AND deleted_at IS NULL
@@ -1781,7 +1780,7 @@ export async function createStorage(
         tokens: result.tokens,
       };
     },
-    async createTarget({ organization, project, slug }) {
+    async createTarget({ organizationId: organization, projectId: project, slug }) {
       return pool.transaction(async t => {
         const targetSlugExists = await t.exists(
           sql`/* targetSlugExists */ SELECT 1 FROM targets WHERE clean_id = ${slug} AND project_id = ${project} LIMIT 1`,
@@ -1812,7 +1811,12 @@ export async function createStorage(
         };
       });
     },
-    async updateTargetSlug({ slug, organization, project, target }) {
+    async updateTargetSlug({
+      slug,
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
+    }) {
       return pool.transaction(async t => {
         const targetSlugExists = await t.exists(
           sql`/* targetSlugExists */ SELECT 1 FROM targets WHERE clean_id = ${slug} AND id != ${target} AND project_id = ${project} LIMIT 1`,
@@ -1841,7 +1845,7 @@ export async function createStorage(
         };
       });
     },
-    async deleteTarget({ organization, target }) {
+    async deleteTarget({ organizationId: organization, targetId: target }) {
       const result = await tracedTransaction('deleteTarget', pool, async t => {
         const tokensResult = await t.query<Pick<tokens, 'token'>>(sql`/* findTokensForDeletion */
           SELECT token FROM tokens WHERE target_id = ${target} AND deleted_at IS NULL
@@ -1875,18 +1879,18 @@ export async function createStorage(
     getTarget: batch(
       async (
         selectors: Array<{
-          organization: string;
-          project: string;
-          target: string;
+          organizationId: string;
+          projectId: string;
+          targetId: string;
         }>,
       ) => {
         const uniqueSelectorsMap = new Map<string, (typeof selectors)[0]>();
 
         for (const selector of selectors) {
           const key = JSON.stringify({
-            organization: selector.organization,
-            project: selector.project,
-            target: selector.target,
+            organization: selector.organizationId,
+            project: selector.projectId,
+            target: selector.targetId,
           });
 
           uniqueSelectorsMap.set(key, selector);
@@ -1904,7 +1908,7 @@ export async function createStorage(
               WHERE
                 (id, project_id) IN (
                   (${sql.join(
-                    uniqueSelectors.map(s => sql`${s.target}, ${s.project}`),
+                    uniqueSelectors.map(s => sql`${s.targetId}, ${s.projectId}`),
                     sql`), (`,
                   )})
                 )
@@ -1914,25 +1918,25 @@ export async function createStorage(
 
         return selectors.map(selector => {
           const row = rows.find(
-            row => row.id === selector.target && row.projectId === selector.project,
+            row => row.id === selector.targetId && row.projectId === selector.projectId,
           );
 
           if (!row) {
             return Promise.reject(
               new Error(
-                `Target not found (target=${selector.target}, project=${selector.project})`,
+                `Target not found (target=${selector.targetId}, project=${selector.projectId})`,
               ),
             );
           }
 
           return Promise.resolve({
             ...row,
-            orgId: selector.organization,
+            orgId: selector.organizationId,
           });
         });
       },
     ),
-    async getTargetBySlug({ organization, project, slug }) {
+    async getTargetBySlug({ organizationId: organization, projectId: project, slug }) {
       const result = await pool.maybeOne<unknown>(sql`/* getTargetBySlug */
         SELECT
           ${targetSQLFields}
@@ -1953,7 +1957,7 @@ export async function createStorage(
         orgId: organization,
       };
     },
-    async getTargets({ organization, project }) {
+    async getTargets({ organizationId: organization, projectId: project }) {
       const results = await pool.query<unknown>(sql`/* getTargets */
         SELECT
           ${targetSQLFields}
@@ -1970,7 +1974,7 @@ export async function createStorage(
         orgId: organization,
       }));
     },
-    async getTargetIdsOfOrganization({ organization }) {
+    async getTargetIdsOfOrganization({ organizationId: organization }) {
       const results = await pool.query<Slonik<Pick<targets, 'id'>>>(
         sql`/* getTargetIdsOfOrganization */
           SELECT t.id as id FROM targets as t
@@ -1982,7 +1986,7 @@ export async function createStorage(
 
       return results.rows.map(r => r.id);
     },
-    async getTargetIdsOfProject({ project }) {
+    async getTargetIdsOfProject({ projectId: project }) {
       const results = await pool.query<Slonik<Pick<targets, 'id'>>>(
         sql`/* getTargetIdsOfProject */
           SELECT id FROM targets WHERE project_id = ${project}
@@ -1991,7 +1995,7 @@ export async function createStorage(
 
       return results.rows.map(r => r.id);
     },
-    async getTargetSettings({ target, project }) {
+    async getTargetSettings({ targetId: target, projectId: project }) {
       const row = await pool.one<
         Pick<
           targets,
@@ -2018,7 +2022,7 @@ export async function createStorage(
 
       return transformTargetSettings(row);
     },
-    async setTargetValidation({ target, project, enabled }) {
+    async setTargetValidation({ targetId: target, projectId: project, enabled }) {
       return transformTargetSettings(
         await tracedTransaction('setTargetValidation', pool, async trx => {
           const targetValidationRowExists = await trx.exists(sql`/* findTargetValidation */
@@ -2062,8 +2066,8 @@ export async function createStorage(
       ).validation;
     },
     async updateTargetValidationSettings({
-      target,
-      project,
+      targetId: target,
+      projectId: project,
       percentage,
       period,
       targets,
@@ -2114,7 +2118,7 @@ export async function createStorage(
       ).validation;
     },
 
-    async countSchemaVersionsOfProject({ project, period }) {
+    async countSchemaVersionsOfProject({ projectId: project, period }) {
       if (period) {
         const result = await pool.maybeOne<{
           total: number;
@@ -2137,7 +2141,7 @@ export async function createStorage(
 
       return result?.total ?? 0;
     },
-    async countSchemaVersionsOfTarget({ target, period }) {
+    async countSchemaVersionsOfTarget({ targetId: target, period }) {
       if (period) {
         const result = await pool.maybeOne<{
           total: number;
@@ -2158,14 +2162,14 @@ export async function createStorage(
       return result?.total ?? 0;
     },
 
-    async hasSchema({ target }) {
+    async hasSchema({ targetId: target }) {
       return pool.exists(
         sql`/* hasSchema */
           SELECT 1 FROM schema_versions as v WHERE v.target_id = ${target} LIMIT 1
         `,
       );
     },
-    async getMaybeLatestValidVersion({ target }) {
+    async getMaybeLatestValidVersion({ targetId: target }) {
       const version = await pool.maybeOne<unknown>(
         sql`/* getMaybeLatestValidVersion */
           SELECT
@@ -2183,7 +2187,7 @@ export async function createStorage(
 
       return SchemaVersionModel.parse(version);
     },
-    async getLatestValidVersion({ target }) {
+    async getLatestValidVersion({ targetId: target }) {
       const version = await pool.maybeOne<unknown>(
         sql`/* getLatestValidVersion */
           SELECT
@@ -2197,7 +2201,7 @@ export async function createStorage(
 
       return SchemaVersionModel.parse(version);
     },
-    async getLatestVersion({ project, target }) {
+    async getLatestVersion({ projectId: project, targetId: target }) {
       const version = await pool.maybeOne<unknown>(
         sql`/* getLatestVersion */
           SELECT
@@ -2213,7 +2217,7 @@ export async function createStorage(
       return SchemaVersionModel.parse(version);
     },
 
-    async getMaybeLatestVersion({ project, target }) {
+    async getMaybeLatestVersion({ projectId: project, targetId: target }) {
       const version = await pool.maybeOne<unknown>(
         sql`/* getMaybeLatestVersion */
           SELECT
@@ -2239,7 +2243,7 @@ export async function createStorage(
             ${schemaVersionSQLFields()}
           FROM "schema_versions"
           WHERE
-            "target_id" = ${args.target}
+            "target_id" = ${args.targetId}
             AND (
               (
                 "created_at" = ${args.beforeVersionCreatedAt}
@@ -2260,7 +2264,7 @@ export async function createStorage(
 
       return SchemaVersionModel.parse(version);
     },
-    async getLatestSchemas({ project, target, onlyComposable }) {
+    async getLatestSchemas({ projectId: project, targetId: target, onlyComposable }) {
       const latest = await pool.maybeOne<
         Pick<schema_versions, 'id' | 'is_composable'>
       >(sql`/* getLatestSchemas */
@@ -2280,12 +2284,12 @@ export async function createStorage(
       }
 
       const schemas = await storage.getSchemasOfVersion({
-        version: latest.id,
+        versionId: latest.id,
         includeMetadata: true,
       });
 
       return {
-        version: latest.id,
+        versionId: latest.id,
         valid: latest.is_composable,
         schemas,
       };
@@ -2340,7 +2344,7 @@ export async function createStorage(
 
       return transformSchema(result);
     },
-    async getSchemasOfVersion({ version, includeMetadata = false }) {
+    async getSchemasOfVersion({ versionId: version, includeMetadata = false }) {
       const result = await pool.query<
         Pick<
           OverrideProp<schema_log, 'action', 'PUSH'>,
@@ -2386,7 +2390,7 @@ export async function createStorage(
 
       return result.rows.map(transformSchema);
     },
-    async getSchemasOfPreviousVersion({ version, target, onlyComposable }) {
+    async getSchemasOfPreviousVersion({ versionId: version, targetId: target, onlyComposable }) {
       const results = await pool.query<
         OverrideProp<schema_log, 'action', 'PUSH'> &
           Pick<projects, 'type'> &
@@ -2495,7 +2499,7 @@ export async function createStorage(
       return { serviceName: after.service_name, after: after.sdl, before: before?.sdl ?? null };
     },
 
-    async getVersion({ project, target, version }) {
+    async getVersion({ projectId: project, targetId: target, versionId: version }) {
       const result = await pool.one(sql`/* getVersion */
         SELECT 
           ${schemaVersionSQLFields(sql`sv.`)}
@@ -2586,7 +2590,7 @@ export async function createStorage(
           sql`/* findLatestSchemaVersion */
           SELECT sv.id, sv.base_schema
           FROM schema_versions as sv
-          WHERE sv.target_id = ${args.target}
+          WHERE sv.target_id = ${args.targetId}
           ORDER BY sv.created_at DESC
           LIMIT 1
         `,
@@ -2608,8 +2612,8 @@ export async function createStorage(
               ${'system'}::text,
               ${'system'}::text,
               lower(${args.serviceName}::text),
-              ${args.project},
-              ${args.target},
+              ${args.projectId},
+              ${args.targetId},
               'DELETE'
             )
           RETURNING *
@@ -2618,7 +2622,7 @@ export async function createStorage(
         // creates a new version
         const newVersion = await insertSchemaVersion(trx, {
           isComposable: args.composable,
-          targetId: args.target,
+          targetId: args.targetId,
           actionId: deleteActionResult.id,
           baseSchema: latestVersion.base_schema,
           previousSchemaVersion: latestVersion.id,
@@ -2660,7 +2664,7 @@ export async function createStorage(
 
         if (args.coordinatesDiff) {
           await updateSchemaCoordinateStatus(trx, {
-            targetId: args.target,
+            targetId: args.targetId,
             versionId: newVersion.id,
             coordinatesDiff: args.coordinatesDiff,
           });
@@ -2719,8 +2723,8 @@ export async function createStorage(
               ${url}::text,
               ${input.commit}::text,
               ${input.schema}::text,
-              ${input.project},
-              ${input.target},
+              ${input.projectId},
+              ${input.targetId},
               ${input.metadata},
               'PUSH'
             )
@@ -2730,7 +2734,7 @@ export async function createStorage(
         // creates a new version
         const version = await insertSchemaVersion(trx, {
           isComposable: input.valid,
-          targetId: input.target,
+          targetId: input.targetId,
           actionId: log.id,
           baseSchema: input.base_schema,
           previousSchemaVersion: input.previousSchemaVersion,
@@ -2780,7 +2784,7 @@ export async function createStorage(
 
         if (input.coordinatesDiff) {
           await updateSchemaCoordinateStatus(trx, {
-            targetId: input.target,
+            targetId: input.targetId,
             versionId: version.id,
             coordinatesDiff: input.coordinatesDiff,
           });
@@ -2818,7 +2822,7 @@ export async function createStorage(
       return changes.rows.map(row => HiveSchemaChangeModel.parse(row));
     },
 
-    async updateVersionStatus({ version, valid }) {
+    async updateVersionStatus({ versionId: version, valid }) {
       return SchemaVersionModel.parse(
         await pool.maybeOne<unknown>(sql`/* updateVersionStatus */
           UPDATE
@@ -2840,7 +2844,7 @@ export async function createStorage(
             FROM schema_log as sl
             LEFT JOIN projects as p ON (p.id = sl.project_id)
             WHERE (sl.id, sl.target_id) IN ((${sql.join(
-              selectors.map(s => sql`${s.commit}, ${s.target}`),
+              selectors.map(s => sql`${s.commit}, ${s.targetId}`),
               sql`), (`,
             )}))
         `,
@@ -2849,7 +2853,7 @@ export async function createStorage(
 
       return selectors.map(selector => {
         const schema = schemas.find(
-          row => row.id === selector.commit && row.target === selector.target,
+          row => row.id === selector.commit && row.target === selector.targetId,
         );
 
         if (schema) {
@@ -2857,11 +2861,20 @@ export async function createStorage(
         }
 
         return Promise.reject(
-          new Error(`Schema log not found (commit=${selector.commit}, target=${selector.target})`),
+          new Error(
+            `Schema log not found (commit=${selector.commit}, target=${selector.targetId})`,
+          ),
         );
       });
     }),
-    async createActivity({ organization, project, target, user, type, meta }) {
+    async createActivity({
+      organizationId: organization,
+      projectId: project,
+      targetId: target,
+      userId: user,
+      type,
+      meta,
+    }) {
       const { identifiers, values } = objectToParams<Omit<activities, 'id' | 'created_at'>>({
         activity_metadata: meta,
         activity_type: type,
@@ -2875,7 +2888,7 @@ export async function createStorage(
         sql`/* createActivity */ INSERT INTO activities (${identifiers}) VALUES (${values}) RETURNING *;`,
       );
     },
-    async addSlackIntegration({ organization, token }) {
+    async addSlackIntegration({ organizationId: organization, token }) {
       await pool.query<Slonik<organizations>>(
         sql`/* addSlackIntegration */
           UPDATE organizations
@@ -2884,7 +2897,7 @@ export async function createStorage(
         `,
       );
     },
-    async deleteSlackIntegration({ organization }) {
+    async deleteSlackIntegration({ organizationId: organization }) {
       await pool.query<Slonik<organizations>>(
         sql`/* deleteSlackIntegration */
           UPDATE organizations
@@ -2893,7 +2906,7 @@ export async function createStorage(
         `,
       );
     },
-    async getSlackIntegrationToken({ organization }) {
+    async getSlackIntegrationToken({ organizationId: organization }) {
       const result = await pool.maybeOne<Pick<organizations, 'slack_token'>>(
         sql`/* getSlackIntegrationToken */
           SELECT slack_token
@@ -2904,7 +2917,7 @@ export async function createStorage(
 
       return result?.slack_token;
     },
-    async addGitHubIntegration({ organization, installationId }) {
+    async addGitHubIntegration({ organizationId: organization, installationId }) {
       await pool.query<Slonik<organizations>>(
         sql`/* addGitHubIntegration */
           UPDATE organizations
@@ -2913,7 +2926,7 @@ export async function createStorage(
         `,
       );
     },
-    async deleteGitHubIntegration({ organization }) {
+    async deleteGitHubIntegration({ organizationId: organization }) {
       await pool.query<Slonik<organizations>>(
         sql`/* deleteGitHubIntegration */
           UPDATE organizations
@@ -2929,7 +2942,7 @@ export async function createStorage(
         `,
       );
     },
-    async getGitHubIntegrationInstallationId({ organization }) {
+    async getGitHubIntegrationInstallationId({ organizationId: organization }) {
       const result = await pool.maybeOne<Pick<organizations, 'github_app_installation_id'>>(
         sql`/* getGitHubIntegrationInstallationId */
           SELECT github_app_installation_id
@@ -2966,7 +2979,7 @@ export async function createStorage(
 
       return result.rows.map(transformAlertChannel);
     },
-    async getAlertChannels({ project }) {
+    async getAlertChannels({ projectId: project }) {
       const result = await pool.query<Slonik<alert_channels>>(
         sql`/* getAlertChannels */ SELECT * FROM alert_channels WHERE project_id = ${project} ORDER BY created_at DESC`,
       );
@@ -2988,7 +3001,7 @@ export async function createStorage(
         organizationId,
       );
     },
-    async deleteAlerts({ organization, project, alerts }) {
+    async deleteAlerts({ organizationId: organization, projectId: project, alertIds: alerts }) {
       const result = await pool.query<Slonik<alerts>>(
         sql`/* deleteAlerts */
           DELETE FROM alerts
@@ -3001,7 +3014,7 @@ export async function createStorage(
 
       return result.rows.map(row => transformAlert(row, organization));
     },
-    async getAlerts({ organization, project }) {
+    async getAlerts({ organizationId: organization, projectId: project }) {
       const result = await pool.query<Slonik<alerts>>(
         sql`/* getAlerts */ SELECT * FROM alerts WHERE project_id = ${project} ORDER BY created_at DESC`,
       );
@@ -3183,13 +3196,13 @@ export async function createStorage(
 
       return rows;
     },
-    async getBaseSchema({ project, target }) {
+    async getBaseSchema({ projectId: project, targetId: target }) {
       const data = await pool.maybeOne<Record<string, string>>(
         sql`/* getBaseSchema */ SELECT base_schema FROM targets WHERE id=${target} AND project_id=${project}`,
       );
       return data?.base_schema ?? null;
     },
-    async updateBaseSchema({ project, target }, base) {
+    async updateBaseSchema({ projectId: project, targetId: target }, base) {
       if (base) {
         await pool.query(
           sql`/* updateBaseSchema */ UPDATE targets SET base_schema = ${base} WHERE id = ${target} AND project_id = ${project}`,
@@ -3209,7 +3222,7 @@ export async function createStorage(
     },
     async getOrganizationBilling(selector) {
       const results = await pool.query<Slonik<organizations_billing>>(
-        sql`/* getOrganizationBilling */ SELECT * FROM organizations_billing WHERE organization_id = ${selector.organization}`,
+        sql`/* getOrganizationBilling */ SELECT * FROM organizations_billing WHERE organization_id = ${selector.organizationId}`,
       );
 
       const mapped = results.rows.map(transformOrganizationBilling);
@@ -3220,7 +3233,7 @@ export async function createStorage(
       await pool.query<Slonik<organizations_billing>>(
         sql`/* deleteOrganizationBilling */ 
           DELETE FROM organizations_billing
-          WHERE organization_id = ${selector.organization}`,
+          WHERE organization_id = ${selector.organizationId}`,
       );
     },
     async createOrganizationBilling({
@@ -3240,7 +3253,7 @@ export async function createStorage(
         ),
       );
     },
-    async completeGetStartedStep({ organization, step }) {
+    async completeGetStartedStep({ organizationId: organization, step }) {
       await update(
         pool,
         'organizations',
@@ -3623,7 +3636,7 @@ export async function createStorage(
       return transformSchemaPolicy(result);
     },
     async findInheritedPolicies(selector): Promise<SchemaPolicy[]> {
-      const { organization, project } = selector;
+      const { organizationId: organization, projectId: project } = selector;
 
       const result = await pool.any<schema_policy_config>(sql`/* findInheritedPolicies */
         SELECT *
@@ -4758,9 +4771,9 @@ export async function createStorage(
       });
 
       return this.getTarget({
-        target: args.targetId,
-        project: args.projectId,
-        organization: args.organizationId,
+        targetId: args.targetId,
+        projectId: args.projectId,
+        organizationId: args.organizationId,
       });
     },
     pool,

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -1109,10 +1109,18 @@ export const SchemaCheckModel = z.union([
 export type SchemaCheckInput = z.TypeOf<typeof SchemaCheckInputModel>;
 export type SchemaCheck = z.TypeOf<typeof SchemaCheckModel>;
 
-export const TargetBreadcrumbModel = z.object({
-  organization: z.string(),
-  project: z.string(),
-  target: z.string(),
-});
+export const TargetBreadcrumbModel = z
+  .object({
+    organization_slug: z.string(),
+    project_slug: z.string(),
+    target_slug: z.string(),
+  })
+  .transform(value => {
+    return {
+      organizationSlug: value.organization_slug,
+      projectSlug: value.project_slug,
+      targetSlug: value.target_slug,
+    };
+  });
 
 export type TargetBreadcrumb = z.TypeOf<typeof TargetBreadcrumbModel>;

--- a/packages/services/stripe-billing/src/api.ts
+++ b/packages/services/stripe-billing/src/api.ts
@@ -34,7 +34,7 @@ export const stripeBillingApiRouter = t.router({
     .query(async ({ ctx, input }) => {
       const storage = await ctx.storage$;
       const organizationBillingRecord = await storage.getOrganizationBilling({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       if (!organizationBillingRecord) {
@@ -57,7 +57,7 @@ export const stripeBillingApiRouter = t.router({
     .query(async ({ ctx, input }) => {
       const storage = await ctx.storage$;
       const organizationBillingRecord = await storage.getOrganizationBilling({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       if (!organizationBillingRecord) {
@@ -83,7 +83,7 @@ export const stripeBillingApiRouter = t.router({
     .query(async ({ ctx, input }) => {
       const storage = await ctx.storage$;
       const organizationBillingRecord = await storage.getOrganizationBilling({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       if (!organizationBillingRecord) {
@@ -96,7 +96,7 @@ export const stripeBillingApiRouter = t.router({
 
       if (customer.deleted === true) {
         await storage.deleteOrganizationBilling({
-          organization: input.organizationId,
+          organizationId: input.organizationId,
         });
 
         return null;
@@ -136,10 +136,10 @@ export const stripeBillingApiRouter = t.router({
       const storage = await ctx.storage$;
       const [organizationBillingRecord, organization, stripePrices] = await Promise.all([
         storage.getOrganizationBilling({
-          organization: input.organizationId,
+          organizationId: input.organizationId,
         }),
         storage.getOrganization({
-          organization: input.organizationId,
+          organizationId: input.organizationId,
         }),
         ctx.stripeData$,
       ]);
@@ -188,7 +188,7 @@ export const stripeBillingApiRouter = t.router({
     .mutation(async ({ ctx, input }) => {
       const storage = await ctx.storage$;
       const organizationBillingRecord = await storage.getOrganizationBilling({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       if (organizationBillingRecord === null) {
@@ -213,7 +213,7 @@ export const stripeBillingApiRouter = t.router({
     .mutation(async ({ ctx, input }) => {
       const storage = await ctx.storage$;
       const organizationBillingRecord = await storage.getOrganizationBilling({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       if (organizationBillingRecord === null) {
@@ -258,14 +258,14 @@ export const stripeBillingApiRouter = t.router({
     .mutation(async ({ ctx, input }) => {
       const storage = await ctx.storage$;
       let organizationBillingRecord = await storage.getOrganizationBilling({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
       const organization = await storage.getOrganization({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       const orgOwner = await storage.getOrganizationOwner({
-        organization: input.organizationId,
+        organizationId: input.organizationId,
       });
 
       const customerId = organizationBillingRecord?.externalBillingReference

--- a/packages/web/app/src/components/admin/AdminStats.tsx
+++ b/packages/web/app/src/components/admin/AdminStats.tsx
@@ -436,7 +436,7 @@ export function AdminStats({
   );
 
   return (
-    <DataWrapper query={query} organizationId={null}>
+    <DataWrapper query={query} organizationSlug={null}>
       {({ data }) => (
         <div className="flex flex-col gap-6">
           <div className="flex justify-between rounded-md border border-gray-800 bg-gray-900/50 p-5">

--- a/packages/web/app/src/components/layouts/organization-selectors.tsx
+++ b/packages/web/app/src/components/layouts/organization-selectors.tsx
@@ -12,7 +12,7 @@ const OrganizationSelector_OrganizationConnectionFragment = graphql(`
 `);
 
 export function OrganizationSelector(props: {
-  currentOrganizationCleanId: string;
+  currentOrganizationSlug: string;
   organizations: FragmentType<typeof OrganizationSelector_OrganizationConnectionFragment> | null;
 }) {
   const router = useRouter();
@@ -22,17 +22,17 @@ export function OrganizationSelector(props: {
   )?.nodes;
 
   const currentOrganization = organizations?.find(
-    node => node.slug === props.currentOrganizationCleanId,
+    node => node.slug === props.currentOrganizationSlug,
   );
 
   return organizations ? (
     <Select
-      value={props.currentOrganizationCleanId}
+      value={props.currentOrganizationSlug}
       onValueChange={id => {
         void router.navigate({
-          to: '/$organizationId',
+          to: '/$organizationSlug',
           params: {
-            organizationId: id,
+            organizationSlug: id,
           },
         });
       }}

--- a/packages/web/app/src/components/layouts/organization.tsx
+++ b/packages/web/app/src/components/layouts/organization.tsx
@@ -92,7 +92,7 @@ export function OrganizationLayout({
 }: {
   page?: Page;
   className?: string;
-  organizationId: string;
+  organizationSlug: string;
   children: ReactNode;
 }): ReactElement | null {
   const [isModalOpen, toggleModalOpen] = useToggle();
@@ -105,13 +105,13 @@ export function OrganizationLayout({
     OrganizationLayout_OrganizationFragment,
     query.data?.organizations.nodes,
   );
-  const currentOrganization = organizations?.find(org => org.slug === props.organizationId);
+  const currentOrganization = organizations?.find(org => org.slug === props.organizationSlug);
 
   useOrganizationAccess({
     member: currentOrganization?.me ?? null,
     scope: OrganizationAccessScope.Read,
     redirect: true,
-    organizationId: props.organizationId,
+    organizationSlug: props.organizationSlug,
   });
 
   useLastVisitedOrganizationWriter(currentOrganization?.slug);
@@ -119,7 +119,7 @@ export function OrganizationLayout({
   const meInCurrentOrg = currentOrganization?.me;
 
   if (query.error) {
-    return <QueryError error={query.error} organizationId={props.organizationId} />;
+    return <QueryError error={query.error} organizationSlug={props.organizationSlug} />;
   }
 
   return (
@@ -129,14 +129,14 @@ export function OrganizationLayout({
           <div className="flex flex-row items-center gap-4">
             <HiveLink className="size-8" />
             <OrganizationSelector
-              currentOrganizationSlug={props.organizationId}
+              currentOrganizationSlug={props.organizationSlug}
               organizations={query.data?.organizations ?? null}
             />
           </div>
           <div>
             <UserMenu
               me={query.data?.me ?? null}
-              currentOrganizationSlug={props.organizationId}
+              currentOrganizationSlug={props.organizationSlug}
               organizations={query.data?.organizations ?? null}
             />
           </div>
@@ -224,7 +224,7 @@ export function OrganizationLayout({
                 New project
               </Button>
               <CreateProjectModal
-                organizationId={props.organizationId}
+                organizationSlug={props.organizationSlug}
                 isOpen={isModalOpen}
                 toggleModalOpen={toggleModalOpen}
                 // reset the form every time it is closed
@@ -316,7 +316,7 @@ function ProjectTypeCard(props: {
 function CreateProjectModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
+  organizationSlug: string;
 }) {
   const [_, mutate] = useMutation(CreateProjectMutation);
   const router = useRouter();
@@ -334,7 +334,7 @@ function CreateProjectModal(props: {
   async function onSubmit(values: z.infer<typeof createProjectFormSchema>) {
     const { data, error } = await mutate({
       input: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
         slug: values.projectSlug,
         type: values.projectType,
       },
@@ -344,7 +344,7 @@ function CreateProjectModal(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug',
         params: {
-          organizationSlug: props.organizationId,
+          organizationSlug: props.organizationSlug,
           projectSlug: data.createProject.ok.createdProject.slug,
         },
       });

--- a/packages/web/app/src/components/layouts/organization.tsx
+++ b/packages/web/app/src/components/layouts/organization.tsx
@@ -129,14 +129,14 @@ export function OrganizationLayout({
           <div className="flex flex-row items-center gap-4">
             <HiveLink className="size-8" />
             <OrganizationSelector
-              currentOrganizationCleanId={props.organizationId}
+              currentOrganizationSlug={props.organizationId}
               organizations={query.data?.organizations ?? null}
             />
           </div>
           <div>
             <UserMenu
               me={query.data?.me ?? null}
-              currentOrganizationCleanId={props.organizationId}
+              currentOrganizationSlug={props.organizationId}
               organizations={query.data?.organizations ?? null}
             />
           </div>
@@ -148,15 +148,18 @@ export function OrganizationLayout({
             <Tabs value={page} className="min-w-[600px]">
               <TabsList variant="menu">
                 <TabsTrigger variant="menu" value={Page.Overview} asChild>
-                  <Link to="/$organizationId" params={{ organizationId: currentOrganization.slug }}>
+                  <Link
+                    to="/$organizationSlug"
+                    params={{ organizationSlug: currentOrganization.slug }}
+                  >
                     Overview
                   </Link>
                 </TabsTrigger>
                 {canAccessOrganization(OrganizationAccessScope.Members, meInCurrentOrg) && (
                   <TabsTrigger variant="menu" value={Page.Members} asChild>
                     <Link
-                      to="/$organizationId/view/members"
-                      params={{ organizationId: currentOrganization.slug }}
+                      to="/$organizationSlug/view/members"
+                      params={{ organizationSlug: currentOrganization.slug }}
                       search={{ page: 'list' }}
                     >
                       Members
@@ -167,16 +170,16 @@ export function OrganizationLayout({
                   <>
                     <TabsTrigger variant="menu" value={Page.Policy} asChild>
                       <Link
-                        to="/$organizationId/view/policy"
-                        params={{ organizationId: currentOrganization.slug }}
+                        to="/$organizationSlug/view/policy"
+                        params={{ organizationSlug: currentOrganization.slug }}
                       >
                         Policy
                       </Link>
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.Settings} asChild>
                       <Link
-                        to="/$organizationId/view/settings"
-                        params={{ organizationId: currentOrganization.slug }}
+                        to="/$organizationSlug/view/settings"
+                        params={{ organizationSlug: currentOrganization.slug }}
                       >
                         Settings
                       </Link>
@@ -187,8 +190,8 @@ export function OrganizationLayout({
                   env.zendeskSupport && (
                     <TabsTrigger variant="menu" value={Page.Support} asChild>
                       <Link
-                        to="/$organizationId/view/support"
-                        params={{ organizationId: currentOrganization.slug }}
+                        to="/$organizationSlug/view/support"
+                        params={{ organizationSlug: currentOrganization.slug }}
                       >
                         Support
                       </Link>
@@ -198,8 +201,8 @@ export function OrganizationLayout({
                   canAccessOrganization(OrganizationAccessScope.Settings, meInCurrentOrg) && (
                     <TabsTrigger variant="menu" value={Page.Subscription} asChild>
                       <Link
-                        to="/$organizationId/view/subscription"
-                        params={{ organizationId: currentOrganization.slug }}
+                        to="/$organizationSlug/view/subscription"
+                        params={{ organizationSlug: currentOrganization.slug }}
                       >
                         Subscription
                       </Link>
@@ -339,10 +342,10 @@ function CreateProjectModal(props: {
     if (data?.createProject.ok) {
       props.toggleModalOpen();
       void router.navigate({
-        to: '/$organizationId/$projectId',
+        to: '/$organizationSlug/$projectSlug',
         params: {
-          organizationId: props.organizationId,
-          projectId: data.createProject.ok.createdProject.slug,
+          organizationSlug: props.organizationId,
+          projectSlug: data.createProject.ok.createdProject.slug,
         },
       });
     } else if (data?.createProject.error?.inputErrors.slug) {

--- a/packages/web/app/src/components/layouts/project-selector.tsx
+++ b/packages/web/app/src/components/layouts/project-selector.tsx
@@ -18,8 +18,8 @@ const ProjectSelector_OrganizationConnectionFragment = graphql(`
 `);
 
 export function ProjectSelector(props: {
-  currentOrganizationCleanId: string;
-  currentProjectCleanId: string;
+  currentOrganizationSlug: string;
+  currentProjectSlug: string;
   organizations: FragmentType<typeof ProjectSelector_OrganizationConnectionFragment> | null;
 }) {
   const router = useRouter();
@@ -30,18 +30,18 @@ export function ProjectSelector(props: {
   )?.nodes;
 
   const currentOrganization = organizations?.find(
-    node => node.slug === props.currentOrganizationCleanId,
+    node => node.slug === props.currentOrganizationSlug,
   );
 
   const projects = currentOrganization?.projects.nodes;
-  const currentProject = projects?.find(node => node.slug === props.currentProjectCleanId);
+  const currentProject = projects?.find(node => node.slug === props.currentProjectSlug);
 
   return (
     <>
       {currentOrganization ? (
         <Link
-          to="/$organizationId"
-          params={{ organizationId: props.currentOrganizationCleanId }}
+          to="/$organizationSlug"
+          params={{ organizationSlug: props.currentOrganizationSlug }}
           className="max-w-[200px] shrink-0 truncate font-medium"
         >
           {currentOrganization.slug}
@@ -53,13 +53,13 @@ export function ProjectSelector(props: {
         <>
           <div className="italic text-gray-500">/</div>
           <Select
-            value={props.currentProjectCleanId}
+            value={props.currentProjectSlug}
             onValueChange={id => {
               void router.navigate({
-                to: '/$organizationId/$projectId',
+                to: '/$organizationSlug/$projectSlug',
                 params: {
-                  organizationId: props.currentOrganizationCleanId,
-                  projectId: id,
+                  organizationSlug: props.currentOrganizationSlug,
+                  projectSlug: id,
                 },
               });
             }}

--- a/packages/web/app/src/components/layouts/project.tsx
+++ b/packages/web/app/src/components/layouts/project.tsx
@@ -105,15 +105,15 @@ export function ProjectLayout({
           <div className="flex flex-row items-center gap-4">
             <HiveLink className="size-8" />
             <ProjectSelector
-              currentOrganizationCleanId={props.organizationId}
-              currentProjectCleanId={props.projectId}
+              currentOrganizationSlug={props.organizationId}
+              currentProjectSlug={props.projectId}
               organizations={query.data?.organizations ?? null}
             />
           </div>
           <div>
             <UserMenu
               me={me ?? null}
-              currentOrganizationCleanId={props.organizationId}
+              currentOrganizationSlug={props.organizationId}
               organizations={query.data?.organizations ?? null}
             />
           </div>
@@ -131,10 +131,10 @@ export function ProjectLayout({
               <TabsList variant="menu">
                 <TabsTrigger variant="menu" value={Page.Targets} asChild>
                   <Link
-                    to="/$organizationId/$projectId"
+                    to="/$organizationSlug/$projectSlug"
                     params={{
-                      organizationId: currentOrganization.slug,
-                      projectId: currentProject.slug,
+                      organizationSlug: currentOrganization.slug,
+                      projectSlug: currentProject.slug,
                     }}
                   >
                     Targets
@@ -143,10 +143,10 @@ export function ProjectLayout({
                 {canAccessProject(ProjectAccessScope.Alerts, currentOrganization.me) && (
                   <TabsTrigger variant="menu" value={Page.Alerts} asChild>
                     <Link
-                      to="/$organizationId/$projectId/view/alerts"
+                      to="/$organizationSlug/$projectSlug/view/alerts"
                       params={{
-                        organizationId: currentOrganization.slug,
-                        projectId: currentProject.slug,
+                        organizationSlug: currentOrganization.slug,
+                        projectSlug: currentProject.slug,
                       }}
                     >
                       Alerts
@@ -157,10 +157,10 @@ export function ProjectLayout({
                   <>
                     <TabsTrigger variant="menu" value={Page.Policy} asChild>
                       <Link
-                        to="/$organizationId/$projectId/view/policy"
+                        to="/$organizationSlug/$projectSlug/view/policy"
                         params={{
-                          organizationId: currentOrganization.slug,
-                          projectId: currentProject.slug,
+                          organizationSlug: currentOrganization.slug,
+                          projectSlug: currentProject.slug,
                         }}
                       >
                         Policy
@@ -168,10 +168,10 @@ export function ProjectLayout({
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.Settings} asChild>
                       <Link
-                        to="/$organizationId/$projectId/view/settings"
+                        to="/$organizationSlug/$projectSlug/view/settings"
                         params={{
-                          organizationId: currentOrganization.slug,
-                          projectId: currentProject.slug,
+                          organizationSlug: currentOrganization.slug,
+                          projectSlug: currentProject.slug,
                         }}
                       >
                         Settings
@@ -277,11 +277,11 @@ function CreateTargetModal(props: {
     if (data?.createTarget.ok) {
       props.toggleModalOpen();
       void router.navigate({
-        to: '/$organizationId/$projectId/$targetId',
+        to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationId,
-          projectId,
-          targetId: data.createTarget.ok.createdTarget.slug,
+          organizationSlug: organizationId,
+          projectSlug: projectId,
+          targetSlug: data.createTarget.ok.createdTarget.slug,
         },
       });
       toast({

--- a/packages/web/app/src/components/layouts/project.tsx
+++ b/packages/web/app/src/components/layouts/project.tsx
@@ -69,8 +69,8 @@ export function ProjectLayout({
   ...props
 }: {
   page: Page;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
   className?: string;
   children: ReactNode;
 }) {
@@ -82,18 +82,18 @@ export function ProjectLayout({
 
   const me = query.data?.me;
   const currentOrganization = query.data?.organizations.nodes.find(
-    node => node.slug === props.organizationId,
+    node => node.slug === props.organizationSlug,
   );
   const currentProject = currentOrganization?.projects.nodes.find(
-    node => node.slug === props.projectId,
+    node => node.slug === props.projectSlug,
   );
 
   useProjectAccess({
     scope: ProjectAccessScope.Read,
     member: currentOrganization?.me ?? null,
     redirect: true,
-    organizationId: props.organizationId,
-    projectId: props.projectId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
   });
 
   useLastVisitedOrganizationWriter(currentOrganization?.slug);
@@ -105,15 +105,15 @@ export function ProjectLayout({
           <div className="flex flex-row items-center gap-4">
             <HiveLink className="size-8" />
             <ProjectSelector
-              currentOrganizationSlug={props.organizationId}
-              currentProjectSlug={props.projectId}
+              currentOrganizationSlug={props.organizationSlug}
+              currentProjectSlug={props.projectSlug}
               organizations={query.data?.organizations ?? null}
             />
           </div>
           <div>
             <UserMenu
               me={me ?? null}
-              currentOrganizationSlug={props.organizationId}
+              currentOrganizationSlug={props.organizationSlug}
               organizations={query.data?.organizations ?? null}
             />
           </div>
@@ -121,7 +121,10 @@ export function ProjectLayout({
       </header>
 
       {page === Page.Settings || currentProject?.registryModel !== 'LEGACY' ? null : (
-        <ProjectMigrationToast orgId={props.organizationId} projectId={currentProject.slug} />
+        <ProjectMigrationToast
+          organizationSlug={props.organizationSlug}
+          projectSlug={currentProject.slug}
+        />
       )}
 
       <div className="relative h-[--tabs-navbar-height] border-b border-gray-800">
@@ -195,8 +198,8 @@ export function ProjectLayout({
             </Button>
           ) : null}
           <CreateTargetModal
-            organizationId={props.organizationId}
-            projectId={props.projectId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
             isOpen={isModalOpen}
             toggleModalOpen={toggleModalOpen}
           />
@@ -214,9 +217,9 @@ export const CreateTarget_CreateTargetMutation = graphql(`
     createTarget(input: $input) {
       ok {
         selector {
-          organization
-          project
-          target
+          organizationSlug
+          projectSlug
+          targetSlug
         }
         createdTarget {
           id
@@ -249,10 +252,10 @@ const createTargetFormSchema = z.object({
 function CreateTargetModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }) {
-  const { organizationId, projectId } = props;
+  const { organizationSlug, projectSlug } = props;
   const [_, mutate] = useMutation(CreateTarget_CreateTargetMutation);
   const router = useRouter();
   const { toast } = useToast();
@@ -268,8 +271,8 @@ function CreateTargetModal(props: {
   async function onSubmit(values: z.infer<typeof createTargetFormSchema>) {
     const { data, error } = await mutate({
       input: {
-        project: props.projectId,
-        organization: props.organizationId,
+        projectSlug: props.projectSlug,
+        organizationSlug: props.organizationSlug,
         slug: values.targetSlug,
       },
     });
@@ -279,8 +282,8 @@ function CreateTargetModal(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationSlug: organizationId,
-          projectSlug: projectId,
+          organizationSlug: organizationSlug,
+          projectSlug: projectSlug,
           targetSlug: data.createTarget.ok.createdTarget.slug,
         },
       });

--- a/packages/web/app/src/components/layouts/project.tsx
+++ b/packages/web/app/src/components/layouts/project.tsx
@@ -282,8 +282,8 @@ function CreateTargetModal(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationSlug: organizationSlug,
-          projectSlug: projectSlug,
+          organizationSlug,
+          projectSlug,
           targetSlug: data.createTarget.ok.createdTarget.slug,
         },
       });

--- a/packages/web/app/src/components/layouts/target-selector.tsx
+++ b/packages/web/app/src/components/layouts/target-selector.tsx
@@ -24,9 +24,9 @@ const TargetSelector_OrganizationConnectionFragment = graphql(`
 `);
 
 export function TargetSelector(props: {
-  currentOrganizationCleanId: string;
-  currentProjectCleanId: string;
-  currentTargetCleanId: string;
+  currentOrganizationSlug: string;
+  currentProjectSlug: string;
+  currentTargetSlug: string;
   organizations: FragmentType<typeof TargetSelector_OrganizationConnectionFragment> | null;
 }) {
   const router = useRouter();
@@ -37,22 +37,22 @@ export function TargetSelector(props: {
   )?.nodes;
 
   const currentOrganization = organizations?.find(
-    node => node.slug === props.currentOrganizationCleanId,
+    node => node.slug === props.currentOrganizationSlug,
   );
 
   const projects = currentOrganization?.projects.nodes;
-  const currentProject = projects?.find(node => node.slug === props.currentProjectCleanId);
+  const currentProject = projects?.find(node => node.slug === props.currentProjectSlug);
 
   const targets = currentProject?.targets.nodes;
-  const currentTarget = targets?.find(node => node.slug === props.currentTargetCleanId);
+  const currentTarget = targets?.find(node => node.slug === props.currentTargetSlug);
 
   return (
     <>
       {currentOrganization ? (
         <Link
-          to="/$organizationId"
+          to="/$organizationSlug"
           params={{
-            organizationId: currentOrganization.slug,
+            organizationSlug: currentOrganization.slug,
           }}
           className="max-w-[200px] shrink-0 truncate font-medium"
         >
@@ -64,10 +64,10 @@ export function TargetSelector(props: {
       <div className="italic text-gray-500">/</div>
       {currentOrganization && currentProject ? (
         <Link
-          to="/$organizationId/$projectId"
+          to="/$organizationSlug/$projectSlug"
           params={{
-            organizationId: props.currentOrganizationCleanId,
-            projectId: props.currentProjectCleanId,
+            organizationSlug: props.currentOrganizationSlug,
+            projectSlug: props.currentProjectSlug,
           }}
           className="max-w-[200px] shrink-0 truncate font-medium"
         >
@@ -80,14 +80,14 @@ export function TargetSelector(props: {
       {targets?.length && currentOrganization && currentProject && currentTarget ? (
         <>
           <Select
-            value={props.currentTargetCleanId}
+            value={props.currentTargetSlug}
             onValueChange={id => {
               void router.navigate({
-                to: '/$organizationId/$projectId/$targetId',
+                to: '/$organizationSlug/$projectSlug/$targetSlug',
                 params: {
-                  organizationId: props.currentOrganizationCleanId,
-                  projectId: props.currentProjectCleanId,
-                  targetId: id,
+                  organizationSlug: props.currentOrganizationSlug,
+                  projectSlug: props.currentProjectSlug,
+                  targetSlug: id,
                 },
               });
             }}

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -154,15 +154,15 @@ export const TargetLayout = ({
             <HiveLink className="size-8" />
             <TargetSelector
               organizations={query.data?.organizations ?? null}
-              currentOrganizationCleanId={props.organizationId}
-              currentProjectCleanId={props.projectId}
-              currentTargetCleanId={props.targetId}
+              currentOrganizationSlug={props.organizationId}
+              currentProjectSlug={props.projectId}
+              currentTargetSlug={props.targetId}
             />
           </div>
           <div>
             <UserMenu
               me={me ?? null}
-              currentOrganizationCleanId={props.organizationId}
+              currentOrganizationSlug={props.organizationId}
               organizations={query.data?.organizations ?? null}
             />
           </div>
@@ -182,11 +182,11 @@ export const TargetLayout = ({
                   <>
                     <TabsTrigger variant="menu" value={Page.Schema} asChild>
                       <Link
-                        to="/$organizationId/$projectId/$targetId"
+                        to="/$organizationSlug/$projectSlug/$targetSlug"
                         params={{
-                          organizationId: props.organizationId,
-                          projectId: props.projectId,
-                          targetId: props.targetId,
+                          organizationSlug: props.organizationId,
+                          projectSlug: props.projectId,
+                          targetSlug: props.targetId,
                         }}
                       >
                         Schema
@@ -194,11 +194,11 @@ export const TargetLayout = ({
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.Checks} asChild>
                       <Link
-                        to="/$organizationId/$projectId/$targetId/checks"
+                        to="/$organizationSlug/$projectSlug/$targetSlug/checks"
                         params={{
-                          organizationId: props.organizationId,
-                          projectId: props.projectId,
-                          targetId: props.targetId,
+                          organizationSlug: props.organizationId,
+                          projectSlug: props.projectId,
+                          targetSlug: props.targetId,
                         }}
                       >
                         Checks
@@ -206,11 +206,11 @@ export const TargetLayout = ({
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.Explorer} asChild>
                       <Link
-                        to="/$organizationId/$projectId/$targetId/explorer"
+                        to="/$organizationSlug/$projectSlug/$targetSlug/explorer"
                         params={{
-                          organizationId: props.organizationId,
-                          projectId: props.projectId,
-                          targetId: props.targetId,
+                          organizationSlug: props.organizationId,
+                          projectSlug: props.projectId,
+                          targetSlug: props.targetId,
                         }}
                       >
                         Explorer
@@ -218,11 +218,11 @@ export const TargetLayout = ({
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.History} asChild>
                       <Link
-                        to="/$organizationId/$projectId/$targetId/history"
+                        to="/$organizationSlug/$projectSlug/$targetSlug/history"
                         params={{
-                          organizationId: currentOrganization.slug,
-                          projectId: currentProject.slug,
-                          targetId: currentTarget.slug,
+                          organizationSlug: currentOrganization.slug,
+                          projectSlug: currentProject.slug,
+                          targetSlug: currentTarget.slug,
                         }}
                       >
                         History
@@ -230,11 +230,11 @@ export const TargetLayout = ({
                     </TabsTrigger>
                     <TabsTrigger variant="menu" value={Page.Insights} asChild>
                       <Link
-                        to="/$organizationId/$projectId/$targetId/insights"
+                        to="/$organizationSlug/$projectSlug/$targetSlug/insights"
                         params={{
-                          organizationId: props.organizationId,
-                          projectId: props.projectId,
-                          targetId: props.targetId,
+                          organizationSlug: props.organizationId,
+                          projectSlug: props.projectId,
+                          targetSlug: props.targetId,
                         }}
                       >
                         Insights
@@ -243,11 +243,11 @@ export const TargetLayout = ({
                     {currentOrganization.isAppDeploymentsEnabled && (
                       <TabsTrigger variant="menu" value={Page.Apps} asChild>
                         <Link
-                          to="/$organizationId/$projectId/$targetId/apps"
+                          to="/$organizationSlug/$projectSlug/$targetSlug/apps"
                           params={{
-                            organizationId: props.organizationId,
-                            projectId: props.projectId,
-                            targetId: props.targetId,
+                            organizationSlug: props.organizationId,
+                            projectSlug: props.projectId,
+                            targetSlug: props.targetId,
                           }}
                         >
                           Apps
@@ -256,11 +256,11 @@ export const TargetLayout = ({
                     )}
                     <TabsTrigger variant="menu" value={Page.Laboratory} asChild>
                       <Link
-                        to="/$organizationId/$projectId/$targetId/laboratory"
+                        to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                         params={{
-                          organizationId: props.organizationId,
-                          projectId: props.projectId,
-                          targetId: props.targetId,
+                          organizationSlug: props.organizationId,
+                          projectSlug: props.projectId,
+                          targetSlug: props.targetId,
                         }}
                       >
                         Laboratory
@@ -271,11 +271,11 @@ export const TargetLayout = ({
                 {canAccessSettingsPage && (
                   <TabsTrigger variant="menu" value={Page.Settings} asChild>
                     <Link
-                      to="/$organizationId/$projectId/$targetId/settings"
+                      to="/$organizationSlug/$projectSlug/$targetSlug/settings"
                       params={{
-                        organizationId: props.organizationId,
-                        projectId: props.projectId,
-                        targetId: props.targetId,
+                        organizationSlug: props.organizationId,
+                        projectSlug: props.projectId,
+                        targetSlug: props.targetId,
                       }}
                       search={{ page: 'general' }}
                     >
@@ -487,11 +487,11 @@ export function ConnectSchemaModal(props: {
                 }}
                 variant="primary"
                 className="font-bold underline"
-                to="/$organizationId/$projectId/$targetId/settings"
+                to="/$organizationSlug/$projectSlug/$targetSlug/settings"
                 params={{
-                  organizationId: props.organizationId,
-                  projectId: props.projectId,
-                  targetId: props.targetId,
+                  organizationSlug: props.organizationId,
+                  projectSlug: props.projectId,
+                  targetSlug: props.targetId,
                 }}
                 target="_blank"
                 rel="noreferrer"

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -89,9 +89,9 @@ export const TargetLayout = ({
   ...props
 }: {
   page: Page;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   className?: string;
   children: ReactNode;
   connect?: ReactNode;
@@ -102,25 +102,23 @@ export const TargetLayout = ({
     requestPolicy: 'cache-first',
   });
 
-  const { organizationId: orgId, projectId } = props;
-
   const me = query.data?.me;
   const currentOrganization = query.data?.organizations.nodes.find(
-    node => node.slug === props.organizationId,
+    node => node.slug === props.organizationSlug,
   );
   const currentProject = currentOrganization?.projects.nodes.find(
-    node => node.slug === props.projectId,
+    node => node.slug === props.projectSlug,
   );
-  const currentTarget = currentProject?.targets.nodes.find(node => node.slug === props.targetId);
+  const currentTarget = currentProject?.targets.nodes.find(node => node.slug === props.targetSlug);
   const isCDNEnabled = query.data?.isCDNEnabled === true;
 
   useTargetAccess({
     scope: TargetAccessScope.Read,
     member: currentOrganization?.me ?? null,
     redirect: true,
-    targetId: props.targetId,
-    projectId,
-    organizationId: orgId,
+    targetSlug: props.targetSlug,
+    projectSlug: props.projectSlug,
+    organizationSlug: props.organizationSlug,
   });
 
   useLastVisitedOrganizationWriter(currentOrganization?.slug);
@@ -154,15 +152,15 @@ export const TargetLayout = ({
             <HiveLink className="size-8" />
             <TargetSelector
               organizations={query.data?.organizations ?? null}
-              currentOrganizationSlug={props.organizationId}
-              currentProjectSlug={props.projectId}
-              currentTargetSlug={props.targetId}
+              currentOrganizationSlug={props.organizationSlug}
+              currentProjectSlug={props.projectSlug}
+              currentTargetSlug={props.targetSlug}
             />
           </div>
           <div>
             <UserMenu
               me={me ?? null}
-              currentOrganizationSlug={props.organizationId}
+              currentOrganizationSlug={props.organizationSlug}
               organizations={query.data?.organizations ?? null}
             />
           </div>
@@ -170,7 +168,10 @@ export const TargetLayout = ({
       </header>
 
       {currentProject?.registryModel === 'LEGACY' ? (
-        <ProjectMigrationToast orgId={orgId} projectId={projectId} />
+        <ProjectMigrationToast
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+        />
       ) : null}
 
       <div className="relative h-[--tabs-navbar-height] border-b border-gray-800">
@@ -184,9 +185,9 @@ export const TargetLayout = ({
                       <Link
                         to="/$organizationSlug/$projectSlug/$targetSlug"
                         params={{
-                          organizationSlug: props.organizationId,
-                          projectSlug: props.projectId,
-                          targetSlug: props.targetId,
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                          targetSlug: props.targetSlug,
                         }}
                       >
                         Schema
@@ -196,9 +197,9 @@ export const TargetLayout = ({
                       <Link
                         to="/$organizationSlug/$projectSlug/$targetSlug/checks"
                         params={{
-                          organizationSlug: props.organizationId,
-                          projectSlug: props.projectId,
-                          targetSlug: props.targetId,
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                          targetSlug: props.targetSlug,
                         }}
                       >
                         Checks
@@ -208,9 +209,9 @@ export const TargetLayout = ({
                       <Link
                         to="/$organizationSlug/$projectSlug/$targetSlug/explorer"
                         params={{
-                          organizationSlug: props.organizationId,
-                          projectSlug: props.projectId,
-                          targetSlug: props.targetId,
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                          targetSlug: props.targetSlug,
                         }}
                       >
                         Explorer
@@ -232,9 +233,9 @@ export const TargetLayout = ({
                       <Link
                         to="/$organizationSlug/$projectSlug/$targetSlug/insights"
                         params={{
-                          organizationSlug: props.organizationId,
-                          projectSlug: props.projectId,
-                          targetSlug: props.targetId,
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                          targetSlug: props.targetSlug,
                         }}
                       >
                         Insights
@@ -245,9 +246,9 @@ export const TargetLayout = ({
                         <Link
                           to="/$organizationSlug/$projectSlug/$targetSlug/apps"
                           params={{
-                            organizationSlug: props.organizationId,
-                            projectSlug: props.projectId,
-                            targetSlug: props.targetId,
+                            organizationSlug: props.organizationSlug,
+                            projectSlug: props.projectSlug,
+                            targetSlug: props.targetSlug,
                           }}
                         >
                           Apps
@@ -258,9 +259,9 @@ export const TargetLayout = ({
                       <Link
                         to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                         params={{
-                          organizationSlug: props.organizationId,
-                          projectSlug: props.projectId,
-                          targetSlug: props.targetId,
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                          targetSlug: props.targetSlug,
                         }}
                       >
                         Laboratory
@@ -273,9 +274,9 @@ export const TargetLayout = ({
                     <Link
                       to="/$organizationSlug/$projectSlug/$targetSlug/settings"
                       params={{
-                        organizationSlug: props.organizationId,
-                        projectSlug: props.projectId,
-                        targetSlug: props.targetId,
+                        organizationSlug: props.organizationSlug,
+                        projectSlug: props.projectSlug,
+                        targetSlug: props.targetSlug,
                       }}
                       search={{ page: 'general' }}
                     >
@@ -302,9 +303,9 @@ export const TargetLayout = ({
                   Connect to CDN
                 </Button>
                 <ConnectSchemaModal
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   isOpen={isModalOpen}
                   toggleModalOpen={toggleModalOpen}
                 />
@@ -364,17 +365,17 @@ function composeEndpoint(baseUrl: string, artifactType: CdnArtifactType): string
 export function ConnectSchemaModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [query] = useQuery({
     query: ConnectSchemaModalQuery,
     variables: {
       targetSelector: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       },
     },
     requestPolicy: 'cache-and-network',
@@ -489,9 +490,9 @@ export function ConnectSchemaModal(props: {
                 className="font-bold underline"
                 to="/$organizationSlug/$projectSlug/$targetSlug/settings"
                 params={{
-                  organizationSlug: props.organizationId,
-                  projectSlug: props.projectId,
-                  targetSlug: props.targetId,
+                  organizationSlug: props.organizationSlug,
+                  projectSlug: props.projectSlug,
+                  targetSlug: props.targetSlug,
                 }}
                 target="_blank"
                 rel="noreferrer"

--- a/packages/web/app/src/components/organization/Permissions.tsx
+++ b/packages/web/app/src/components/organization/Permissions.tsx
@@ -25,7 +25,7 @@ const OrganizationPermissions_UpdateMemberAccessMutation = graphql(`
   ) {
     updateOrganizationMemberAccess(input: $input) {
       selector {
-        organization
+        organizationSlug
       }
       organization {
         id
@@ -312,8 +312,8 @@ export function usePermissionsManager({
       setState('LOADING');
       const result = await mutate({
         input: {
-          organization: organization.slug,
-          user: member.user.id,
+          organizationSlug: organization.slug,
+          userId: member.user.id,
           targetScopes,
           projectScopes,
           organizationScopes,

--- a/packages/web/app/src/components/organization/Usage.tsx
+++ b/packages/web/app/src/components/organization/Usage.tsx
@@ -36,7 +36,7 @@ export function OrganizationUsageEstimationView(props: {
     query: Usage_UsageEstimationQuery,
     variables: {
       input: {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
         month: new Date().getMonth() + 1,
         year: new Date().getFullYear(),
       },
@@ -45,7 +45,7 @@ export function OrganizationUsageEstimationView(props: {
 
   return (
     <div className="right-4 top-7">
-      <DataWrapper query={query} organizationId={organization.slug}>
+      <DataWrapper query={query} organizationSlug={organization.slug}>
         {result => (
           <Table>
             <THead>

--- a/packages/web/app/src/components/organization/billing/BillingPaymentMethod.tsx
+++ b/packages/web/app/src/components/organization/billing/BillingPaymentMethod.tsx
@@ -63,7 +63,7 @@ export const ManagePaymentMethod = (props: {
             onClick={() => {
               void mutate({
                 selector: {
-                  organization: organization.slug,
+                  organizationSlug: organization.slug,
                 },
               }).then(result => {
                 if (result.data?.generateStripePortalLink) {

--- a/packages/web/app/src/components/organization/members/invitations.tsx
+++ b/packages/web/app/src/components/organization/members/invitations.tsx
@@ -298,7 +298,7 @@ const Members_Invitation = graphql(`
 
 function Invitation(props: {
   invitation: FragmentType<typeof Members_Invitation>;
-  organizationCleanId: string;
+  organizationSlug: string;
   refetchInvitations(): void;
 }) {
   const invitation = useFragment(Members_Invitation, props.invitation);
@@ -336,7 +336,7 @@ function Invitation(props: {
                   try {
                     const result = await deleteInvitation({
                       input: {
-                        organization: props.organizationCleanId,
+                        organization: props.organizationSlug,
                         email: invitation.email,
                       },
                     });
@@ -453,7 +453,7 @@ export function OrganizationInvitations(props: {
               <Invitation
                 key={node.id}
                 invitation={node}
-                organizationCleanId={organization.slug}
+                organizationSlug={organization.slug}
                 refetchInvitations={props.refetchInvitations}
               />
             ))}

--- a/packages/web/app/src/components/organization/members/invitations.tsx
+++ b/packages/web/app/src/components/organization/members/invitations.tsx
@@ -120,9 +120,9 @@ function MemberInvitationForm(props: {
     try {
       const result = await invite({
         input: {
-          organization: organization.slug,
+          organizationSlug: organization.slug,
           email: data.email,
-          role: data.role,
+          roleId: data.role,
         },
       });
 
@@ -336,7 +336,7 @@ function Invitation(props: {
                   try {
                     const result = await deleteInvitation({
                       input: {
-                        organization: props.organizationSlug,
+                        organizationSlug: props.organizationSlug,
                         email: invitation.email,
                       },
                     });

--- a/packages/web/app/src/components/organization/members/list.tsx
+++ b/packages/web/app/src/components/organization/members/list.tsx
@@ -161,9 +161,9 @@ function OrganizationMemberRoleSwitcher(props: {
           try {
             const result = await assignRole({
               input: {
-                organization: organization.slug,
-                role: role.id,
-                user: member.user.id,
+                organizationSlug: organization.slug,
+                roleId: role.id,
+                userId: member.user.id,
               },
             });
 
@@ -384,8 +384,8 @@ function OrganizationMemberRow(props: {
                   try {
                     const result = await deleteMember({
                       input: {
-                        organization: organization.slug,
-                        user: member.user.id,
+                        organizationSlug: organization.slug,
+                        userId: member.user.id,
                       },
                     });
 

--- a/packages/web/app/src/components/organization/members/migration.tsx
+++ b/packages/web/app/src/components/organization/members/migration.tsx
@@ -82,7 +82,7 @@ export function MemberRoleMigrationStickyNote(props: {
   const isMembersView =
     // @ts-expect-error - it's missing the `search` property, but it's fine, it works correctly
     router.matchRoute({
-      to: '/$organizationId/view/members',
+      to: '/$organizationSlug/view/members',
     }) !== false;
 
   if (
@@ -107,9 +107,9 @@ export function MemberRoleMigrationStickyNote(props: {
         {daysLeft.current} {daysLeft.current > 1 ? 'days' : 'day'} left to{' '}
         <Link
           className="underline underline-offset-4"
-          to="/$organizationId/view/members"
+          to="/$organizationSlug/view/members"
           params={{
-            organizationId: organization.slug,
+            organizationSlug: organization.slug,
           }}
           search={{
             page: 'migration',
@@ -396,7 +396,7 @@ const OrganizationMemberRolesMigrationGroup_Migrate = graphql(`
 `);
 
 function OrganizationMemberRolesMigrationGroup(props: {
-  organizationCleanId: string;
+  organizationSlug: string;
   memberGroup: FragmentType<typeof OrganizationMemberRolesMigrationGroup_MemberRoleMigrationGroup>;
   roles: readonly {
     id: string;
@@ -459,14 +459,14 @@ function OrganizationMemberRolesMigrationGroup(props: {
           'roleId' in data
             ? {
                 assignRole: {
-                  organization: props.organizationCleanId,
+                  organization: props.organizationSlug,
                   role: data.roleId,
                   users: data.users,
                 },
               }
             : {
                 createRole: {
-                  organization: props.organizationCleanId,
+                  organization: props.organizationSlug,
                   name: data.name,
                   description: data.description,
                   organizationScopes: data.organizationScopes.filter(
@@ -888,7 +888,7 @@ export function OrganizationMemberRolesMigration(props: {
                 key={memberGroup.id}
                 memberGroup={memberGroup}
                 roles={organization.memberRoles}
-                organizationCleanId={organization.slug}
+                organizationSlug={organization.slug}
               />
             ))}
           </tbody>

--- a/packages/web/app/src/components/organization/members/migration.tsx
+++ b/packages/web/app/src/components/organization/members/migration.tsx
@@ -459,14 +459,14 @@ function OrganizationMemberRolesMigrationGroup(props: {
           'roleId' in data
             ? {
                 assignRole: {
-                  organization: props.organizationSlug,
-                  role: data.roleId,
-                  users: data.users,
+                  organizationSlug: props.organizationSlug,
+                  roleId: data.roleId,
+                  userIds: data.users,
                 },
               }
             : {
                 createRole: {
-                  organization: props.organizationSlug,
+                  organizationSlug: props.organizationSlug,
                   name: data.name,
                   description: data.description,
                   organizationScopes: data.organizationScopes.filter(
@@ -479,7 +479,7 @@ function OrganizationMemberRolesMigrationGroup(props: {
                   targetScopes: data.targetScopes.filter((s): s is TargetAccessScope =>
                     Object.values(TargetAccessScope).includes(s as TargetAccessScope),
                   ),
-                  users: data.users,
+                  userIds: data.users,
                 },
               },
       });

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -181,8 +181,8 @@ function OrganizationMemberRoleEditor(props: {
     try {
       const result = await updateMemberRole({
         input: {
-          organization: props.organizationSlug,
-          role: role.id,
+          organizationSlug: props.organizationSlug,
+          roleId: role.id,
           name: data.name,
           description: data.description,
           organizationAccessScopes: data.organizationScopes.filter(scope =>
@@ -446,7 +446,7 @@ function OrganizationMemberRoleCreator(props: {
     try {
       const result = await createMemberRole({
         input: {
-          organization: props.organizationSlug,
+          organizationSlug: props.organizationSlug,
           name: data.name,
           description: data.description,
           organizationAccessScopes: data.organizationScopes.filter(scope =>
@@ -860,8 +860,8 @@ export function OrganizationMemberRoles(props: {
                   try {
                     const result = await deleteRole({
                       input: {
-                        organization: organization.slug,
-                        role: roleToDelete.id,
+                        organizationSlug: organization.slug,
+                        roleId: roleToDelete.id,
                       },
                     });
 

--- a/packages/web/app/src/components/organization/members/roles.tsx
+++ b/packages/web/app/src/components/organization/members/roles.tsx
@@ -113,7 +113,7 @@ const OrganizationMemberRoleEditor_MeFragment = graphql(`
 function OrganizationMemberRoleEditor(props: {
   mode?: 'edit' | 'read-only';
   close(): void;
-  organizationCleanId: string;
+  organizationSlug: string;
   me: FragmentType<typeof OrganizationMemberRoleEditor_MeFragment>;
   role: FragmentType<typeof OrganizationMemberRoleRow_MemberRoleFragment>;
 }) {
@@ -181,7 +181,7 @@ function OrganizationMemberRoleEditor(props: {
     try {
       const result = await updateMemberRole({
         input: {
-          organization: props.organizationCleanId,
+          organization: props.organizationSlug,
           role: role.id,
           name: data.name,
           description: data.description,
@@ -393,7 +393,7 @@ const OrganizationMemberRoleCreator_MeFragment = graphql(`
 
 function OrganizationMemberRoleCreator(props: {
   close(): void;
-  organizationCleanId: string;
+  organizationSlug: string;
   me: FragmentType<typeof OrganizationMemberRoleCreator_MeFragment>;
 }) {
   const me = useFragment(OrganizationMemberRoleCreator_MeFragment, props.me);
@@ -446,7 +446,7 @@ function OrganizationMemberRoleCreator(props: {
     try {
       const result = await createMemberRole({
         input: {
-          organization: props.organizationCleanId,
+          organization: props.organizationSlug,
           name: data.name,
           description: data.description,
           organizationAccessScopes: data.organizationScopes.filter(scope =>
@@ -601,7 +601,7 @@ function OrganizationMemberRoleCreator(props: {
 }
 
 function OrganizationMemberRoleCreateButton(props: {
-  organizationCleanId: string;
+  organizationSlug: string;
   me: FragmentType<typeof OrganizationMemberRoleCreator_MeFragment>;
 }) {
   const [open, setOpen] = useState(false);
@@ -613,7 +613,7 @@ function OrganizationMemberRoleCreateButton(props: {
       </DialogTrigger>
       {open ? (
         <OrganizationMemberRoleCreator
-          organizationCleanId={props.organizationCleanId}
+          organizationSlug={props.organizationSlug}
           me={props.me}
           close={() => setOpen(false)}
         />
@@ -808,7 +808,7 @@ export function OrganizationMemberRoles(props: {
       >
         {roleToEdit ? (
           <OrganizationMemberRoleEditor
-            organizationCleanId={organization.slug}
+            organizationSlug={organization.slug}
             me={organization.me}
             role={roleToEdit}
             close={() => setRoleToEdit(null)}
@@ -826,7 +826,7 @@ export function OrganizationMemberRoles(props: {
         {roleToShow ? (
           <OrganizationMemberRoleEditor
             mode="read-only"
-            organizationCleanId={organization.slug}
+            organizationSlug={organization.slug}
             me={organization.me}
             role={roleToShow}
             close={() => setRoleToShow(null)}
@@ -901,7 +901,7 @@ export function OrganizationMemberRoles(props: {
         >
           <OrganizationMemberRoleCreateButton
             me={organization.me}
-            organizationCleanId={organization.slug}
+            organizationSlug={organization.slug}
           />
         </SubPageLayoutHeader>
         <table className="w-full table-auto divide-y-[1px] divide-gray-500/20">

--- a/packages/web/app/src/components/organization/stripe.tsx
+++ b/packages/web/app/src/components/organization/stripe.tsx
@@ -7,7 +7,7 @@ export function RenderIfStripeAvailable(props: { children: ReactNode; organizati
    * If Stripe is not enabled we redirect the user to the organization.
    */
   if (!getIsStripeEnabled()) {
-    return <Navigate to="/$organizationId" params={{ organizationId: props.organizationId }} />;
+    return <Navigate to="/$organizationSlug" params={{ organizationSlug: props.organizationId }} />;
   }
 
   return <>{props.children}</>;

--- a/packages/web/app/src/components/organization/stripe.tsx
+++ b/packages/web/app/src/components/organization/stripe.tsx
@@ -2,12 +2,14 @@ import { ReactNode } from 'react';
 import { getIsStripeEnabled } from '@/lib/billing/stripe-public-key';
 import { Navigate } from '@tanstack/react-router';
 
-export function RenderIfStripeAvailable(props: { children: ReactNode; organizationId: string }) {
+export function RenderIfStripeAvailable(props: { children: ReactNode; organizationSlug: string }) {
   /**
    * If Stripe is not enabled we redirect the user to the organization.
    */
   if (!getIsStripeEnabled()) {
-    return <Navigate to="/$organizationSlug" params={{ organizationSlug: props.organizationId }} />;
+    return (
+      <Navigate to="/$organizationSlug" params={{ organizationSlug: props.organizationSlug }} />
+    );
   }
 
   return <>{props.children}</>;

--- a/packages/web/app/src/components/policy/policy-settings.tsx
+++ b/packages/web/app/src/components/policy/policy-settings.tsx
@@ -164,7 +164,7 @@ export function PolicySettings({
   const activePolicy = useFragment(PolicySettings_SchemaPolicyFragment, currentState);
 
   return (
-    <DataWrapper query={availableRules} organizationId={null}>
+    <DataWrapper query={availableRules} organizationSlug={null}>
       {query => (
         <PolicySettingsListForm
           saving={saving}

--- a/packages/web/app/src/components/project/alerts/create-alert.tsx
+++ b/packages/web/app/src/components/project/alerts/create-alert.tsx
@@ -45,8 +45,8 @@ export const CreateAlertModal = (props: {
   toggleModalOpen: () => void;
   targets: FragmentType<typeof CreateAlertModal_TargetFragment>[];
   channels: FragmentType<typeof CreateAlertModal_AlertChannelFragment>[];
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }): ReactElement => {
   const { isOpen, toggleModalOpen } = props;
   const targets = useFragment(CreateAlertModal_TargetFragment, props.targets);
@@ -77,10 +77,10 @@ export const CreateAlertModal = (props: {
     async onSubmit(values) {
       const { error, data } = await mutate({
         input: {
-          organization: props.organizationId,
-          project: props.projectId,
-          target: values.target,
-          channel: values.channel,
+          organizationSlug: props.organizationSlug,
+          projectSlug: props.projectSlug,
+          targetSlug: values.target,
+          channelId: values.channel,
           type: values.type,
         },
       });

--- a/packages/web/app/src/components/project/alerts/create-channel.tsx
+++ b/packages/web/app/src/components/project/alerts/create-channel.tsx
@@ -34,13 +34,13 @@ export const CreateChannel_AddAlertChannelMutation = graphql(`
 export const CreateChannelModal = ({
   isOpen,
   toggleModalOpen,
-  organizationId,
-  projectId,
+  organizationSlug,
+  projectSlug,
 }: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }): ReactElement => {
   const [mutation, mutate] = useMutation(CreateChannel_AddAlertChannelMutation);
   const { errors, values, touched, handleChange, handleBlur, handleSubmit, isSubmitting } =
@@ -68,8 +68,8 @@ export const CreateChannelModal = ({
       async onSubmit(values) {
         const { data, error } = await mutate({
           input: {
-            organization: organizationId,
-            project: projectId,
+            organizationSlug: organizationSlug,
+            projectSlug: projectSlug,
             name: values.name,
             type: values.type,
             slack: values.type === AlertChannelType.Slack ? { channel: values.slackChannel } : null,

--- a/packages/web/app/src/components/project/alerts/create-channel.tsx
+++ b/packages/web/app/src/components/project/alerts/create-channel.tsx
@@ -68,8 +68,8 @@ export const CreateChannelModal = ({
       async onSubmit(values) {
         const { data, error } = await mutate({
           input: {
-            organizationSlug: organizationSlug,
-            projectSlug: projectSlug,
+            organizationSlug,
+            projectSlug,
             name: values.name,
             type: values.type,
             slack: values.type === AlertChannelType.Slack ? { channel: values.slackChannel } : null,

--- a/packages/web/app/src/components/project/alerts/delete-alerts-button.tsx
+++ b/packages/web/app/src/components/project/alerts/delete-alerts-button.tsx
@@ -20,13 +20,13 @@ export const DeleteAlertsButton_DeleteAlertsMutation = graphql(`
 export function DeleteAlertsButton({
   selected,
   onSuccess,
-  organizationId,
-  projectId,
+  organizationSlug,
+  projectSlug,
 }: {
   selected: string[];
   onSuccess(): void;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }) {
   const [mutation, mutate] = useMutation(DeleteAlertsButton_DeleteAlertsMutation);
 
@@ -37,9 +37,9 @@ export function DeleteAlertsButton({
       onClick={async () => {
         await mutate({
           input: {
-            organization: organizationId,
-            project: projectId,
-            alerts: selected,
+            organizationSlug,
+            projectSlug,
+            alertIds: selected,
           },
         });
         onSuccess();

--- a/packages/web/app/src/components/project/alerts/delete-channels-button.tsx
+++ b/packages/web/app/src/components/project/alerts/delete-channels-button.tsx
@@ -20,13 +20,13 @@ export const DeleteChannelsButton_DeleteChannelsMutation = graphql(`
 export function DeleteChannelsButton({
   selected,
   onSuccess,
-  organizationId,
-  projectId,
+  organizationSlug,
+  projectSlug,
 }: {
   selected: string[];
   onSuccess(): void;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }) {
   const [mutation, mutate] = useMutation(DeleteChannelsButton_DeleteChannelsMutation);
 
@@ -37,9 +37,9 @@ export function DeleteChannelsButton({
       onClick={async () => {
         await mutate({
           input: {
-            organization: organizationId,
-            project: projectId,
-            channels: selected,
+            organizationSlug,
+            projectSlug,
+            channelIds: selected,
           },
         });
         onSuccess();

--- a/packages/web/app/src/components/project/migration-toast.tsx
+++ b/packages/web/app/src/components/project/migration-toast.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from '@tanstack/react-router';
 import { Button } from '../ui/button';
 
-export function ProjectMigrationToast({ projectId, orgId }: { projectId: string; orgId: string }) {
+export function ProjectMigrationToast(props: { projectSlug: string; organizationSlug: string }) {
   const router = useRouter();
   const handleOnClick = () => {
     void router.navigate({
-      to: `/${orgId}/${projectId}/view/settings`,
+      to: `/${props.organizationSlug}/${props.projectSlug}/view/settings`,
     });
   };
   return (

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -74,18 +74,18 @@ const ExternalCompositionForm_ProjectFragment = graphql(`
 `);
 
 const ExternalCompositionStatus = ({
-  projectId,
-  organizationId,
+  projectSlug,
+  organizationSlug,
 }: {
-  projectId: string;
-  organizationId: string;
+  projectSlug: string;
+  organizationSlug: string;
 }) => {
   const [query] = useQuery({
     query: ExternalCompositionStatus_TestQuery,
     variables: {
       selector: {
-        project: projectId,
-        organization: organizationId,
+        projectSlug,
+        organizationSlug,
       },
     },
     requestPolicy: 'network-only',
@@ -169,8 +169,8 @@ const ExternalCompositionForm = ({
   function onSubmit(values: FormValues) {
     void enable({
       input: {
-        project: project.slug,
-        organization: organization.slug,
+        projectSlug: project.slug,
+        organizationSlug: organization.slug,
         endpoint: values.endpoint,
         secret: values.secret,
       },
@@ -245,8 +245,8 @@ const ExternalCompositionForm = ({
                     mutation.data?.enableExternalSchemaComposition.ok?.externalSchemaComposition
                       ?.endpoint) ? (
                     <ExternalCompositionStatus
-                      projectId={project.slug}
-                      organizationId={organization.slug}
+                      projectSlug={project.slug}
+                      organizationSlug={organization.slug}
                     />
                   ) : null}
                 </div>
@@ -349,8 +349,8 @@ export const ExternalCompositionSettings = (props: {
     query: ExternalComposition_ProjectConfigurationQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
       },
     },
   });
@@ -363,8 +363,8 @@ export const ExternalCompositionSettings = (props: {
         setEnabled(false);
         const result = await disableComposition({
           input: {
-            project: project.slug,
-            organization: organization.slug,
+            projectSlug: project.slug,
+            organizationSlug: organization.slug,
           },
         });
         const error = result.error?.message || result.data?.disableExternalSchemaComposition.error;

--- a/packages/web/app/src/components/project/settings/model-migration.tsx
+++ b/packages/web/app/src/components/project/settings/model-migration.tsx
@@ -135,7 +135,7 @@ const ModelMigrationSettings_ProjectFragment = graphql(`
 
 export function ModelMigrationSettings(props: {
   project: FragmentType<typeof ModelMigrationSettings_ProjectFragment>;
-  organizationId: string;
+  organizationSlug: string;
 }): ReactElement | null {
   const project = useFragment(ModelMigrationSettings_ProjectFragment, props.project);
   const isStitching = project.type === 'STITCHING';
@@ -150,8 +150,8 @@ export function ModelMigrationSettings(props: {
     try {
       const result = await upgradeMutation({
         input: {
-          project: project.slug,
-          organization: props.organizationId,
+          projectSlug: project.slug,
+          organizationSlug: props.organizationSlug,
           model: RegistryModel.Modern,
         },
       });
@@ -196,7 +196,7 @@ export function ModelMigrationSettings(props: {
             onClick={() => {
               void router.navigate({
                 to: '/$organizationSlug/view/support',
-                params: { organizationSlug: props.organizationId },
+                params: { organizationSlug: props.organizationSlug },
               });
             }}
           >
@@ -334,7 +334,7 @@ export function ModelMigrationSettings(props: {
                 onClick={() => {
                   void router.navigate({
                     to: '/$organizationSlug/view/support',
-                    params: { organizationSlug: props.organizationId },
+                    params: { organizationSlug: props.organizationSlug },
                   });
                 }}
               >

--- a/packages/web/app/src/components/project/settings/model-migration.tsx
+++ b/packages/web/app/src/components/project/settings/model-migration.tsx
@@ -195,8 +195,8 @@ export function ModelMigrationSettings(props: {
             size="lg"
             onClick={() => {
               void router.navigate({
-                to: '/$organizationId/view/support',
-                params: { organizationId: props.organizationId },
+                to: '/$organizationSlug/view/support',
+                params: { organizationSlug: props.organizationId },
               });
             }}
           >
@@ -333,8 +333,8 @@ export function ModelMigrationSettings(props: {
                 variant="link"
                 onClick={() => {
                   void router.navigate({
-                    to: '/$organizationId/view/support',
-                    params: { organizationId: props.organizationId },
+                    to: '/$organizationSlug/view/support',
+                    params: { organizationSlug: props.organizationId },
                   });
                 }}
               >

--- a/packages/web/app/src/components/project/settings/native-composition.tsx
+++ b/packages/web/app/src/components/project/settings/native-composition.tsx
@@ -38,8 +38,8 @@ const IncrementalNativeCompositionSwitch_Mutation = graphql(`
 `);
 
 const IncrementalNativeCompositionSwitch = (props: {
-  organizationCleanId: string;
-  projectCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
   target: FragmentType<typeof IncrementalNativeCompositionSwitch_TargetFragment>;
 }) => {
   const target = useFragment(IncrementalNativeCompositionSwitch_TargetFragment, props.target);
@@ -67,8 +67,8 @@ const IncrementalNativeCompositionSwitch = (props: {
                 onCheckedChange={nativeComposition => {
                   void mutate({
                     input: {
-                      organization: props.organizationCleanId,
-                      project: props.projectCleanId,
+                      organization: props.organizationSlug,
+                      project: props.projectSlug,
                       target: target.slug,
                       nativeComposition,
                     },
@@ -255,8 +255,8 @@ export function NativeCompositionSettings(props: {
               <div className="flex flex-row gap-4">
                 {project.targets.nodes.map(target => (
                   <IncrementalNativeCompositionSwitch
-                    organizationCleanId={organization.slug}
-                    projectCleanId={project.slug}
+                    organizationSlug={organization.slug}
+                    projectSlug={project.slug}
                     key={target.id}
                     target={target}
                   />

--- a/packages/web/app/src/components/project/settings/native-composition.tsx
+++ b/packages/web/app/src/components/project/settings/native-composition.tsx
@@ -67,9 +67,9 @@ const IncrementalNativeCompositionSwitch = (props: {
                 onCheckedChange={nativeComposition => {
                   void mutate({
                     input: {
-                      organization: props.organizationSlug,
-                      project: props.projectSlug,
-                      target: target.slug,
+                      organizationSlug: props.organizationSlug,
+                      projectSlug: props.projectSlug,
+                      targetSlug: target.slug,
                       nativeComposition,
                     },
                   });
@@ -153,8 +153,8 @@ export function NativeCompositionSettings(props: {
     query: NativeCompositionSettings_ProjectQuery,
     variables: {
       selector: {
-        organization: organization.slug,
-        project: project.slug,
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
       },
     },
     pause: project.isNativeFederationEnabled,
@@ -172,8 +172,8 @@ export function NativeCompositionSettings(props: {
       try {
         const result = await mutate({
           input: {
-            organization: organization.slug,
-            project: project.slug,
+            organizationSlug: organization.slug,
+            projectSlug: project.slug,
             enabled,
           },
         });

--- a/packages/web/app/src/components/target/explorer/common.tsx
+++ b/packages/web/app/src/components/target/explorer/common.tsx
@@ -63,9 +63,9 @@ const SchemaExplorerUsageStats_UsageFragment = graphql(`
 export function SchemaExplorerUsageStats(props: {
   usage: FragmentType<typeof SchemaExplorerUsageStats_UsageFragment>;
   totalRequests: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const usage = useFragment(SchemaExplorerUsageStats_UsageFragment, props.usage);
   const percentage = props.totalRequests ? (usage.total / props.totalRequests) * 100 : 0;
@@ -118,11 +118,11 @@ export function SchemaExplorerUsageStats(props: {
                             <td className="px-2 pl-0 text-left">
                               <NextLink
                                 className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                                to="/$organizationId/$projectId/$targetId/insights/$operationName/$operationHash"
+                                to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                                 params={{
-                                  organizationId: props.organizationCleanId,
-                                  projectId: props.projectCleanId,
-                                  targetId: props.targetCleanId,
+                                  organizationSlug: props.organizationSlug,
+                                  projectSlug: props.projectSlug,
+                                  targetSlug: props.targetSlug,
                                   operationName: `${op.hash.substring(0, 4)}_${op.name}`,
                                   operationHash: op.hash,
                                 }}
@@ -163,11 +163,11 @@ export function SchemaExplorerUsageStats(props: {
                       <li key={clientName} className="font-bold">
                         <NextLink
                           className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                          to="/$organizationId/$projectId/$targetId/insights/client/$name"
+                          to="/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name"
                           params={{
-                            organizationId: props.organizationCleanId,
-                            projectId: props.projectCleanId,
-                            targetId: props.targetCleanId,
+                            organizationSlug: props.organizationSlug,
+                            projectSlug: props.projectSlug,
+                            targetSlug: props.targetSlug,
                             name: clientName,
                           }}
                         >
@@ -277,9 +277,9 @@ export function GraphQLTypeCard(props: {
   totalRequests?: number;
   usage?: FragmentType<typeof SchemaExplorerUsageStats_UsageFragment>;
   supergraphMetadata?: FragmentType<typeof GraphQLTypeCard_SupergraphMetadataFragment> | null;
-  targetCleanId: string;
-  projectCleanId: string;
-  organizationCleanId: string;
+  targetSlug: string;
+  projectSlug: string;
+  organizationSlug: string;
   children: ReactNode;
 }): ReactElement {
   const supergraphMetadata = useFragment(
@@ -294,9 +294,9 @@ export function GraphQLTypeCard(props: {
             <div className="font-normal text-gray-500">{props.kind}</div>
             <div className="font-semibold">
               <GraphQLTypeAsLink
-                organizationId={props.organizationCleanId}
-                projectId={props.projectCleanId}
-                targetId={props.targetCleanId}
+                organizationId={props.organizationSlug}
+                projectId={props.projectSlug}
+                targetId={props.targetSlug}
                 type={props.name}
               />
             </div>
@@ -309,9 +309,9 @@ export function GraphQLTypeCard(props: {
             <div className="flex flex-row gap-2">
               {props.implements.map(t => (
                 <GraphQLTypeAsLink
-                  organizationId={props.organizationCleanId}
-                  projectId={props.projectCleanId}
-                  targetId={props.targetCleanId}
+                  organizationId={props.organizationSlug}
+                  projectId={props.projectSlug}
+                  targetId={props.targetSlug}
                   key={t}
                   type={t}
                 />
@@ -323,16 +323,16 @@ export function GraphQLTypeCard(props: {
           <SchemaExplorerUsageStats
             totalRequests={props.totalRequests}
             usage={props.usage}
-            organizationCleanId={props.organizationCleanId}
-            projectCleanId={props.projectCleanId}
-            targetCleanId={props.targetCleanId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
           />
         ) : null}
         {supergraphMetadata ? (
           <SupergraphMetadataList
-            targetId={props.targetCleanId}
-            projectId={props.projectCleanId}
-            organizationId={props.organizationCleanId}
+            targetId={props.targetSlug}
+            projectId={props.projectSlug}
+            organizationId={props.organizationSlug}
             supergraphMetadata={supergraphMetadata}
           />
         ) : null}
@@ -346,9 +346,9 @@ function GraphQLArguments(props: {
   parentCoordinate: string;
   args: FragmentType<typeof GraphQLArguments_ArgumentFragment>[];
   styleDeprecated: boolean;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const args = useFragment(GraphQLArguments_ArgumentFragment, props.args);
   const [isCollapsedGlobally] = useArgumentListToggle();
@@ -374,9 +374,9 @@ function GraphQLArguments(props: {
                   deprecationReason={arg.deprecationReason}
                 >
                   <LinkToCoordinatePage
-                    organizationId={props.organizationCleanId}
-                    projectId={props.projectCleanId}
-                    targetId={props.targetCleanId}
+                    organizationId={props.organizationSlug}
+                    projectId={props.projectSlug}
+                    targetId={props.targetSlug}
                     coordinate={coordinate}
                   >
                     {arg.name}
@@ -384,9 +384,9 @@ function GraphQLArguments(props: {
                 </DeprecationNote>
                 {': '}
                 <GraphQLTypeAsLink
-                  organizationId={props.organizationCleanId}
-                  projectId={props.projectCleanId}
-                  targetId={props.targetCleanId}
+                  organizationId={props.organizationSlug}
+                  projectId={props.projectSlug}
+                  targetId={props.targetSlug}
                   type={arg.type}
                 />
                 {arg.description ? <Description description={arg.description} /> : null}
@@ -412,9 +412,9 @@ function GraphQLArguments(props: {
                 deprecationReason={arg.deprecationReason}
               >
                 <LinkToCoordinatePage
-                  organizationId={props.organizationCleanId}
-                  projectId={props.projectCleanId}
-                  targetId={props.targetCleanId}
+                  organizationId={props.organizationSlug}
+                  projectId={props.projectSlug}
+                  targetId={props.targetSlug}
                   coordinate={coordinate}
                 >
                   {arg.name}
@@ -422,9 +422,9 @@ function GraphQLArguments(props: {
               </DeprecationNote>
               {': '}
               <GraphQLTypeAsLink
-                organizationId={props.organizationCleanId}
-                projectId={props.projectCleanId}
-                targetId={props.targetCleanId}
+                organizationId={props.organizationSlug}
+                projectId={props.projectSlug}
+                targetId={props.targetSlug}
                 type={arg.type}
               />
             </span>
@@ -469,9 +469,9 @@ export function GraphQLFields(props: {
   fields: Array<FragmentType<typeof GraphQLFields_FieldFragment>>;
   totalRequests?: number;
   collapsed?: boolean;
-  targetCleanId: string;
-  projectCleanId: string;
-  organizationCleanId: string;
+  targetSlug: string;
+  projectSlug: string;
+  organizationSlug: string;
   filterValue?: string;
   warnAboutUnusedArguments: boolean;
   warnAboutDeprecatedArguments: boolean;
@@ -536,9 +536,9 @@ export function GraphQLFields(props: {
                   deprecationReason={field.deprecationReason}
                 >
                   <LinkToCoordinatePage
-                    organizationId={props.organizationCleanId}
-                    projectId={props.projectCleanId}
-                    targetId={props.targetCleanId}
+                    organizationId={props.organizationSlug}
+                    projectId={props.projectSlug}
+                    targetId={props.targetSlug}
                     coordinate={coordinate}
                     className="font-semibold"
                   >
@@ -547,9 +547,9 @@ export function GraphQLFields(props: {
                 </DeprecationNote>
                 {field.args.length > 0 ? (
                   <GraphQLArguments
-                    organizationCleanId={props.organizationCleanId}
-                    projectCleanId={props.projectCleanId}
-                    targetCleanId={props.targetCleanId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                     styleDeprecated={props.styleDeprecated}
                     parentCoordinate={coordinate}
                     args={field.args}
@@ -557,9 +557,9 @@ export function GraphQLFields(props: {
                 ) : null}
                 <span className="mr-1">:</span>
                 <GraphQLTypeAsLink
-                  organizationId={props.organizationCleanId}
-                  projectId={props.projectCleanId}
-                  targetId={props.targetCleanId}
+                  organizationId={props.organizationSlug}
+                  projectId={props.projectSlug}
+                  targetId={props.targetSlug}
                   className="font-semibold text-gray-400"
                   type={field.type}
                 />
@@ -568,9 +568,9 @@ export function GraphQLFields(props: {
                 {field.supergraphMetadata ? (
                   <div className="ml-1">
                     <SupergraphMetadataList
-                      targetId={props.targetCleanId}
-                      projectId={props.projectCleanId}
-                      organizationId={props.organizationCleanId}
+                      targetId={props.targetSlug}
+                      projectId={props.projectSlug}
+                      organizationId={props.organizationSlug}
                       supergraphMetadata={field.supergraphMetadata}
                     />
                   </div>
@@ -579,9 +579,9 @@ export function GraphQLFields(props: {
                   <SchemaExplorerUsageStats
                     totalRequests={totalRequests}
                     usage={field.usage}
-                    targetCleanId={props.targetCleanId}
-                    projectCleanId={props.projectCleanId}
-                    organizationCleanId={props.organizationCleanId}
+                    targetSlug={props.targetSlug}
+                    projectSlug={props.projectSlug}
+                    organizationSlug={props.organizationSlug}
                   />
                 ) : null}
               </div>
@@ -606,9 +606,9 @@ export function GraphQLInputFields(props: {
   typeName: string;
   fields: FragmentType<typeof GraphQLInputFields_InputFieldFragment>[];
   totalRequests?: number;
-  targetCleanId: string;
-  projectCleanId: string;
-  organizationCleanId: string;
+  targetSlug: string;
+  projectSlug: string;
+  organizationSlug: string;
   styleDeprecated: boolean;
 }): ReactElement {
   const fields = useFragment(GraphQLInputFields_InputFieldFragment, props.fields);
@@ -625,9 +625,9 @@ export function GraphQLInputFields(props: {
                 deprecationReason={field.deprecationReason}
               >
                 <LinkToCoordinatePage
-                  organizationId={props.organizationCleanId}
-                  projectId={props.projectCleanId}
-                  targetId={props.targetCleanId}
+                  organizationId={props.organizationSlug}
+                  projectId={props.projectSlug}
+                  targetId={props.targetSlug}
                   coordinate={coordinate}
                   className="font-semibold text-white"
                 >
@@ -636,9 +636,9 @@ export function GraphQLInputFields(props: {
               </DeprecationNote>
               <span className="mr-1">:</span>
               <GraphQLTypeAsLink
-                organizationId={props.organizationCleanId}
-                projectId={props.projectCleanId}
-                targetId={props.targetCleanId}
+                organizationId={props.organizationSlug}
+                projectId={props.projectSlug}
+                targetId={props.targetSlug}
                 className="font-semibold"
                 type={field.type}
               />
@@ -647,9 +647,9 @@ export function GraphQLInputFields(props: {
               <SchemaExplorerUsageStats
                 totalRequests={props.totalRequests}
                 usage={field.usage}
-                targetCleanId={props.targetCleanId}
-                projectCleanId={props.projectCleanId}
-                organizationCleanId={props.organizationCleanId}
+                targetSlug={props.targetSlug}
+                projectSlug={props.projectSlug}
+                organizationSlug={props.organizationSlug}
               />
             ) : null}
           </GraphQLTypeCardListItem>
@@ -679,11 +679,11 @@ function GraphQLTypeAsLink(props: {
           <p>
             <NextLink
               className="text-sm font-normal hover:underline hover:underline-offset-2"
-              to="/$organizationId/$projectId/$targetId/explorer/$typename"
+              to="/$organizationSlug/$projectSlug/$targetSlug/explorer/$typename"
               params={{
-                organizationId: props.organizationId,
-                projectId: props.projectId,
-                targetId: props.targetId,
+                organizationSlug: props.organizationId,
+                projectSlug: props.projectId,
+                targetSlug: props.targetId,
                 typename,
               }}
               search={router.latestLocation.search}
@@ -695,11 +695,11 @@ function GraphQLTypeAsLink(props: {
           <p>
             <NextLink
               className="text-sm font-normal hover:underline hover:underline-offset-2"
-              to="/$organizationId/$projectId/$targetId/insights/schema-coordinate/$coordinate"
+              to="/$organizationSlug/$projectSlug/$targetSlug/insights/schema-coordinate/$coordinate"
               params={{
-                organizationId: props.organizationId,
-                projectId: props.projectId,
-                targetId: props.targetId,
+                organizationSlug: props.organizationId,
+                projectSlug: props.projectId,
+                targetSlug: props.targetId,
                 coordinate: typename,
               }}
               search={router.latestLocation.search}
@@ -732,11 +732,11 @@ export const LinkToCoordinatePage = React.forwardRef<
     <NextLink
       ref={ref}
       className={cn('hover:underline hover:underline-offset-2', props.className)}
-      to="/$organizationId/$projectId/$targetId/insights/schema-coordinate/$coordinate"
+      to="/$organizationSlug/$projectSlug/$targetSlug/insights/schema-coordinate/$coordinate"
       params={{
-        organizationId: props.organizationId,
-        projectId: props.projectId,
-        targetId: props.targetId,
+        organizationSlug: props.organizationId,
+        projectSlug: props.projectId,
+        targetSlug: props.targetId,
         coordinate: props.coordinate,
       }}
       search={router.latestLocation.search}

--- a/packages/web/app/src/components/target/explorer/common.tsx
+++ b/packages/web/app/src/components/target/explorer/common.tsx
@@ -294,9 +294,9 @@ export function GraphQLTypeCard(props: {
             <div className="font-normal text-gray-500">{props.kind}</div>
             <div className="font-semibold">
               <GraphQLTypeAsLink
-                organizationId={props.organizationSlug}
-                projectId={props.projectSlug}
-                targetId={props.targetSlug}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 type={props.name}
               />
             </div>
@@ -309,9 +309,9 @@ export function GraphQLTypeCard(props: {
             <div className="flex flex-row gap-2">
               {props.implements.map(t => (
                 <GraphQLTypeAsLink
-                  organizationId={props.organizationSlug}
-                  projectId={props.projectSlug}
-                  targetId={props.targetSlug}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   key={t}
                   type={t}
                 />
@@ -330,9 +330,9 @@ export function GraphQLTypeCard(props: {
         ) : null}
         {supergraphMetadata ? (
           <SupergraphMetadataList
-            targetId={props.targetSlug}
-            projectId={props.projectSlug}
-            organizationId={props.organizationSlug}
+            targetSlug={props.targetSlug}
+            projectSlug={props.projectSlug}
+            organizationSlug={props.organizationSlug}
             supergraphMetadata={supergraphMetadata}
           />
         ) : null}
@@ -374,9 +374,9 @@ function GraphQLArguments(props: {
                   deprecationReason={arg.deprecationReason}
                 >
                   <LinkToCoordinatePage
-                    organizationId={props.organizationSlug}
-                    projectId={props.projectSlug}
-                    targetId={props.targetSlug}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                     coordinate={coordinate}
                   >
                     {arg.name}
@@ -384,9 +384,9 @@ function GraphQLArguments(props: {
                 </DeprecationNote>
                 {': '}
                 <GraphQLTypeAsLink
-                  organizationId={props.organizationSlug}
-                  projectId={props.projectSlug}
-                  targetId={props.targetSlug}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   type={arg.type}
                 />
                 {arg.description ? <Description description={arg.description} /> : null}
@@ -412,9 +412,9 @@ function GraphQLArguments(props: {
                 deprecationReason={arg.deprecationReason}
               >
                 <LinkToCoordinatePage
-                  organizationId={props.organizationSlug}
-                  projectId={props.projectSlug}
-                  targetId={props.targetSlug}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   coordinate={coordinate}
                 >
                   {arg.name}
@@ -422,9 +422,9 @@ function GraphQLArguments(props: {
               </DeprecationNote>
               {': '}
               <GraphQLTypeAsLink
-                organizationId={props.organizationSlug}
-                projectId={props.projectSlug}
-                targetId={props.targetSlug}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 type={arg.type}
               />
             </span>
@@ -536,9 +536,9 @@ export function GraphQLFields(props: {
                   deprecationReason={field.deprecationReason}
                 >
                   <LinkToCoordinatePage
-                    organizationId={props.organizationSlug}
-                    projectId={props.projectSlug}
-                    targetId={props.targetSlug}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                     coordinate={coordinate}
                     className="font-semibold"
                   >
@@ -557,9 +557,9 @@ export function GraphQLFields(props: {
                 ) : null}
                 <span className="mr-1">:</span>
                 <GraphQLTypeAsLink
-                  organizationId={props.organizationSlug}
-                  projectId={props.projectSlug}
-                  targetId={props.targetSlug}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   className="font-semibold text-gray-400"
                   type={field.type}
                 />
@@ -568,9 +568,9 @@ export function GraphQLFields(props: {
                 {field.supergraphMetadata ? (
                   <div className="ml-1">
                     <SupergraphMetadataList
-                      targetId={props.targetSlug}
-                      projectId={props.projectSlug}
-                      organizationId={props.organizationSlug}
+                      targetSlug={props.targetSlug}
+                      projectSlug={props.projectSlug}
+                      organizationSlug={props.organizationSlug}
                       supergraphMetadata={field.supergraphMetadata}
                     />
                   </div>
@@ -625,9 +625,9 @@ export function GraphQLInputFields(props: {
                 deprecationReason={field.deprecationReason}
               >
                 <LinkToCoordinatePage
-                  organizationId={props.organizationSlug}
-                  projectId={props.projectSlug}
-                  targetId={props.targetSlug}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   coordinate={coordinate}
                   className="font-semibold text-white"
                 >
@@ -636,9 +636,9 @@ export function GraphQLInputFields(props: {
               </DeprecationNote>
               <span className="mr-1">:</span>
               <GraphQLTypeAsLink
-                organizationId={props.organizationSlug}
-                projectId={props.projectSlug}
-                targetId={props.targetSlug}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 className="font-semibold"
                 type={field.type}
               />
@@ -662,9 +662,9 @@ export function GraphQLInputFields(props: {
 function GraphQLTypeAsLink(props: {
   type: string;
   className?: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const router = useRouter();
   const typename = props.type.replace(/[[\]!]+/g, '');
@@ -681,9 +681,9 @@ function GraphQLTypeAsLink(props: {
               className="text-sm font-normal hover:underline hover:underline-offset-2"
               to="/$organizationSlug/$projectSlug/$targetSlug/explorer/$typename"
               params={{
-                organizationSlug: props.organizationId,
-                projectSlug: props.projectId,
-                targetSlug: props.targetId,
+                organizationSlug: props.organizationSlug,
+                projectSlug: props.projectSlug,
+                targetSlug: props.targetSlug,
                 typename,
               }}
               search={router.latestLocation.search}
@@ -697,9 +697,9 @@ function GraphQLTypeAsLink(props: {
               className="text-sm font-normal hover:underline hover:underline-offset-2"
               to="/$organizationSlug/$projectSlug/$targetSlug/insights/schema-coordinate/$coordinate"
               params={{
-                organizationSlug: props.organizationId,
-                projectSlug: props.projectId,
-                targetSlug: props.targetId,
+                organizationSlug: props.organizationSlug,
+                projectSlug: props.projectSlug,
+                targetSlug: props.targetSlug,
                 coordinate: typename,
               }}
               search={router.latestLocation.search}
@@ -720,9 +720,9 @@ export const LinkToCoordinatePage = React.forwardRef<
   {
     coordinate: string;
     children: ReactNode;
-    organizationId: string;
-    projectId: string;
-    targetId: string;
+    organizationSlug: string;
+    projectSlug: string;
+    targetSlug: string;
     className?: string;
   }
 >((props, ref) => {
@@ -734,9 +734,9 @@ export const LinkToCoordinatePage = React.forwardRef<
       className={cn('hover:underline hover:underline-offset-2', props.className)}
       to="/$organizationSlug/$projectSlug/$targetSlug/insights/schema-coordinate/$coordinate"
       params={{
-        organizationSlug: props.organizationId,
-        projectSlug: props.projectId,
-        targetSlug: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
         coordinate: props.coordinate,
       }}
       search={router.latestLocation.search}

--- a/packages/web/app/src/components/target/explorer/enum-type.tsx
+++ b/packages/web/app/src/components/target/explorer/enum-type.tsx
@@ -36,9 +36,9 @@ const GraphQLEnumTypeComponent_TypeFragment = graphql(`
 export function GraphQLEnumTypeComponent(props: {
   type: FragmentType<typeof GraphQLEnumTypeComponent_TypeFragment>;
   totalRequests?: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   styleDeprecated: boolean;
 }) {
   const ttype = useFragment(GraphQLEnumTypeComponent_TypeFragment, props.type);
@@ -48,9 +48,9 @@ export function GraphQLEnumTypeComponent(props: {
       kind="enum"
       description={ttype.description}
       supergraphMetadata={ttype.supergraphMetadata}
-      targetCleanId={props.targetCleanId}
-      projectCleanId={props.projectCleanId}
-      organizationCleanId={props.organizationCleanId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
     >
       <div className="flex flex-col">
         {ttype.values.map((value, i) => (
@@ -61,9 +61,9 @@ export function GraphQLEnumTypeComponent(props: {
                 deprecationReason={value.deprecationReason}
               >
                 <LinkToCoordinatePage
-                  organizationId={props.organizationCleanId}
-                  projectId={props.projectCleanId}
-                  targetId={props.targetCleanId}
+                  organizationId={props.organizationSlug}
+                  projectId={props.projectSlug}
+                  targetId={props.targetSlug}
                   coordinate={`${ttype.name}.${value.name}`}
                 >
                   {value.name}
@@ -72,9 +72,9 @@ export function GraphQLEnumTypeComponent(props: {
             </div>
             {value.supergraphMetadata ? (
               <SupergraphMetadataList
-                targetId={props.targetCleanId}
-                projectId={props.projectCleanId}
-                organizationId={props.organizationCleanId}
+                targetId={props.targetSlug}
+                projectId={props.projectSlug}
+                organizationId={props.organizationSlug}
                 supergraphMetadata={value.supergraphMetadata}
               />
             ) : null}
@@ -82,9 +82,9 @@ export function GraphQLEnumTypeComponent(props: {
               <SchemaExplorerUsageStats
                 totalRequests={props.totalRequests}
                 usage={value.usage}
-                targetCleanId={props.targetCleanId}
-                projectCleanId={props.projectCleanId}
-                organizationCleanId={props.organizationCleanId}
+                targetSlug={props.targetSlug}
+                projectSlug={props.projectSlug}
+                organizationSlug={props.organizationSlug}
               />
             ) : null}
           </GraphQLTypeCardListItem>

--- a/packages/web/app/src/components/target/explorer/enum-type.tsx
+++ b/packages/web/app/src/components/target/explorer/enum-type.tsx
@@ -61,9 +61,9 @@ export function GraphQLEnumTypeComponent(props: {
                 deprecationReason={value.deprecationReason}
               >
                 <LinkToCoordinatePage
-                  organizationId={props.organizationSlug}
-                  projectId={props.projectSlug}
-                  targetId={props.targetSlug}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   coordinate={`${ttype.name}.${value.name}`}
                 >
                   {value.name}
@@ -72,9 +72,9 @@ export function GraphQLEnumTypeComponent(props: {
             </div>
             {value.supergraphMetadata ? (
               <SupergraphMetadataList
-                targetId={props.targetSlug}
-                projectId={props.projectSlug}
-                organizationId={props.organizationSlug}
+                targetSlug={props.targetSlug}
+                projectSlug={props.projectSlug}
+                organizationSlug={props.organizationSlug}
                 supergraphMetadata={value.supergraphMetadata}
               />
             ) : null}

--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -99,11 +99,11 @@ export function TypeFilter(props: {
       options={types}
       onChange={option => {
         void router.navigate({
-          to: '/$organizationId/$projectId/$targetId/explorer/$typename',
+          to: '/$organizationSlug/$projectSlug/$targetSlug/explorer/$typename',
           params: {
-            organizationId: props.organizationId,
-            projectId: props.projectId,
-            targetId: props.targetId,
+            organizationSlug: props.organizationId,
+            projectSlug: props.projectId,
+            targetSlug: props.targetId,
             typename: option.value,
           },
         });
@@ -190,19 +190,19 @@ const variants: Array<{
   {
     value: 'all',
     label: 'All',
-    pathname: '/$organizationId/$projectId/$targetId/explorer',
+    pathname: '/$organizationSlug/$projectSlug/$targetSlug/explorer',
     tooltip: 'Shows all types, including unused and deprecated ones',
   },
   {
     value: 'unused',
     label: 'Unused',
-    pathname: '/$organizationId/$projectId/$targetId/explorer/unused',
+    pathname: '/$organizationSlug/$projectSlug/$targetSlug/explorer/unused',
     tooltip: 'Shows only types that are not used in any operation',
   },
   {
     value: 'deprecated',
     label: 'Deprecated',
-    pathname: '/$organizationId/$projectId/$targetId/explorer/deprecated',
+    pathname: '/$organizationSlug/$projectSlug/$targetSlug/explorer/deprecated',
     tooltip: 'Shows only types that are marked as deprecated',
   },
 ];
@@ -229,9 +229,9 @@ export function SchemaVariantFilter(props: {
                     <Link
                       to={variant.pathname}
                       params={{
-                        organizationId: props.organizationId,
-                        projectId: props.projectId,
-                        targetId: props.targetId,
+                        organizationSlug: props.organizationId,
+                        projectSlug: props.projectId,
+                        targetSlug: props.targetId,
                       }}
                     >
                       {variant.label}

--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -19,12 +19,18 @@ import { useArgumentListToggle, usePeriodSelector } from './provider';
 
 const TypeFilter_AllTypes = graphql(`
   query TypeFilter_AllTypes(
-    $organization: ID!
-    $project: ID!
-    $target: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $period: DateRangeInput!
   ) {
-    target(selector: { organization: $organization, project: $project, target: $target }) {
+    target(
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
+    ) {
       __typename
       id
       latestValidSchemaVersion {
@@ -61,9 +67,9 @@ const TypeFilter_AllTypes = graphql(`
 
 export function TypeFilter(props: {
   typename?: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   period: {
     to: string;
     from: string;
@@ -73,9 +79,9 @@ export function TypeFilter(props: {
   const [query] = useQuery({
     query: TypeFilter_AllTypes,
     variables: {
-      organization: props.organizationId,
-      project: props.projectId,
-      target: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       period: props.period,
     },
     requestPolicy: 'cache-first',
@@ -101,9 +107,9 @@ export function TypeFilter(props: {
         void router.navigate({
           to: '/$organizationSlug/$projectSlug/$targetSlug/explorer/$typename',
           params: {
-            organizationSlug: props.organizationId,
-            projectSlug: props.projectId,
-            targetSlug: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
             typename: option.value,
           },
         });
@@ -208,9 +214,9 @@ const variants: Array<{
 ];
 
 export function SchemaVariantFilter(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   variant: 'all' | 'unused' | 'deprecated';
 }) {
   return (
@@ -229,9 +235,9 @@ export function SchemaVariantFilter(props: {
                     <Link
                       to={variant.pathname}
                       params={{
-                        organizationSlug: props.organizationId,
-                        projectSlug: props.projectId,
-                        targetSlug: props.targetId,
+                        organizationSlug: props.organizationSlug,
+                        projectSlug: props.projectSlug,
+                        targetSlug: props.targetSlug,
                       }}
                     >
                       {variant.label}

--- a/packages/web/app/src/components/target/explorer/input-object-type.tsx
+++ b/packages/web/app/src/components/target/explorer/input-object-type.tsx
@@ -20,9 +20,9 @@ const GraphQLInputObjectTypeComponent_TypeFragment = graphql(`
 export function GraphQLInputObjectTypeComponent(props: {
   type: FragmentType<typeof GraphQLInputObjectTypeComponent_TypeFragment>;
   totalRequests?: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   styleDeprecated: boolean;
 }) {
   const ttype = useFragment(GraphQLInputObjectTypeComponent_TypeFragment, props.type);
@@ -34,17 +34,17 @@ export function GraphQLInputObjectTypeComponent(props: {
       totalRequests={props.totalRequests}
       usage={ttype.usage}
       supergraphMetadata={ttype.supergraphMetadata}
-      targetCleanId={props.targetCleanId}
-      projectCleanId={props.projectCleanId}
-      organizationCleanId={props.organizationCleanId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
     >
       <GraphQLInputFields
         typeName={ttype.name}
         fields={ttype.fields}
         totalRequests={props.totalRequests}
-        targetCleanId={props.targetCleanId}
-        projectCleanId={props.projectCleanId}
-        organizationCleanId={props.organizationCleanId}
+        targetSlug={props.targetSlug}
+        projectSlug={props.projectSlug}
+        organizationSlug={props.organizationSlug}
         styleDeprecated={props.styleDeprecated}
       />
     </GraphQLTypeCard>

--- a/packages/web/app/src/components/target/explorer/interface-type.tsx
+++ b/packages/web/app/src/components/target/explorer/interface-type.tsx
@@ -21,9 +21,9 @@ const GraphQLInterfaceTypeComponent_TypeFragment = graphql(`
 export function GraphQLInterfaceTypeComponent(props: {
   type: FragmentType<typeof GraphQLInterfaceTypeComponent_TypeFragment>;
   totalRequests?: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   warnAboutUnusedArguments: boolean;
   warnAboutDeprecatedArguments: boolean;
   styleDeprecated: boolean;
@@ -36,17 +36,17 @@ export function GraphQLInterfaceTypeComponent(props: {
       description={ttype.description}
       implements={ttype.interfaces}
       supergraphMetadata={ttype.supergraphMetadata}
-      targetCleanId={props.targetCleanId}
-      projectCleanId={props.projectCleanId}
-      organizationCleanId={props.organizationCleanId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
     >
       <GraphQLFields
         typeName={ttype.name}
         fields={ttype.fields}
         totalRequests={props.totalRequests}
-        targetCleanId={props.targetCleanId}
-        projectCleanId={props.projectCleanId}
-        organizationCleanId={props.organizationCleanId}
+        targetSlug={props.targetSlug}
+        projectSlug={props.projectSlug}
+        organizationSlug={props.organizationSlug}
         warnAboutDeprecatedArguments={props.warnAboutDeprecatedArguments}
         warnAboutUnusedArguments={props.warnAboutUnusedArguments}
         styleDeprecated={props.styleDeprecated}

--- a/packages/web/app/src/components/target/explorer/object-type.tsx
+++ b/packages/web/app/src/components/target/explorer/object-type.tsx
@@ -23,9 +23,9 @@ export function GraphQLObjectTypeComponent(props: {
   type: FragmentType<typeof GraphQLObjectTypeComponent_TypeFragment>;
   totalRequests?: number;
   collapsed?: boolean;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   warnAboutUnusedArguments: boolean;
   warnAboutDeprecatedArguments: boolean;
   styleDeprecated: boolean;
@@ -43,9 +43,9 @@ export function GraphQLObjectTypeComponent(props: {
       description={ttype.description}
       implements={ttype.interfaces}
       supergraphMetadata={ttype.supergraphMetadata}
-      targetCleanId={props.targetCleanId}
-      projectCleanId={props.projectCleanId}
-      organizationCleanId={props.organizationCleanId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
     >
       <GraphQLFields
         typeName={ttype.name}
@@ -53,9 +53,9 @@ export function GraphQLObjectTypeComponent(props: {
         filterValue={search}
         totalRequests={props.totalRequests}
         collapsed={props.collapsed}
-        targetCleanId={props.targetCleanId}
-        projectCleanId={props.projectCleanId}
-        organizationCleanId={props.organizationCleanId}
+        targetSlug={props.targetSlug}
+        projectSlug={props.projectSlug}
+        organizationSlug={props.organizationSlug}
         warnAboutDeprecatedArguments={props.warnAboutDeprecatedArguments}
         warnAboutUnusedArguments={props.warnAboutUnusedArguments}
         styleDeprecated={props.styleDeprecated}

--- a/packages/web/app/src/components/target/explorer/scalar-type.tsx
+++ b/packages/web/app/src/components/target/explorer/scalar-type.tsx
@@ -18,9 +18,9 @@ const GraphQLScalarTypeComponent_TypeFragment = graphql(`
 export function GraphQLScalarTypeComponent(props: {
   type: FragmentType<typeof GraphQLScalarTypeComponent_TypeFragment>;
   totalRequests?: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const ttype = useFragment(GraphQLScalarTypeComponent_TypeFragment, props.type);
   return (
@@ -28,9 +28,9 @@ export function GraphQLScalarTypeComponent(props: {
       name={ttype.name}
       kind="scalar"
       supergraphMetadata={ttype.supergraphMetadata}
-      targetCleanId={props.targetCleanId}
-      projectCleanId={props.projectCleanId}
-      organizationCleanId={props.organizationCleanId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
     >
       <div className="flex flex-row gap-4 p-4">
         <div className="grow text-sm">
@@ -40,9 +40,9 @@ export function GraphQLScalarTypeComponent(props: {
           <SchemaExplorerUsageStats
             totalRequests={props.totalRequests}
             usage={ttype.usage}
-            targetCleanId={props.targetCleanId}
-            projectCleanId={props.projectCleanId}
-            organizationCleanId={props.organizationCleanId}
+            targetSlug={props.targetSlug}
+            projectSlug={props.projectSlug}
+            organizationSlug={props.organizationSlug}
           />
         ) : null}
       </div>

--- a/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
+++ b/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
@@ -24,11 +24,11 @@ function SubgraphChip(props: {
 }): React.ReactElement {
   const inner = (
     <Link
-      to="/$organizationId/$projectId/$targetId"
+      to="/$organizationSlug/$projectSlug/$targetSlug"
       params={{
-        organizationId: props.organizationId,
-        projectId: props.projectId,
-        targetId: props.targetId,
+        organizationSlug: props.organizationId,
+        projectSlug: props.projectId,
+        targetSlug: props.targetId,
       }}
       // TODO(router)
       hash={`service-${props.text}`}

--- a/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
+++ b/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
@@ -18,17 +18,17 @@ function stringToHslColor(str: string, s = 30, l = 80) {
 function SubgraphChip(props: {
   text: string;
   tooltip: boolean;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): React.ReactElement {
   const inner = (
     <Link
       to="/$organizationSlug/$projectSlug/$targetSlug"
       params={{
-        organizationSlug: props.organizationId,
-        projectSlug: props.projectId,
-        targetSlug: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       }}
       // TODO(router)
       hash={`service-${props.text}`}
@@ -67,9 +67,9 @@ const tooltipColor = 'rgb(36, 39, 46)';
 const previewThreshold = 3;
 
 export function SupergraphMetadataList(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   supergraphMetadata: FragmentType<typeof SupergraphMetadataList_SupergraphMetadataFragment>;
 }) {
   const supergraphMetadata = useFragment(
@@ -86,9 +86,9 @@ export function SupergraphMetadataList(props: {
       return [
         supergraphMetadata.ownedByServiceNames.map((serviceName, index) => (
           <SubgraphChip
-            organizationId={props.organizationId}
-            projectId={props.projectId}
-            targetId={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             key={`${serviceName}-${index}`}
             text={serviceName}
             tooltip
@@ -103,9 +103,9 @@ export function SupergraphMetadataList(props: {
         .slice(0, previewThreshold)
         .map((serviceName, index) => (
           <SubgraphChip
-            organizationId={props.organizationId}
-            projectId={props.projectId}
-            targetId={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             key={`${serviceName}-${index}`}
             text={serviceName}
             tooltip
@@ -113,9 +113,9 @@ export function SupergraphMetadataList(props: {
         )),
       supergraphMetadata.ownedByServiceNames.map((serviceName, index) => (
         <SubgraphChip
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           key={`${serviceName}-${index}`}
           text={serviceName}
           tooltip={false}

--- a/packages/web/app/src/components/target/explorer/union-type.tsx
+++ b/packages/web/app/src/components/target/explorer/union-type.tsx
@@ -58,9 +58,9 @@ export function GraphQLUnionTypeComponent(props: {
             ) : null}
             {member.supergraphMetadata ? (
               <SupergraphMetadataList
-                targetId={props.targetSlug}
-                projectId={props.projectSlug}
-                organizationId={props.organizationSlug}
+                targetSlug={props.targetSlug}
+                projectSlug={props.projectSlug}
+                organizationSlug={props.organizationSlug}
                 supergraphMetadata={member.supergraphMetadata}
               />
             ) : null}

--- a/packages/web/app/src/components/target/explorer/union-type.tsx
+++ b/packages/web/app/src/components/target/explorer/union-type.tsx
@@ -28,9 +28,9 @@ const GraphQLUnionTypeComponent_TypeFragment = graphql(`
 export function GraphQLUnionTypeComponent(props: {
   type: FragmentType<typeof GraphQLUnionTypeComponent_TypeFragment>;
   totalRequests?: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const ttype = useFragment(GraphQLUnionTypeComponent_TypeFragment, props.type);
   return (
@@ -39,9 +39,9 @@ export function GraphQLUnionTypeComponent(props: {
       kind="union"
       description={ttype.description}
       supergraphMetadata={ttype.supergraphMetadata}
-      targetCleanId={props.targetCleanId}
-      projectCleanId={props.projectCleanId}
-      organizationCleanId={props.organizationCleanId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
     >
       <div className="flex flex-col">
         {ttype.members.map((member, i) => (
@@ -51,16 +51,16 @@ export function GraphQLUnionTypeComponent(props: {
               <SchemaExplorerUsageStats
                 totalRequests={props.totalRequests}
                 usage={member.usage}
-                targetCleanId={props.targetCleanId}
-                projectCleanId={props.projectCleanId}
-                organizationCleanId={props.organizationCleanId}
+                targetSlug={props.targetSlug}
+                projectSlug={props.projectSlug}
+                organizationSlug={props.organizationSlug}
               />
             ) : null}
             {member.supergraphMetadata ? (
               <SupergraphMetadataList
-                targetId={props.targetCleanId}
-                projectId={props.projectCleanId}
-                organizationId={props.organizationCleanId}
+                targetId={props.targetSlug}
+                projectId={props.projectSlug}
+                organizationId={props.organizationSlug}
                 supergraphMetadata={member.supergraphMetadata}
               />
             ) : null}

--- a/packages/web/app/src/components/target/history/MarkAsValid.tsx
+++ b/packages/web/app/src/components/target/history/MarkAsValid.tsx
@@ -36,19 +36,19 @@ const MarkAsValid_SchemaVersionFragment = graphql(`
 
 export function MarkAsValid(props: {
   version: FragmentType<typeof MarkAsValid_SchemaVersionFragment>;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement | null {
   const version = useFragment(MarkAsValid_SchemaVersionFragment, props.version);
   const [mutation, mutate] = useMutation(UpdateSchemaVersionStatusMutation);
   const markAsValid = useCallback(async () => {
     await mutate({
       input: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
-        version: version.id,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
+        versionId: version.id,
         valid: true,
       },
     });

--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -112,9 +112,9 @@ export function ChangesBlock(
   props: {
     title: string | React.ReactElement;
     criticality: CriticalityLevel;
-    organizationId: string;
-    projectId: string;
-    targetId: string;
+    organizationSlug: string;
+    projectSlug: string;
+    targetSlug: string;
     schemaCheckId: string;
     conditionBreakingChangeMetadata?: FragmentType<
       typeof ChangesBlock_SchemaCheckConditionalBreakingChangeMetadataFragment
@@ -138,9 +138,9 @@ export function ChangesBlock(
       <div className="list-inside list-disc space-y-2 text-sm leading-relaxed">
         {changes.map((change, key) => (
           <ChangeItem
-            organizationId={props.organizationId}
-            projectId={props.projectId}
-            targetId={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             schemaCheckId={props.schemaCheckId}
             key={key}
             change={change}
@@ -170,9 +170,9 @@ function ChangeItem(props: {
   conditionBreakingChangeMetadata: FragmentType<
     typeof ChangesBlock_SchemaCheckConditionalBreakingChangeMetadataFragment
   > | null;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   schemaCheckId: string;
 }) {
   const change = isChangesBlock_SchemaChangeWithUsageFragment(props.change)
@@ -234,9 +234,9 @@ function ChangeItem(props: {
         <AccordionContent className="pb-8 pt-4">
           {change.approval && (
             <SchemaChangeApproval
-              organizationId={props.organizationId}
-              projectId={props.projectId}
-              targetId={props.targetId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
+              targetSlug={props.targetSlug}
               schemaCheckId={props.schemaCheckId}
               approval={change.approval}
             />
@@ -272,8 +272,8 @@ function ChangeItem(props: {
                                           className="text-orange-500 hover:text-orange-500"
                                           to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                                           params={{
-                                            organizationSlug: props.organizationId,
-                                            projectSlug: props.projectId,
+                                            organizationSlug: props.organizationSlug,
+                                            projectSlug: props.projectSlug,
                                             targetSlug: target.target.slug,
                                             operationName: `${hash.substring(0, 4)}_${name}`,
                                             operationHash: hash,
@@ -339,8 +339,8 @@ function ChangeItem(props: {
                             className="text-orange-500 hover:text-orange-500"
                             to="/$organizationSlug/$projectSlug/$targetSlug/insights/schema-coordinate/$coordinate"
                             params={{
-                              organizationSlug: props.organizationId,
-                              projectSlug: props.projectId,
+                              organizationSlug: props.organizationSlug,
+                              projectSlug: props.projectSlug,
                               targetSlug: target.target.slug,
                               coordinate: change.path!.join('.'),
                             }}
@@ -387,9 +387,9 @@ function ApprovedByBadge(props: {
 
 function SchemaChangeApproval(props: {
   approval: FragmentType<typeof ChangesBlock_SchemaChangeApprovalFragment>;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   schemaCheckId: string;
 }) {
   const approval = useFragment(ChangesBlock_SchemaChangeApprovalFragment, props.approval);
@@ -397,9 +397,13 @@ function SchemaChangeApproval(props: {
   const approvalDate = format(new Date(approval.approvedAt), 'do MMMM yyyy');
   const schemaCheckPath =
     '/' +
-    [props.organizationId, props.projectId, props.targetId, 'checks', approval.schemaCheckId].join(
-      '/',
-    );
+    [
+      props.organizationSlug,
+      props.projectSlug,
+      props.targetSlug,
+      'checks',
+      approval.schemaCheckId,
+    ].join('/');
 
   return (
     <div className="mb-3">

--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -270,11 +270,11 @@ function ChangeItem(props: {
                                       <p key={i}>
                                         <Link
                                           className="text-orange-500 hover:text-orange-500"
-                                          to="/$organizationId/$projectId/$targetId/insights/$operationName/$operationHash"
+                                          to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                                           params={{
-                                            organizationId: props.organizationId,
-                                            projectId: props.projectId,
-                                            targetId: target.target.slug,
+                                            organizationSlug: props.organizationId,
+                                            projectSlug: props.projectId,
+                                            targetSlug: target.target.slug,
                                             operationName: `${hash.substring(0, 4)}_${name}`,
                                             operationHash: hash,
                                           }}
@@ -337,11 +337,11 @@ function ChangeItem(props: {
                           <Link
                             key={index}
                             className="text-orange-500 hover:text-orange-500"
-                            to="/$organizationId/$projectId/$targetId/insights/schema-coordinate/$coordinate"
+                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/schema-coordinate/$coordinate"
                             params={{
-                              organizationId: props.organizationId,
-                              projectId: props.projectId,
-                              targetId: target.target.slug,
+                              organizationSlug: props.organizationId,
+                              projectSlug: props.projectId,
+                              targetSlug: target.target.slug,
                               coordinate: change.path!.join('.'),
                             }}
                             target="_blank"

--- a/packages/web/app/src/components/target/insights/Filters.tsx
+++ b/packages/web/app/src/components/target/insights/Filters.tsx
@@ -213,9 +213,9 @@ function OperationsFilterContainer({
     query: OperationsFilterContainer_OperationStatsQuery,
     variables: {
       selector: {
-        organizationSlug: organizationSlug,
-        projectSlug: projectSlug,
-        targetSlug: targetSlug,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
         period,
         operations: [],
       },

--- a/packages/web/app/src/components/target/insights/Filters.tsx
+++ b/packages/web/app/src/components/target/insights/Filters.tsx
@@ -196,26 +196,26 @@ function OperationsFilterContainer({
   onClose,
   onFilter,
   selected,
-  organizationId,
-  projectId,
-  targetId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
 }: {
   onFilter(keys: string[]): void;
   onClose(): void;
   isOpen: boolean;
   period: DateRangeInput;
   selected?: string[];
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement | null {
   const [query, refresh] = useQuery({
     query: OperationsFilterContainer_OperationStatsQuery,
     variables: {
       selector: {
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationSlug: organizationSlug,
+        projectSlug: projectSlug,
+        targetSlug: targetSlug,
         period,
         operations: [],
       },
@@ -296,16 +296,16 @@ export function OperationsFilterTrigger({
   period,
   onFilter,
   selected,
-  organizationId,
-  projectId,
-  targetId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
 }: {
   period: DateRangeInput;
   onFilter(keys: string[]): void;
   selected?: string[];
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const [isOpen, toggle] = useToggle();
 
@@ -316,9 +316,9 @@ export function OperationsFilterTrigger({
         <FilterIcon className="ml-2 size-4" />
       </Button>
       <OperationsFilterContainer
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         isOpen={isOpen}
         onClose={toggle}
         period={period}
@@ -545,26 +545,26 @@ function ClientsFilterContainer({
   onClose,
   onFilter,
   selected,
-  organizationId,
-  projectId,
-  targetId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
 }: {
   onFilter(keys: string[]): void;
   onClose(): void;
   isOpen: boolean;
   period: DateRangeInput;
   selected?: string[];
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement | null {
   const [query, refresh] = useQuery({
     query: ClientsFilterContainer_ClientStatsQuery,
     variables: {
       selector: {
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
         period,
         operations: [],
       },
@@ -604,16 +604,16 @@ export function ClientsFilterTrigger({
   period,
   onFilter,
   selected,
-  organizationId,
-  projectId,
-  targetId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
 }: {
   period: DateRangeInput;
   onFilter(keys: string[]): void;
   selected?: string[];
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const [isOpen, toggle] = useToggle();
 
@@ -624,9 +624,9 @@ export function ClientsFilterTrigger({
         <FilterIcon className="ml-2 size-4" />
       </Button>
       <ClientsFilterContainer
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         isOpen={isOpen}
         onClose={toggle}
         period={period}

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -67,11 +67,11 @@ function OperationRow({
             <Button variant="orangeLink" className="h-auto p-0" asChild>
               <Link
                 className="block max-w-[300px] truncate"
-                to="/$organizationId/$projectId/$targetId/insights/$operationName/$operationHash"
+                to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                 params={{
-                  organizationId: organization,
-                  projectId: project,
-                  targetId: target,
+                  organizationSlug: organization,
+                  projectSlug: project,
+                  targetSlug: target,
                   operationName: operation.name,
                   operationHash: operation.hash,
                 }}

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -41,15 +41,15 @@ interface Operation {
 
 function OperationRow({
   operation,
-  organization,
-  project,
-  target,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   selectedPeriod,
 }: {
   operation: Operation;
-  organization: string;
-  project: string;
-  target: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   selectedPeriod: null | { to: string; from: string };
 }): ReactElement {
   const count = useFormattedNumber(operation.requests);
@@ -69,9 +69,9 @@ function OperationRow({
                 className="block max-w-[300px] truncate"
                 to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                 params={{
-                  organizationSlug: organization,
-                  projectSlug: project,
-                  targetSlug: target,
+                  organizationSlug: organizationSlug,
+                  projectSlug: projectSlug,
+                  targetSlug: targetSlug,
                   operationName: operation.name,
                   operationHash: operation.hash,
                 }}
@@ -174,9 +174,9 @@ function OperationsTable({
   pagination,
   setPagination,
   className,
-  organization,
-  project,
-  target,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   selectedPeriod,
 }: {
   operations: Operation[];
@@ -185,9 +185,9 @@ function OperationsTable({
   sorting: SortingState;
   setSorting: OnChangeFn<SortingState>;
   className?: string;
-  organization: string;
-  project: string;
-  target: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   clients: readonly { name: string }[] | null;
   clientFilter: string | null;
   setClientFilter: (filter: string) => void;
@@ -260,9 +260,9 @@ function OperationsTable({
                   <OperationRow
                     operation={row.original}
                     key={row.original.id}
-                    organization={organization}
-                    project={project}
-                    target={target}
+                    organizationSlug={organizationSlug}
+                    projectSlug={projectSlug}
+                    targetSlug={targetSlug}
                     selectedPeriod={selectedPeriod}
                   />
                 ),
@@ -342,9 +342,9 @@ const OperationsTableContainer_OperationsStatsFragment = graphql(`
 
 function OperationsTableContainer({
   operationsFilter,
-  organization,
-  project,
-  target,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   clientFilter,
   setClientFilter,
   className,
@@ -353,9 +353,9 @@ function OperationsTableContainer({
 }: {
   operationStats: FragmentType<typeof OperationsTableContainer_OperationsStatsFragment> | null;
   operationsFilter: readonly string[];
-  organization: string;
-  project: string;
-  target: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   selectedPeriod: { from: string; to: string } | null;
   clientFilter: string | null;
   setClientFilter: (client: string) => void;
@@ -424,9 +424,9 @@ function OperationsTableContainer({
       setPagination={safeSetPagination}
       sorting={sorting}
       setSorting={setSorting}
-      organization={organization}
-      project={project}
-      target={target}
+      organizationSlug={organizationSlug}
+      projectSlug={projectSlug}
+      targetSlug={targetSlug}
       clients={operationStats?.clients.nodes ?? null}
       clientFilter={clientFilter}
       setClientFilter={setClientFilter}
@@ -456,18 +456,18 @@ const OperationsList_OperationsStatsQuery = graphql(`
 
 export function OperationsList({
   className,
-  organization,
-  project,
-  target,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   period,
   operationsFilter = [],
   clientNamesFilter = [],
   selectedPeriod,
 }: {
   className?: string;
-  organization: string;
-  project: string;
-  target: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   period: DateRangeInput;
   operationsFilter: readonly string[];
   clientNamesFilter: string[];
@@ -478,9 +478,9 @@ export function OperationsList({
     query: OperationsList_OperationsStatsQuery,
     variables: {
       selector: {
-        organization,
-        project,
-        target,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
         period,
         operations: [],
         clientNames: clientNamesFilter,
@@ -507,9 +507,9 @@ export function OperationsList({
         className={className}
         setClientFilter={setClientFilter}
         clientFilter={clientFilter}
-        organization={organization}
-        project={project}
-        target={target}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         selectedPeriod={selectedPeriod}
       />
     </OperationsFallback>

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -69,9 +69,9 @@ function OperationRow({
                 className="block max-w-[300px] truncate"
                 to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                 params={{
-                  organizationSlug: organizationSlug,
-                  projectSlug: projectSlug,
-                  targetSlug: targetSlug,
+                  organizationSlug,
+                  projectSlug,
+                  targetSlug,
                   operationName: operation.name,
                   operationHash: operation.hash,
                 }}

--- a/packages/web/app/src/components/target/insights/Stats.tsx
+++ b/packages/web/app/src/components/target/insights/Stats.tsx
@@ -560,11 +560,11 @@ function ClientsStats(props: {
         }
 
         void router.navigate({
-          to: '/$organizationId/$projectId/$targetId/insights/client/$name',
+          to: '/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name',
           params: {
-            organizationId: props.organizationId,
-            projectId: props.projectId,
-            targetId: props.targetId,
+            organizationSlug: props.organizationId,
+            projectSlug: props.projectId,
+            targetSlug: props.targetId,
             name: ev.value,
           },
           search(searchParams) {

--- a/packages/web/app/src/components/target/insights/Stats.tsx
+++ b/packages/web/app/src/components/target/insights/Stats.tsx
@@ -422,9 +422,9 @@ function getLevelOption() {
 
 function ClientsStats(props: {
   operationStats: FragmentType<typeof ClientsStats_OperationsStatsFragment> | null;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const router = useRouter();
   const styles = useChartStyles();
@@ -562,9 +562,9 @@ function ClientsStats(props: {
         void router.navigate({
           to: '/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name',
           params: {
-            organizationSlug: props.organizationId,
-            projectSlug: props.projectId,
-            targetSlug: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
             name: ev.value,
           },
           search(searchParams) {
@@ -1005,9 +1005,9 @@ function RpmOverTimeStats({
 }
 
 export function OperationsStats({
-  organization,
-  project,
-  target,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   period,
   operationsFilter,
   clientNamesFilter,
@@ -1015,9 +1015,9 @@ export function OperationsStats({
   mode,
   dateRangeText,
 }: {
-  organization: string;
-  project: string;
-  target: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   period: {
     from: string;
     to: string;
@@ -1032,17 +1032,17 @@ export function OperationsStats({
     query: Stats_GeneralOperationsStatsQuery,
     variables: {
       selector: {
-        organization,
-        project,
-        target,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
         period,
         operations: operationsFilter,
         clientNames: clientNamesFilter,
       },
       allOperationsSelector: {
-        organization,
-        project,
-        target,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
         period,
       },
       resolution,
@@ -1129,9 +1129,9 @@ export function OperationsStats({
         <OperationsFallback state={state} refetch={refetch}>
           <ClientsStats
             operationStats={operationsStats ?? null}
-            organizationId={organization}
-            projectId={project}
-            targetId={target}
+            organizationSlug={organizationSlug}
+            projectSlug={projectSlug}
+            targetSlug={targetSlug}
           />
         </OperationsFallback>
       </div>

--- a/packages/web/app/src/components/target/laboratory/create-collection-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/create-collection-modal.tsx
@@ -140,9 +140,9 @@ export function CreateCollectionModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
   collectionId?: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const { isOpen, toggleModalOpen, collectionId } = props;
   const [mutationCreate, mutateCreate] = useMutation(CreateCollectionMutation);
@@ -153,9 +153,9 @@ export function CreateCollectionModal(props: {
     variables: {
       id: collectionId!,
       selector: {
-        target: props.targetId,
-        organization: props.organizationId,
-        project: props.projectId,
+        targetSlug: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
     },
     pause: !collectionId,
@@ -189,9 +189,9 @@ export function CreateCollectionModal(props: {
     const { error } = collectionId
       ? await mutateUpdate({
           selector: {
-            target: props.targetId,
-            organization: props.organizationId,
-            project: props.projectId,
+            targetSlug: props.targetSlug,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
           },
           input: {
             collectionId,
@@ -201,9 +201,9 @@ export function CreateCollectionModal(props: {
         })
       : await mutateCreate({
           selector: {
-            target: props.targetId,
-            organization: props.organizationId,
-            project: props.projectId,
+            targetSlug: props.targetSlug,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
           },
           input: values,
         });

--- a/packages/web/app/src/components/target/laboratory/create-operation-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/create-operation-modal.tsx
@@ -92,18 +92,18 @@ export function CreateOperationModal(props: {
   isOpen: boolean;
   close: () => void;
   onSaveSuccess: (args: { id: string; name: string }) => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const { toast } = useToast();
   const { isOpen, close, onSaveSuccess } = props;
   const [, mutateCreate] = useMutation(CreateOperationMutation);
 
   const { collections, fetching } = useCollections({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const { queryEditor, variableEditor, headerEditor } = useEditorContext({
     nonNull: true,
@@ -122,9 +122,9 @@ export function CreateOperationModal(props: {
   async function onSubmit(values: CreateOperationModalFormValues) {
     const result = await mutateCreate({
       selector: {
-        target: props.targetId,
-        organization: props.organizationId,
-        project: props.projectId,
+        targetSlug: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
       input: {
         name: values.name,
@@ -161,9 +161,9 @@ export function CreateOperationModal(props: {
       close={close}
       onSubmit={onSubmit}
       isOpen={isOpen}
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       fetching={fetching}
       form={form}
       collections={collections}
@@ -175,10 +175,10 @@ export function CreateOperationModalContent(props: {
   isOpen: boolean;
   close: () => void;
   onSubmit: (values: CreateOperationModalFormValues) => void;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
   form: UseFormReturn<CreateOperationModalFormValues>;
-  targetId: string;
+  targetSlug: string;
   fetching: boolean;
   collections: DocumentCollectionOperation[];
 }): ReactElement {

--- a/packages/web/app/src/components/target/laboratory/delete-collection-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/delete-collection-modal.tsx
@@ -41,9 +41,9 @@ export function DeleteCollectionModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
   collectionId: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const { toast } = useToast();
   const { isOpen, toggleModalOpen, collectionId } = props;
@@ -53,9 +53,9 @@ export function DeleteCollectionModal(props: {
     const { error } = await mutate({
       id: collectionId,
       selector: {
-        target: props.targetId,
-        organization: props.organizationId,
-        project: props.projectId,
+        targetSlug: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
     });
     toggleModalOpen();

--- a/packages/web/app/src/components/target/laboratory/delete-operation-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/delete-operation-modal.tsx
@@ -50,9 +50,9 @@ export function DeleteOperationModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
   operationId: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const { toast } = useToast();
   const { isOpen, toggleModalOpen, operationId } = props;
@@ -62,9 +62,9 @@ export function DeleteOperationModal(props: {
     const { error } = await mutate({
       id: operationId,
       selector: {
-        target: props.targetId,
-        organization: props.organizationId,
-        project: props.projectId,
+        targetSlug: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
     });
     toggleModalOpen();

--- a/packages/web/app/src/components/target/laboratory/edit-operation-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/edit-operation-modal.tsx
@@ -69,16 +69,16 @@ export type EditOperationModalFormValues = z.infer<typeof editOperationModalForm
 export const EditOperationModal = (props: {
   operationId: string;
   close: () => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement => {
   const { toast } = useToast();
   const [updateOperationNameState, mutate] = useMutation(UpdateOperationNameMutation);
   const { collections } = useCollections({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const { setTabState } = useEditorContext({ nonNull: true });
 
@@ -105,9 +105,9 @@ export const EditOperationModal = (props: {
   async function onSubmit(values: EditOperationModalFormValues) {
     const response = await mutate({
       selector: {
-        target: props.targetId,
-        organization: props.organizationId,
-        project: props.projectId,
+        targetSlug: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
       input: {
         collectionId: values.collectionId,

--- a/packages/web/app/src/components/target/settings/cdn-access-tokens.tsx
+++ b/packages/web/app/src/components/target/settings/cdn-access-tokens.tsx
@@ -46,9 +46,9 @@ const CDNAccessTokenCreateMutation = graphql(`
 function CreateCDNAccessTokenModal(props: {
   onCreateCDNAccessToken: () => void;
   onClose: () => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const [createCdnAccessToken, mutate] = useMutation(CDNAccessTokenCreateMutation);
 
@@ -64,9 +64,9 @@ function CreateCDNAccessTokenModal(props: {
       await mutate({
         input: {
           selector: {
-            organization: props.organizationId,
-            project: props.projectId,
-            target: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
           },
           alias: values.alias,
         },
@@ -193,9 +193,9 @@ function DeleteCDNAccessTokenModal(props: {
   cdnAccessTokenId: string;
   onDeletedAccessTokenId: (deletedAccessTokenId: string) => void;
   onClose: () => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const [deleteCdnAccessToken, mutate] = useMutation(CDNAccessTokenDeleteMutation);
 
@@ -232,9 +232,9 @@ function DeleteCDNAccessTokenModal(props: {
             mutate({
               input: {
                 selector: {
-                  organization: props.organizationId,
-                  project: props.projectId,
-                  target: props.targetId,
+                  organizationSlug: props.organizationSlug,
+                  projectSlug: props.projectSlug,
+                  targetSlug: props.targetSlug,
                 },
                 cdnAccessTokenId: props.cdnAccessTokenId,
               },
@@ -335,9 +335,9 @@ const CDNSearchParams = z.discriminatedUnion('cdn', [
 
 export function CDNAccessTokens(props: {
   me: FragmentType<typeof CDNAccessTokens_MeFragment>;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): React.ReactElement {
   const me = useFragment(CDNAccessTokens_MeFragment, props.me);
 
@@ -363,9 +363,9 @@ export function CDNAccessTokens(props: {
     query: CDNAccessTokensQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       },
       first: 10,
       after: endCursors[endCursors.length - 1] ?? null,
@@ -490,9 +490,9 @@ export function CDNAccessTokens(props: {
             reexecuteQuery({ requestPolicy: 'network-only' });
           }}
           onClose={closeModal}
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
         />
       ) : null}
       {searchParams.cdn === 'delete' ? (
@@ -502,9 +502,9 @@ export function CDNAccessTokens(props: {
             reexecuteQuery({ requestPolicy: 'network-only' });
           }}
           onClose={closeModal}
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
         />
       ) : null}
     </SubPageLayout>

--- a/packages/web/app/src/components/target/settings/registry-access-token.tsx
+++ b/packages/web/app/src/components/target/settings/registry-access-token.tsx
@@ -49,8 +49,8 @@ export const CreateAccessToken_CreateTokenMutation = graphql(`
 `);
 
 const CreateAccessTokenModalQuery = graphql(`
-  query CreateAccessTokenModalQuery($organizationId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query CreateAccessTokenModalQuery($organizationSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         ...CreateAccessTokenModalContent_OrganizationFragment
       }
@@ -69,7 +69,7 @@ export function CreateAccessTokenModal(props: {
   const [organizationQuery] = useQuery({
     query: CreateAccessTokenModalQuery,
     variables: {
-      organizationId: props.organizationId,
+      organizationSlug: props.organizationId,
     },
   });
 

--- a/packages/web/app/src/components/target/settings/registry-access-token.tsx
+++ b/packages/web/app/src/components/target/settings/registry-access-token.tsx
@@ -28,9 +28,9 @@ export const CreateAccessToken_CreateTokenMutation = graphql(`
     createToken(input: $input) {
       ok {
         selector {
-          organization
-          project
-          target
+          organizationSlug
+          projectSlug
+          targetSlug
         }
         createdToken {
           id
@@ -49,8 +49,8 @@ export const CreateAccessToken_CreateTokenMutation = graphql(`
 `);
 
 const CreateAccessTokenModalQuery = graphql(`
-  query CreateAccessTokenModalQuery($organizationSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query CreateAccessTokenModalQuery($organizationSlug: String!) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         ...CreateAccessTokenModalContent_OrganizationFragment
       }
@@ -61,15 +61,15 @@ const CreateAccessTokenModalQuery = graphql(`
 export function CreateAccessTokenModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const { isOpen, toggleModalOpen } = props;
   const [organizationQuery] = useQuery({
     query: CreateAccessTokenModalQuery,
     variables: {
-      organizationSlug: props.organizationId,
+      organizationSlug: props.organizationSlug,
     },
   });
 
@@ -80,9 +80,9 @@ export function CreateAccessTokenModal(props: {
       {organization ? (
         <ModalContent
           organization={organization}
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           toggleModalOpen={toggleModalOpen}
         />
       ) : (
@@ -143,9 +143,9 @@ const createRegistryTokenFormSchema = z.object({
 
 export function ModalContent(props: {
   organization: FragmentType<typeof CreateAccessTokenModalContent_OrganizationFragment>;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   toggleModalOpen: () => void;
 }) {
   const { toast } = useToast();
@@ -175,9 +175,9 @@ export function ModalContent(props: {
   async function onSubmit(values: z.infer<typeof createRegistryTokenFormSchema>) {
     const { error } = await mutate({
       input: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
         name: values.tokenDescription,
         organizationScopes: [],
         projectScopes: [],

--- a/packages/web/app/src/components/target/settings/schema-contracts.tsx
+++ b/packages/web/app/src/components/target/settings/schema-contracts.tsx
@@ -140,9 +140,9 @@ function DisableContractDialog(props: { contractId: string; onClose: () => void 
 }
 
 export function SchemaContracts(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [disabledContractId, setDisabledContractId] = useState<string | null>(null);
 
@@ -150,9 +150,9 @@ export function SchemaContracts(props: {
     query: SchemaContractsQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       },
     },
   });

--- a/packages/web/app/src/components/ui/query-error.tsx
+++ b/packages/web/app/src/components/ui/query-error.tsx
@@ -55,7 +55,10 @@ export function QueryError({
                   If you wish to track it later or share more details with us,{' '}
                   {organizationId ? (
                     <Button variant="link" className="h-auto p-0 text-orange-500" asChild>
-                      <Link to="/$organizationId/view/support" params={{ organizationId }}>
+                      <Link
+                        to="/$organizationSlug/view/support"
+                        params={{ organizationSlug: organizationId }}
+                      >
                         you can use the support
                       </Link>
                     </Button>

--- a/packages/web/app/src/components/ui/query-error.tsx
+++ b/packages/web/app/src/components/ui/query-error.tsx
@@ -55,10 +55,7 @@ export function QueryError({
                   If you wish to track it later or share more details with us,{' '}
                   {organizationSlug ? (
                     <Button variant="link" className="h-auto p-0 text-orange-500" asChild>
-                      <Link
-                        to="/$organizationSlug/view/support"
-                        params={{ organizationSlug: organizationSlug }}
-                      >
+                      <Link to="/$organizationSlug/view/support" params={{ organizationSlug }}>
                         you can use the support
                       </Link>
                     </Button>

--- a/packages/web/app/src/components/ui/query-error.tsx
+++ b/packages/web/app/src/components/ui/query-error.tsx
@@ -9,11 +9,11 @@ import { Link, useRouter } from '@tanstack/react-router';
 export function QueryError({
   error,
   showError,
-  organizationId,
+  organizationSlug,
 }: {
   error: CombinedError;
   showError?: boolean;
-  organizationId: string | null;
+  organizationSlug: string | null;
 }): ReactElement {
   const router = useRouter();
   const requestId =
@@ -53,11 +53,11 @@ export function QueryError({
                 <p>Don't worry, our technical support got this error reported automatically.</p>
                 <p>
                   If you wish to track it later or share more details with us,{' '}
-                  {organizationId ? (
+                  {organizationSlug ? (
                     <Button variant="link" className="h-auto p-0 text-orange-500" asChild>
                       <Link
                         to="/$organizationSlug/view/support"
-                        params={{ organizationSlug: organizationId }}
+                        params={{ organizationSlug: organizationSlug }}
                       >
                         you can use the support
                       </Link>

--- a/packages/web/app/src/components/ui/user-menu.tsx
+++ b/packages/web/app/src/components/ui/user-menu.tsx
@@ -112,7 +112,7 @@ export function UserMenu(props: {
         <LeaveOrganizationModal
           toggleModalOpen={toggleLeaveOrganizationModalOpen}
           isOpen={isLeaveOrganizationModalOpen}
-          organizationId={currentOrganization.slug}
+          organizationSlug={currentOrganization.slug}
         />
       ) : null}
       <div className="flex flex-row items-center gap-8">
@@ -288,16 +288,16 @@ const LeaveOrganizationModal_LeaveOrganizationMutation = graphql(`
 export function LeaveOrganizationModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
+  organizationSlug: string;
 }) {
-  const { organizationId } = props;
+  const { organizationSlug } = props;
   const [, mutate] = useMutation(LeaveOrganizationModal_LeaveOrganizationMutation);
   const notify = useNotifications();
 
   async function onSubmit() {
     const result = await mutate({
       input: {
-        organization: organizationId,
+        organizationSlug,
       },
     });
 
@@ -320,7 +320,7 @@ export function LeaveOrganizationModal(props: {
     <LeaveOrganizationModalContent
       isOpen={props.isOpen}
       toggleModalOpen={props.toggleModalOpen}
-      organizationSlug={organizationId}
+      organizationSlug={organizationSlug}
       onSubmit={onSubmit}
     />
   );

--- a/packages/web/app/src/components/ui/user-menu.tsx
+++ b/packages/web/app/src/components/ui/user-menu.tsx
@@ -85,7 +85,7 @@ const UserMenu_MemberFragment = graphql(`
 export function UserMenu(props: {
   me: FragmentType<typeof UserMenu_MeFragment> | null;
   organizations: FragmentType<typeof UserMenu_OrganizationConnectionFragment> | null;
-  currentOrganizationCleanId: string;
+  currentOrganizationSlug: string;
 }) {
   const docsUrl = getDocsUrl();
   const me = useFragment(UserMenu_MeFragment, props.me);
@@ -96,7 +96,7 @@ export function UserMenu(props: {
   const [isUserSettingsModalOpen, toggleUserSettingsModalOpen] = useToggle();
   const [isLeaveOrganizationModalOpen, toggleLeaveOrganizationModalOpen] = useToggle();
   const currentOrganization = organizations?.find(
-    org => org.slug === props.currentOrganizationCleanId,
+    org => org.slug === props.currentOrganizationSlug,
   );
   const meInOrg = useFragment(UserMenu_MemberFragment, currentOrganization?.me);
 
@@ -168,9 +168,9 @@ export function UserMenu(props: {
                       active={currentOrganization?.slug === org.slug}
                     >
                       <Link
-                        to="/$organizationId"
+                        to="/$organizationSlug"
                         params={{
-                          organizationId: org.slug,
+                          organizationSlug: org.slug,
                         }}
                       >
                         {org.slug}
@@ -215,9 +215,9 @@ export function UserMenu(props: {
               {currentOrganization && env.zendeskSupport ? (
                 <DropdownMenuItem asChild>
                   <Link
-                    to="/$organizationId/view/support"
+                    to="/$organizationSlug/view/support"
                     params={{
-                      organizationId: currentOrganization.slug,
+                      organizationSlug: currentOrganization.slug,
                     }}
                   >
                     <LifeBuoyIcon className="mr-2 size-4" />
@@ -320,7 +320,7 @@ export function LeaveOrganizationModal(props: {
     <LeaveOrganizationModalContent
       isOpen={props.isOpen}
       toggleModalOpen={props.toggleModalOpen}
-      organizationCleanId={organizationId}
+      organizationSlug={organizationId}
       onSubmit={onSubmit}
     />
   );
@@ -329,19 +329,19 @@ export function LeaveOrganizationModal(props: {
 export function LeaveOrganizationModalContent(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationCleanId: string;
+  organizationSlug: string;
   onSubmit: () => void;
 }) {
   return (
     <Dialog open={props.isOpen} onOpenChange={props.toggleModalOpen}>
       <DialogContent className="w-4/5 max-w-[520px] md:w-3/5">
         <DialogHeader>
-          <DialogTitle>Leave {props.organizationCleanId}?</DialogTitle>
+          <DialogTitle>Leave {props.organizationSlug}?</DialogTitle>
           <DialogDescription>
             Are you sure you want to leave this organization?
             <br />
             You will lose access to{' '}
-            <span className="font-semibold text-white">{props.organizationCleanId}</span>.
+            <span className="font-semibold text-white">{props.organizationSlug}</span>.
           </DialogDescription>
           <DialogDescription className="font-bold">This action is irreversible!</DialogDescription>
         </DialogHeader>

--- a/packages/web/app/src/components/v2/data-wrapper.tsx
+++ b/packages/web/app/src/components/v2/data-wrapper.tsx
@@ -5,7 +5,7 @@ import { QueryError } from '@/components/ui/query-error';
 export class DataWrapper<TData, TVariables extends AnyVariables> extends Component<{
   query: UseQueryState<TData, TVariables>;
   showStale?: boolean;
-  organizationId: string | null;
+  organizationSlug: string | null;
   children(props: { data: TData }): ReactNode;
   spinnerComponent?: ReactNode;
 }> {
@@ -17,7 +17,7 @@ export class DataWrapper<TData, TVariables extends AnyVariables> extends Compone
     }
 
     if (error) {
-      return <QueryError organizationId={this.props.organizationId} error={error} />;
+      return <QueryError organizationSlug={this.props.organizationSlug} error={error} />;
     }
 
     if (!data) {

--- a/packages/web/app/src/components/v2/modals/transfer-organization-ownership.tsx
+++ b/packages/web/app/src/components/v2/modals/transfer-organization-ownership.tsx
@@ -98,7 +98,7 @@ export const TransferOrganizationOwnershipModal = ({
     query: TransferOrganizationOwnership_Members,
     variables: {
       selector: {
-        organization: organization.slug,
+        organizationSlug: organization.slug,
       },
     },
   });
@@ -133,8 +133,8 @@ export const TransferOrganizationOwnershipModal = ({
     onSubmit: async values => {
       const result = await mutate({
         input: {
-          organization: organization.slug,
-          user: values.newOwner,
+          organizationSlug: organization.slug,
+          userId: values.newOwner,
         },
       });
 

--- a/packages/web/app/src/lib/access/organization.ts
+++ b/packages/web/app/src/lib/access/organization.ts
@@ -25,14 +25,14 @@ export function canAccessOrganization(
 
 export function useOrganizationAccess({
   scope,
-  organizationId,
+  organizationSlug,
   member: mmember,
   redirect = false,
 }: {
   scope: OrganizationAccessScope;
   member: null | FragmentType<typeof CanAccessOrganization_MemberFragment>;
   redirect?: boolean;
-  organizationId: string;
+  organizationSlug: string;
 }) {
   const member = useFragment(CanAccessOrganization_MemberFragment, mmember);
   const canAccess = canAccessOrganization(scope, mmember);
@@ -44,7 +44,7 @@ export function useOrganizationAccess({
           void router.navigate({
             to: '/$organizationSlug',
             params: {
-              organizationSlug: organizationId,
+              organizationSlug: organizationSlug,
             },
           });
         }

--- a/packages/web/app/src/lib/access/organization.ts
+++ b/packages/web/app/src/lib/access/organization.ts
@@ -42,9 +42,9 @@ export function useOrganizationAccess({
     redirectTo: redirect
       ? router => {
           void router.navigate({
-            to: '/$organizationId',
+            to: '/$organizationSlug',
             params: {
-              organizationId,
+              organizationSlug: organizationId,
             },
           });
         }

--- a/packages/web/app/src/lib/access/organization.ts
+++ b/packages/web/app/src/lib/access/organization.ts
@@ -44,7 +44,7 @@ export function useOrganizationAccess({
           void router.navigate({
             to: '/$organizationSlug',
             params: {
-              organizationSlug: organizationSlug,
+              organizationSlug,
             },
           });
         }

--- a/packages/web/app/src/lib/access/project.ts
+++ b/packages/web/app/src/lib/access/project.ts
@@ -27,14 +27,14 @@ export function useProjectAccess({
   scope,
   member: mmember,
   redirect = false,
-  organizationId,
-  projectId,
+  organizationSlug,
+  projectSlug,
 }: {
   scope: ProjectAccessScope;
   member: null | FragmentType<typeof CanAccessProject_MemberFragment>;
   redirect?: boolean;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }) {
   const member = useFragment(CanAccessProject_MemberFragment, mmember);
 
@@ -46,8 +46,8 @@ export function useProjectAccess({
           void router.navigate({
             to: '/$organizationSlug/$projectSlug',
             params: {
-              organizationSlug: organizationId,
-              projectSlug: projectId,
+              organizationSlug: organizationSlug,
+              projectSlug: projectSlug,
             },
           });
         }

--- a/packages/web/app/src/lib/access/project.ts
+++ b/packages/web/app/src/lib/access/project.ts
@@ -46,8 +46,8 @@ export function useProjectAccess({
           void router.navigate({
             to: '/$organizationSlug/$projectSlug',
             params: {
-              organizationSlug: organizationSlug,
-              projectSlug: projectSlug,
+              organizationSlug,
+              projectSlug,
             },
           });
         }

--- a/packages/web/app/src/lib/access/project.ts
+++ b/packages/web/app/src/lib/access/project.ts
@@ -44,10 +44,10 @@ export function useProjectAccess({
     redirectTo: redirect
       ? router => {
           void router.navigate({
-            to: '/$organizationId/$projectId',
+            to: '/$organizationSlug/$projectSlug',
             params: {
-              organizationId,
-              projectId,
+              organizationSlug: organizationId,
+              projectSlug: projectId,
             },
           });
         }

--- a/packages/web/app/src/lib/access/target.ts
+++ b/packages/web/app/src/lib/access/target.ts
@@ -46,11 +46,11 @@ export function useTargetAccess({
     redirectTo: redirect
       ? router => {
           void router.navigate({
-            to: '/$organizationId/$projectId/$targetId',
+            to: '/$organizationSlug/$projectSlug/$targetSlug',
             params: {
-              organizationId,
-              projectId,
-              targetId,
+              organizationSlug: organizationId,
+              projectSlug: projectId,
+              targetSlug: targetId,
             },
           });
         }

--- a/packages/web/app/src/lib/access/target.ts
+++ b/packages/web/app/src/lib/access/target.ts
@@ -48,9 +48,9 @@ export function useTargetAccess({
           void router.navigate({
             to: '/$organizationSlug/$projectSlug/$targetSlug',
             params: {
-              organizationSlug: organizationSlug,
-              projectSlug: projectSlug,
-              targetSlug: targetSlug,
+              organizationSlug,
+              projectSlug,
+              targetSlug,
             },
           });
         }

--- a/packages/web/app/src/lib/access/target.ts
+++ b/packages/web/app/src/lib/access/target.ts
@@ -28,16 +28,16 @@ export function useTargetAccess({
   scope,
   member: mmember,
   redirect = false,
-  organizationId,
-  projectId,
-  targetId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
 }: {
   scope: TargetAccessScope;
   member: null | FragmentType<typeof CanAccessTarget_MemberFragment>;
   redirect?: boolean;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const member = useFragment(CanAccessTarget_MemberFragment, mmember);
   const canAccess = canAccessTarget(scope, mmember);
@@ -48,9 +48,9 @@ export function useTargetAccess({
           void router.navigate({
             to: '/$organizationSlug/$projectSlug/$targetSlug',
             params: {
-              organizationSlug: organizationId,
-              projectSlug: projectId,
-              targetSlug: targetId,
+              organizationSlug: organizationSlug,
+              projectSlug: projectSlug,
+              targetSlug: targetSlug,
             },
           });
         }

--- a/packages/web/app/src/lib/hooks/laboratory/use-collections.ts
+++ b/packages/web/app/src/lib/hooks/laboratory/use-collections.ts
@@ -39,9 +39,9 @@ export type DocumentCollectionOperation = Exclude<
 const EMPTY_ARRAY: DocumentCollectionOperation[] = [];
 
 export function useCollections(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): {
   fetching: boolean;
   collections: DocumentCollectionOperation[];
@@ -50,9 +50,9 @@ export function useCollections(props: {
     query: CollectionsQuery,
     variables: {
       selector: {
-        target: props.targetId,
-        organization: props.organizationId,
-        project: props.projectId,
+        targetSlug: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
     },
   });

--- a/packages/web/app/src/lib/hooks/laboratory/use-current-operation.ts
+++ b/packages/web/app/src/lib/hooks/laboratory/use-current-operation.ts
@@ -23,18 +23,18 @@ const OperationQuery = graphql(`
 `);
 
 export function useCurrentOperation(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const operationIdFromSearch = useOperationFromQueryString();
   const [{ data }] = useQuery({
     query: OperationQuery,
     variables: {
       selector: {
-        target: props.targetId,
-        project: props.projectId,
-        organization: props.organizationId,
+        targetSlug: props.targetSlug,
+        projectSlug: props.projectSlug,
+        organizationSlug: props.organizationSlug,
       },
       id: operationIdFromSearch!,
     },

--- a/packages/web/app/src/lib/hooks/laboratory/use-operation-collections-plugin.tsx
+++ b/packages/web/app/src/lib/hooks/laboratory/use-operation-collections-plugin.tsx
@@ -77,8 +77,12 @@ const CreateOperationMutation = graphql(`
 `);
 
 export const TargetLaboratoryPageQuery = graphql(`
-  query TargetLaboratoryPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query TargetLaboratoryPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         me {
@@ -88,7 +92,11 @@ export const TargetLaboratoryPageQuery = graphql(`
       }
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       graphqlEndpointUrl
@@ -115,17 +123,17 @@ export const operationCollectionsPlugin: GraphiQLPlugin = {
 };
 
 export function Content() {
-  const { organizationId, projectId, targetId } = useParams({ strict: false }) as {
-    organizationId: string;
-    projectId: string;
-    targetId: string;
+  const { organizationSlug, projectSlug, targetSlug } = useParams({ strict: false }) as {
+    organizationSlug: string;
+    projectSlug: string;
+    targetSlug: string;
   };
   const [query] = useQuery({
     query: TargetLaboratoryPageQuery,
     variables: {
-      organizationSlug: organizationId,
-      projectSlug: projectId,
-      targetSlug: targetId,
+      organizationSlug,
+      projectSlug,
+      targetSlug,
     },
   });
   const currentOrganization = query.data?.organization?.organization;
@@ -134,9 +142,9 @@ export function Content() {
 
   const [isCollectionModalOpen, toggleCollectionModal] = useToggle();
   const { collections, fetching: loading } = useCollections({
-    organizationId,
-    projectId,
-    targetId,
+    organizationSlug,
+    projectSlug,
+    targetSlug,
   });
   const [collectionId, setCollectionId] = useState('');
   const [isDeleteCollectionModalOpen, toggleDeleteCollectionModalOpen] = useToggle();
@@ -144,9 +152,9 @@ export function Content() {
   const [operationToDeleteId, setOperationToDeleteId] = useState<null | string>(null);
   const [operationToEditId, setOperationToEditId] = useState<null | string>(null);
   const { clearOperation, savedOperation, setSavedOperation } = useSyncOperationState({
-    organizationId,
-    projectId,
-    targetId,
+    organizationSlug,
+    projectSlug,
+    targetSlug,
   });
   const router = useRouter();
   const [accordionValue, setAccordionValue] = useState<string[]>([]);
@@ -155,9 +163,9 @@ export function Content() {
   const copyToClipboard = useClipboard();
 
   const currentOperation = useCurrentOperation({
-    organizationId,
-    projectId,
-    targetId,
+    organizationSlug,
+    projectSlug,
+    targetSlug,
   });
   const { queryEditor, variableEditor, headerEditor, tabs, changeTab, addTab } = useEditorContext({
     nonNull: true,
@@ -260,9 +268,9 @@ export function Content() {
         variables: '',
       },
       selector: {
-        target: targetId,
-        organization: organizationId,
-        project: projectId,
+        targetSlug,
+        organizationSlug,
+        projectSlug,
       },
     });
     if (result.error) {
@@ -275,9 +283,9 @@ export function Content() {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug/laboratory',
         params: {
-          organizationSlug: organizationId,
-          projectSlug: projectId,
-          targetSlug: targetId,
+          organizationSlug,
+          projectSlug,
+          targetSlug,
         },
         search: {
           operation: result.data.createOperationInDocumentCollection.ok.operation.id,
@@ -347,9 +355,9 @@ export function Content() {
               <Link
                 to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                 params={{
-                  organizationSlug: organizationId,
-                  projectSlug: projectId,
-                  targetSlug: targetId,
+                  organizationSlug,
+                  projectSlug,
+                  targetSlug,
                 }}
                 search={{ operation: node.id }}
                 className={cn(
@@ -484,26 +492,26 @@ export function Content() {
         </div>
       )}
       <CreateCollectionModal
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         isOpen={isCollectionModalOpen}
         toggleModalOpen={toggleCollectionModal}
         collectionId={collectionId}
       />
       <DeleteCollectionModal
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         isOpen={isDeleteCollectionModalOpen}
         toggleModalOpen={toggleDeleteCollectionModalOpen}
         collectionId={collectionId}
       />
       {operationToDeleteId && (
         <DeleteOperationModal
-          organizationId={organizationId}
-          projectId={projectId}
-          targetId={targetId}
+          organizationSlug={organizationSlug}
+          projectSlug={projectSlug}
+          targetSlug={targetSlug}
           isOpen={isDeleteOperationModalOpen}
           toggleModalOpen={toggleDeleteOperationModalOpen}
           operationId={operationToDeleteId}
@@ -511,9 +519,9 @@ export function Content() {
       )}
       {operationToEditId && (
         <EditOperationModal
-          organizationId={organizationId}
-          projectId={projectId}
-          targetId={targetId}
+          organizationSlug={organizationSlug}
+          projectSlug={projectSlug}
+          targetSlug={targetSlug}
           operationId={operationToEditId}
           close={() => setOperationToEditId(null)}
         />

--- a/packages/web/app/src/lib/hooks/laboratory/use-operation-collections-plugin.tsx
+++ b/packages/web/app/src/lib/hooks/laboratory/use-operation-collections-plugin.tsx
@@ -77,8 +77,8 @@ const CreateOperationMutation = graphql(`
 `);
 
 export const TargetLaboratoryPageQuery = graphql(`
-  query TargetLaboratoryPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetLaboratoryPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         me {
@@ -87,7 +87,9 @@ export const TargetLaboratoryPageQuery = graphql(`
         }
       }
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       graphqlEndpointUrl
       latestSchemaVersion {
@@ -120,7 +122,11 @@ export function Content() {
   };
   const [query] = useQuery({
     query: TargetLaboratoryPageQuery,
-    variables: { organizationId, projectId, targetId },
+    variables: {
+      organizationSlug: organizationId,
+      projectSlug: projectId,
+      targetSlug: targetId,
+    },
   });
   const currentOrganization = query.data?.organization?.organization;
   const canEdit = canAccessTarget(TargetAccessScope.Settings, currentOrganization?.me ?? null);
@@ -267,8 +273,12 @@ export function Content() {
     }
     if (result.data?.createOperationInDocumentCollection.ok) {
       void router.navigate({
-        to: '/$organizationId/$projectId/$targetId/laboratory',
-        params: { organizationId, projectId, targetId },
+        to: '/$organizationSlug/$projectSlug/$targetSlug/laboratory',
+        params: {
+          organizationSlug: organizationId,
+          projectSlug: projectId,
+          targetSlug: targetId,
+        },
         search: {
           operation: result.data.createOperationInDocumentCollection.ok.operation.id,
         },
@@ -335,8 +345,12 @@ export function Content() {
           collection.operations.edges.map(({ node }) => (
             <div key={node.id} className="flex items-center">
               <Link
-                to="/$organizationId/$projectId/$targetId/laboratory"
-                params={{ organizationId, projectId, targetId }}
+                to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
+                params={{
+                  organizationSlug: organizationId,
+                  projectSlug: projectId,
+                  targetSlug: targetId,
+                }}
                 search={{ operation: node.id }}
                 className={cn(
                   'flex w-full items-center gap-x-3 rounded p-2 font-normal text-white/50 hover:bg-gray-100/10 hover:text-white hover:no-underline',

--- a/packages/web/app/src/lib/hooks/laboratory/use-sync-operation-state.ts
+++ b/packages/web/app/src/lib/hooks/laboratory/use-sync-operation-state.ts
@@ -1,18 +1,18 @@
 import { useCurrentOperation } from './use-current-operation';
 
 export function useSyncOperationState(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): {
   savedOperation: { query: string; variables: string; updatedAt: number } | null;
   setSavedOperation: (value: { query: string; variables: string }) => void;
   clearOperation: () => void;
 } {
   const currentOperation = useCurrentOperation({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const storageKey = currentOperation ? `hive:operation-${currentOperation.id}` : null;
   const savedOperationData = storageKey ? localStorage.getItem(storageKey) : null;

--- a/packages/web/app/src/lib/urql-cache.ts
+++ b/packages/web/app/src/lib/urql-cache.ts
@@ -139,8 +139,8 @@ const createTarget: TypedDocumentNodeUpdateResolver<typeof CreateTarget_CreateTa
       query: TargetsDocument,
       variables: {
         selector: {
-          organization: selector.organization,
-          project: selector.project,
+          organizationSlug: selector.organizationSlug,
+          projectSlug: selector.projectSlug,
         },
       },
     },
@@ -181,9 +181,9 @@ const createToken: TypedDocumentNodeUpdateResolver<typeof CreateAccessToken_Crea
       query: TokensDocument,
       variables: {
         selector: {
-          organization: selector.organization,
-          project: selector.project,
-          target: selector.target,
+          organizationSlug: selector.organizationSlug,
+          projectSlug: selector.projectSlug,
+          targetSlug: selector.targetSlug,
         },
       },
     },
@@ -207,9 +207,9 @@ const deleteTokens: TypedDocumentNodeUpdateResolver<typeof DeleteTokensDocument>
       query: TokensDocument,
       variables: {
         selector: {
-          organization: selector.organization,
-          project: selector.project,
-          target: selector.target,
+          organizationSlug: selector.organizationSlug,
+          projectSlug: selector.projectSlug,
+          targetSlug: selector.targetSlug,
         },
       },
     },

--- a/packages/web/app/src/pages/index.tsx
+++ b/packages/web/app/src/pages/index.tsx
@@ -42,8 +42,8 @@ export function IndexPage() {
     } else if (result?.organization.slug) {
       // Redirect to the organization
       void router.navigate({
-        to: '/$organizationId',
-        params: { organizationId: result.organization.slug },
+        to: '/$organizationSlug',
+        params: { organizationSlug: result.organization.slug },
       });
     } // else, still loading
   }, [router, result]);

--- a/packages/web/app/src/pages/index.tsx
+++ b/packages/web/app/src/pages/index.tsx
@@ -49,7 +49,7 @@ export function IndexPage() {
   }, [router, result]);
 
   if (query.error) {
-    return <QueryError organizationId={result?.organization.slug ?? null} error={query.error} />;
+    return <QueryError organizationSlug={result?.organization.slug ?? null} error={query.error} />;
   }
 
   return (

--- a/packages/web/app/src/pages/organization-join.tsx
+++ b/packages/web/app/src/pages/organization-join.tsx
@@ -17,7 +17,7 @@ const JoinOrganizationPage_JoinOrganizationMutation = graphql(`
       __typename
       ... on OrganizationPayload {
         selector {
-          organization
+          organizationSlug
         }
         organization {
           id
@@ -103,7 +103,7 @@ export function JoinOrganizationPage(props: { inviteCode: string }) {
           <HiveLogo className="size-10" />
         </Link>
         <div className="container md:w-3/5 lg:w-1/2">
-          <DataWrapper query={query} organizationId={null}>
+          <DataWrapper query={query} organizationSlug={null}>
             {({ data }) => {
               if (data.organizationByInviteCode == null) {
                 return null;

--- a/packages/web/app/src/pages/organization-join.tsx
+++ b/packages/web/app/src/pages/organization-join.tsx
@@ -70,8 +70,8 @@ export function JoinOrganizationPage(props: { inviteCode: string }) {
           description: `You are now a member of ${org.slug}`,
         });
         void router.navigate({
-          to: '/$organizationId',
-          params: { organizationId: org.slug },
+          to: '/$organizationSlug',
+          params: { organizationSlug: org.slug },
         });
       }
     }

--- a/packages/web/app/src/pages/organization-members.tsx
+++ b/packages/web/app/src/pages/organization-members.tsx
@@ -64,7 +64,7 @@ function PageContent(props: {
     scope: OrganizationAccessScope.Members,
     redirect: true,
     member: organization.me,
-    organizationId: organization.slug,
+    organizationSlug: organization.slug,
   });
 
   if (!organization || !hasAccess) {
@@ -126,7 +126,7 @@ const OrganizationMembersPageQuery = graphql(`
 `);
 
 function OrganizationMembersPageContent(props: {
-  organizationId: string;
+  organizationSlug: string;
   page: SubPage;
   onPageChange(page: SubPage): void;
 }) {
@@ -134,20 +134,20 @@ function OrganizationMembersPageContent(props: {
     query: OrganizationMembersPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
 
   return (
     <OrganizationLayout
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       page={Page.Members}
       className="flex flex-col gap-y-10"
     >
@@ -166,7 +166,7 @@ function OrganizationMembersPageContent(props: {
 }
 
 export function OrganizationMembersPage(props: {
-  organizationId: string;
+  organizationSlug: string;
   page: SubPage;
   onPageChange(page: SubPage): void;
 }) {
@@ -174,7 +174,7 @@ export function OrganizationMembersPage(props: {
     <>
       <Meta title="Members" />
       <OrganizationMembersPageContent
-        organizationId={props.organizationId}
+        organizationSlug={props.organizationSlug}
         page={props.page}
         onPageChange={props.onPageChange}
       />

--- a/packages/web/app/src/pages/organization-new.tsx
+++ b/packages/web/app/src/pages/organization-new.tsx
@@ -57,7 +57,7 @@ export const CreateOrganizationMutation = graphql(`
       ok {
         createdOrganizationPayload {
           selector {
-            organization
+            organizationSlug
           }
           organization {
             id

--- a/packages/web/app/src/pages/organization-new.tsx
+++ b/packages/web/app/src/pages/organization-new.tsx
@@ -115,9 +115,9 @@ export const CreateOrganizationForm = (): JSX.Element => {
         description: `You are now an admin of "${values.slug}" organization.`,
       });
       void router.navigate({
-        to: '/$organizationId',
+        to: '/$organizationSlug',
         params: {
-          organizationId:
+          organizationSlug:
             mutation.data.createOrganization.ok.createdOrganizationPayload.organization.slug,
         },
       });

--- a/packages/web/app/src/pages/organization-policy.tsx
+++ b/packages/web/app/src/pages/organization-policy.tsx
@@ -68,12 +68,12 @@ const UpdateSchemaPolicyForOrganization = graphql(`
   }
 `);
 
-function PolicyPageContent(props: { organizationId: string }) {
+function PolicyPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: OrganizationPolicyPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
@@ -86,7 +86,7 @@ function PolicyPageContent(props: { organizationId: string }) {
     scope: OrganizationAccessScope.Settings,
     member: currentOrganization?.me ?? null,
     redirect: true,
-    organizationId: props.organizationId,
+    organizationSlug: props.organizationSlug,
   });
 
   const legacyProjects = currentOrganization?.projects.nodes.filter(
@@ -94,13 +94,13 @@ function PolicyPageContent(props: { organizationId: string }) {
   );
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
     <OrganizationLayout
       page={Page.Policy}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex flex-col gap-y-10"
     >
       <div>
@@ -165,7 +165,7 @@ function PolicyPageContent(props: { organizationId: string }) {
                 onSave={async (newPolicy, allowOverrides) => {
                   await mutate({
                     selector: {
-                      organization: props.organizationId,
+                      organizationSlug: props.organizationSlug,
                     },
                     policy: newPolicy,
                     allowOverrides,
@@ -216,11 +216,11 @@ function PolicyPageContent(props: { organizationId: string }) {
   );
 }
 
-export function OrganizationPolicyPage(props: { organizationId: string }): ReactElement {
+export function OrganizationPolicyPage(props: { organizationSlug: string }): ReactElement {
   return (
     <>
       <Meta title="Organization Schema Policy" />
-      <PolicyPageContent organizationId={props.organizationId} />
+      <PolicyPageContent organizationSlug={props.organizationSlug} />
     </>
   );
 }

--- a/packages/web/app/src/pages/organization-settings.tsx
+++ b/packages/web/app/src/pages/organization-settings.tsx
@@ -79,14 +79,12 @@ const DeleteGitHubIntegrationMutation = graphql(`
   }
 `);
 
-function Integrations(props: { organizationId: string }) {
-  const orgId = props.organizationId;
-
+function Integrations(props: { organizationSlug: string }) {
   const [checkIntegrations] = useQuery({
     query: Integrations_CheckIntegrationsQuery,
     variables: {
       selector: {
-        organization: orgId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
@@ -116,7 +114,7 @@ function Integrations(props: { organizationId: string }) {
               onClick={async () => {
                 await deleteSlack({
                   input: {
-                    organization: orgId,
+                    organizationSlug: props.organizationSlug,
                   },
                 });
               }}
@@ -126,7 +124,7 @@ function Integrations(props: { organizationId: string }) {
             </Button>
           ) : (
             <Button variant="secondary" asChild>
-              <a href={`/api/slack/connect/${props.organizationId}`}>
+              <a href={`/api/slack/connect/${props.organizationSlug}`}>
                 <SlackIcon className="mr-2" />
                 Connect Slack
               </a>
@@ -146,7 +144,7 @@ function Integrations(props: { organizationId: string }) {
                   onClick={async () => {
                     await deleteGitHub({
                       input: {
-                        organization: orgId,
+                        organizationSlug: props.organizationSlug,
                       },
                     });
                   }}
@@ -155,12 +153,12 @@ function Integrations(props: { organizationId: string }) {
                   Disconnect GitHub
                 </Button>
                 <Button variant="link" asChild>
-                  <a href={`/api/github/connect/${props.organizationId}`}>Adjust permissions</a>
+                  <a href={`/api/github/connect/${props.organizationSlug}`}>Adjust permissions</a>
                 </Button>
               </>
             ) : (
               <Button variant="secondary" asChild>
-                <a href={`/api/github/connect/${props.organizationId}`}>
+                <a href={`/api/github/connect/${props.organizationSlug}`}>
                   <GitHubIcon className="mr-2" />
                   Connect GitHub
                 </a>
@@ -183,7 +181,7 @@ const UpdateOrganizationSlugMutation = graphql(`
       ok {
         updatedOrganizationPayload {
           selector {
-            organization
+            organizationSlug
           }
           organization {
             id
@@ -224,14 +222,14 @@ type SlugFormValues = z.infer<typeof SlugFormSchema>;
 
 const SettingsPageRenderer = (props: {
   organization: FragmentType<typeof SettingsPageRenderer_OrganizationFragment>;
-  organizationId: string;
+  organizationSlug: string;
 }) => {
   const organization = useFragment(SettingsPageRenderer_OrganizationFragment, props.organization);
   const hasAccess = useOrganizationAccess({
     scope: OrganizationAccessScope.Settings,
     member: organization.me,
     redirect: true,
-    organizationId: props.organizationId,
+    organizationSlug: props.organizationSlug,
   });
   const router = useRouter();
   const [isDeleteModalOpen, toggleDeleteModalOpen] = useToggle();
@@ -253,7 +251,7 @@ const SettingsPageRenderer = (props: {
       try {
         const result = await slugMutate({
           input: {
-            organization: props.organizationId,
+            organizationSlug: props.organizationSlug,
             slug: data.slug,
           },
         });
@@ -285,7 +283,7 @@ const SettingsPageRenderer = (props: {
         });
       }
     },
-    [slugMutate, props.organizationId],
+    [slugMutate, props.organizationSlug],
   );
 
   return (
@@ -366,7 +364,7 @@ const SettingsPageRenderer = (props: {
               </CardHeader>
               <CardContent>
                 <div className="flex flex-col gap-y-4 text-gray-500">
-                  <Integrations organizationId={props.organizationId} />
+                  <Integrations organizationSlug={props.organizationSlug} />
                 </div>
               </CardContent>
             </Card>
@@ -431,7 +429,7 @@ const SettingsPageRenderer = (props: {
                   Delete Organization
                 </Button>
                 <DeleteOrganizationModal
-                  organizationId={props.organizationId}
+                  organizationSlug={props.organizationSlug}
                   isOpen={isDeleteModalOpen}
                   toggleModalOpen={toggleDeleteModalOpen}
                 />
@@ -454,18 +452,18 @@ const OrganizationSettingsPageQuery = graphql(`
   }
 `);
 
-function SettingsPageContent(props: { organizationId: string }) {
+function SettingsPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: OrganizationSettingsPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -473,12 +471,12 @@ function SettingsPageContent(props: { organizationId: string }) {
   return (
     <OrganizationLayout
       page={Page.Settings}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex flex-col gap-y-10"
     >
       {currentOrganization ? (
         <SettingsPageRenderer
-          organizationId={props.organizationId}
+          organizationSlug={props.organizationSlug}
           organization={currentOrganization}
         />
       ) : null}
@@ -486,11 +484,11 @@ function SettingsPageContent(props: { organizationId: string }) {
   );
 }
 
-export function OrganizationSettingsPage(props: { organizationId: string }) {
+export function OrganizationSettingsPage(props: { organizationSlug: string }) {
   return (
     <>
       <Meta title="Organization settings" />
-      <SettingsPageContent organizationId={props.organizationId} />
+      <SettingsPageContent organizationSlug={props.organizationSlug} />
     </>
   );
 }
@@ -499,7 +497,7 @@ export const DeleteOrganizationDocument = graphql(`
   mutation deleteOrganization($selector: OrganizationSelectorInput!) {
     deleteOrganization(selector: $selector) {
       selector {
-        organization
+        organizationSlug
       }
       organization {
         __typename
@@ -512,9 +510,9 @@ export const DeleteOrganizationDocument = graphql(`
 export function DeleteOrganizationModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
+  organizationSlug: string;
 }) {
-  const { organizationId } = props;
+  const { organizationSlug } = props;
   const [, mutate] = useMutation(DeleteOrganizationDocument);
   const { toast } = useToast();
   const router = useRouter();
@@ -522,7 +520,7 @@ export function DeleteOrganizationModal(props: {
   const handleDelete = async () => {
     const { error } = await mutate({
       selector: {
-        organization: organizationId,
+        organizationSlug,
       },
     });
     if (error) {

--- a/packages/web/app/src/pages/organization-settings.tsx
+++ b/packages/web/app/src/pages/organization-settings.tsx
@@ -267,9 +267,9 @@ const SettingsPageRenderer = (props: {
             description: 'Organization slug updated',
           });
           void router.navigate({
-            to: '/$organizationId/view/settings',
+            to: '/$organizationSlug/view/settings',
             params: {
-              organizationId:
+              organizationSlug:
                 result.data.updateOrganizationSlug.ok.updatedOrganizationPayload.organization.slug,
             },
           });

--- a/packages/web/app/src/pages/organization-subscription-manage.tsx
+++ b/packages/web/app/src/pages/organization-subscription-manage.tsx
@@ -482,8 +482,8 @@ function ManageSubscriptionPageContent(props: { organizationId: string }) {
             <div>
               <Button asChild>
                 <Link
-                  to="/$organizationId/view/subscription"
-                  params={{ organizationId: currentOrganization.slug }}
+                  to="/$organizationSlug/view/subscription"
+                  params={{ organizationSlug: currentOrganization.slug }}
                 >
                   Subscription usage
                 </Link>

--- a/packages/web/app/src/pages/organization-subscription-manage.tsx
+++ b/packages/web/app/src/pages/organization-subscription-manage.tsx
@@ -70,8 +70,8 @@ const BillingsPlanQuery = graphql(`
 `);
 
 const BillingDowngradeMutation = graphql(`
-  mutation ManageSubscription_DowngradeToHobby($organization: ID!) {
-    downgradeToHobby(input: { organization: { organization: $organization } }) {
+  mutation ManageSubscription_DowngradeToHobby($organizationSlug: String!) {
+    downgradeToHobby(input: { organization: { organizationSlug: $organizationSlug } }) {
       previousPlan
       newPlan
       organization {
@@ -83,7 +83,7 @@ const BillingDowngradeMutation = graphql(`
 
 const BillingUpgradeToProMutation = graphql(`
   mutation ManageSubscription_UpgradeToPro(
-    $organization: ID!
+    $organizationSlug: String!
     $paymentMethodId: String
     $couponCode: String
     $monthlyLimits: RateLimitInput!
@@ -92,7 +92,7 @@ const BillingUpgradeToProMutation = graphql(`
       input: {
         paymentMethodId: $paymentMethodId
         couponCode: $couponCode
-        organization: { organization: $organization }
+        organization: { organizationSlug: $organizationSlug }
         monthlyLimits: $monthlyLimits
       }
     ) {
@@ -106,8 +106,11 @@ const BillingUpgradeToProMutation = graphql(`
 `);
 
 const UpdateOrgRateLimitMutation = graphql(`
-  mutation updateOrgRateLimit($organization: ID!, $monthlyLimits: RateLimitInput!) {
-    updateOrgRateLimit(monthlyLimits: $monthlyLimits, selector: { organization: $organization }) {
+  mutation updateOrgRateLimit($organizationSlug: String!, $monthlyLimits: RateLimitInput!) {
+    updateOrgRateLimit(
+      monthlyLimits: $monthlyLimits
+      selector: { organizationSlug: $organizationSlug }
+    ) {
       ...ManageSubscriptionInner_OrganizationFragment
     }
   }
@@ -127,7 +130,7 @@ function Inner(props: {
     scope: OrganizationAccessScope.Settings,
     member: organization?.me,
     redirect: true,
-    organizationId: organization.slug,
+    organizationSlug: organization.slug,
   });
 
   const [query] = useQuery({ query: BillingsPlanQuery });
@@ -228,7 +231,7 @@ function Inner(props: {
     }
 
     await upgradeToProMutation({
-      organization: organization.slug,
+      organizationSlug: organization.slug,
       monthlyLimits: {
         operations: operationsRateLimit * 1_000_000,
       },
@@ -251,7 +254,7 @@ function Inner(props: {
     }
 
     await downgradeToHobbyMutation({
-      organization: organization.slug,
+      organizationSlug: organization.slug,
     });
   }, [organization.slug, downgradeToHobbyMutation, isFetching]);
 
@@ -261,7 +264,7 @@ function Inner(props: {
     }
 
     await updateOrgRateLimitMutation({
-      organization: organization.slug,
+      organizationSlug: organization.slug,
       monthlyLimits: {
         operations: operationsRateLimit * 1_000_000,
       },
@@ -415,7 +418,7 @@ function Inner(props: {
                 </>
               )}
 
-            {error && <QueryError organizationId={organization.slug} showError error={error} />}
+            {error && <QueryError organizationSlug={organization.slug} showError error={error} />}
             <div>{renderActions()}</div>
           </div>
         </div>
@@ -438,12 +441,12 @@ const ManageSubscriptionPageQuery = graphql(`
   }
 `);
 
-function ManageSubscriptionPageContent(props: { organizationId: string }) {
+function ManageSubscriptionPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: ManageSubscriptionPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
@@ -459,17 +462,17 @@ function ManageSubscriptionPageContent(props: { organizationId: string }) {
     scope: OrganizationAccessScope.Settings,
     member: organization?.me ?? null,
     redirect: true,
-    organizationId: props.organizationId,
+    organizationSlug: props.organizationSlug,
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
     <OrganizationLayout
       page={Page.Subscription}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex flex-col gap-y-10"
     >
       <div className="grow">
@@ -502,13 +505,13 @@ function ManageSubscriptionPageContent(props: { organizationId: string }) {
 }
 
 export function OrganizationSubscriptionManagePage(props: {
-  organizationId: string;
+  organizationSlug: string;
 }): ReactElement {
   return (
     <>
       <Meta title="Manage Subscription" />
-      <RenderIfStripeAvailable organizationId={props.organizationId}>
-        <ManageSubscriptionPageContent organizationId={props.organizationId} />
+      <RenderIfStripeAvailable organizationSlug={props.organizationSlug}>
+        <ManageSubscriptionPageContent organizationSlug={props.organizationSlug} />
       </RenderIfStripeAvailable>
     </>
   );

--- a/packages/web/app/src/pages/organization-subscription.tsx
+++ b/packages/web/app/src/pages/organization-subscription.tsx
@@ -78,12 +78,12 @@ const SubscriptionPageQuery = graphql(`
   }
 `);
 
-function SubscriptionPageContent(props: { organizationId: string }) {
+function SubscriptionPageContent(props: { organizationSlug: string }) {
   const [query] = useQuery({
     query: SubscriptionPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
@@ -97,7 +97,7 @@ function SubscriptionPageContent(props: { organizationId: string }) {
     scope: OrganizationAccessScope.Settings,
     member: organization?.me ?? null,
     redirect: true,
-    organizationId: props.organizationId,
+    organizationSlug: props.organizationSlug,
   });
 
   const monthlyUsage = query.data?.monthlyUsage ?? [];
@@ -107,7 +107,7 @@ function SubscriptionPageContent(props: { organizationId: string }) {
   );
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   if (query.fetching) {
@@ -129,7 +129,7 @@ function SubscriptionPageContent(props: { organizationId: string }) {
   return (
     <OrganizationLayout
       page={Page.Subscription}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex flex-col gap-y-10"
     >
       <div className="grow">
@@ -268,12 +268,12 @@ function SubscriptionPageContent(props: { organizationId: string }) {
   );
 }
 
-export function OrganizationSubscriptionPage(props: { organizationId: string }): ReactElement {
+export function OrganizationSubscriptionPage(props: { organizationSlug: string }): ReactElement {
   return (
     <>
       <Meta title="Subscription & Usage" />
-      <RenderIfStripeAvailable organizationId={props.organizationId}>
-        <SubscriptionPageContent organizationId={props.organizationId} />
+      <RenderIfStripeAvailable organizationSlug={props.organizationSlug}>
+        <SubscriptionPageContent organizationSlug={props.organizationSlug} />
       </RenderIfStripeAvailable>
     </>
   );

--- a/packages/web/app/src/pages/organization-subscription.tsx
+++ b/packages/web/app/src/pages/organization-subscription.tsx
@@ -141,8 +141,8 @@ function SubscriptionPageContent(props: { organizationId: string }) {
           <div>
             <Button asChild>
               <Link
-                to="/$organizationId/view/manage-subscription"
-                params={{ organizationId: currentOrganization.slug }}
+                to="/$organizationSlug/view/manage-subscription"
+                params={{ organizationSlug: currentOrganization.slug }}
               >
                 Manage subscription
               </Link>

--- a/packages/web/app/src/pages/organization-support-ticket.tsx
+++ b/packages/web/app/src/pages/organization-support-ticket.tsx
@@ -43,7 +43,7 @@ const ReplyTicketForm_SupportTicketReplyMutation = graphql(`
 `);
 
 function ReplyTicketForm(props: {
-  organizationId: string;
+  organizationSlug: string;
   ticketId: string;
   onSubmit: () => void;
 }) {
@@ -60,7 +60,7 @@ function ReplyTicketForm(props: {
     try {
       const result = await mutate({
         input: {
-          organization: props.organizationId,
+          organizationSlug: props.organizationSlug,
           ticketId: props.ticketId,
           body: data.body,
         },
@@ -183,7 +183,7 @@ function SupportTicket(props: {
     scope: OrganizationAccessScope.Read,
     member: organization.me,
     redirect: true,
-    organizationId: organization.slug,
+    organizationSlug: organization.slug,
   });
 
   const commentEdges = ticket.comments?.edges;
@@ -228,7 +228,7 @@ function SupportTicket(props: {
 
               <div className="mt-6">
                 <ReplyTicketForm
-                  organizationId={organization.slug}
+                  organizationSlug={organization.slug}
                   ticketId={ticket.id}
                   onSubmit={props.refetch}
                 />
@@ -293,13 +293,13 @@ const SupportTicketPageQuery = graphql(`
   }
 `);
 
-function SupportTicketPageContent(props: { ticketId: string; organizationId: string }) {
+function SupportTicketPageContent(props: { ticketId: string; organizationSlug: string }) {
   const ticketId = props.ticketId as string;
   const [query, refetchQuery] = useQuery({
     query: SupportTicketPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
       ticketId,
     },
@@ -311,7 +311,7 @@ function SupportTicketPageContent(props: { ticketId: string; organizationId: str
   }, [refetchQuery]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -320,7 +320,7 @@ function SupportTicketPageContent(props: { ticketId: string; organizationId: str
   return (
     <OrganizationLayout
       page={Page.Support}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex flex-col gap-y-10"
     >
       {currentOrganization ? (
@@ -339,11 +339,17 @@ function SupportTicketPageContent(props: { ticketId: string; organizationId: str
   );
 }
 
-export function OrganizationSupportTicketPage(props: { organizationId: string; ticketId: string }) {
+export function OrganizationSupportTicketPage(props: {
+  organizationSlug: string;
+  ticketId: string;
+}) {
   return (
     <>
       <Meta title={`Support Ticket #${props.ticketId}`} />
-      <SupportTicketPageContent organizationId={props.organizationId} ticketId={props.ticketId} />
+      <SupportTicketPageContent
+        organizationSlug={props.organizationSlug}
+        ticketId={props.ticketId}
+      />
     </>
   );
 }

--- a/packages/web/app/src/pages/organization-support-ticket.tsx
+++ b/packages/web/app/src/pages/organization-support-ticket.tsx
@@ -207,9 +207,9 @@ function SupportTicket(props: {
                 asChild
               >
                 <Link
-                  to="/$organizationId/view/support"
+                  to="/$organizationSlug/view/support"
                   params={{
-                    organizationId: organization.slug,
+                    organizationSlug: organization.slug,
                   }}
                 >
                   Tickets

--- a/packages/web/app/src/pages/organization-support.tsx
+++ b/packages/web/app/src/pages/organization-support.tsx
@@ -75,7 +75,7 @@ const NewTicketForm_SupportTicketCreateMutation = graphql(`
 `);
 
 function NewTicketForm(props: {
-  organizationId: string;
+  organizationSlug: string;
   isOpen: boolean;
   onClose: () => void;
   onSubmit: () => void;
@@ -104,7 +104,7 @@ function NewTicketForm(props: {
     try {
       const result = await mutate({
         input: {
-          organization: props.organizationId,
+          organizationSlug: props.organizationSlug,
           subject: data.subject,
           priority: data.priority,
           description: data.description,
@@ -254,7 +254,7 @@ const SupportTicketRow_SupportTicket = graphql(`
 `);
 
 function SupportTicketRow(props: {
-  organizationId: string;
+  organizationSlug: string;
   ticket: FragmentType<typeof SupportTicketRow_SupportTicket>;
 }) {
   const ticket = useFragment(SupportTicketRow_SupportTicket, props.ticket);
@@ -271,7 +271,7 @@ function SupportTicketRow(props: {
         >
           <Link
             to="/$organizationSlug/view/support/ticket/$ticketId"
-            params={{ organizationSlug: props.organizationId, ticketId: ticket.id }}
+            params={{ organizationSlug: props.organizationSlug, ticketId: ticket.id }}
           >
             {ticket.subject}
           </Link>
@@ -333,7 +333,7 @@ function Support(props: {
     scope: OrganizationAccessScope.Read,
     member: organization.me,
     redirect: true,
-    organizationId: organization.slug,
+    organizationSlug: organization.slug,
   });
 
   const tickets = supportTicketsConnection?.edges.map(e => e.node);
@@ -354,7 +354,7 @@ function Support(props: {
             <NewTicketForm
               isOpen={isOpen}
               onClose={toggle}
-              organizationId={organization.slug}
+              organizationSlug={organization.slug}
               onSubmit={onSubmit}
             />
           </div>
@@ -374,7 +374,7 @@ function Support(props: {
               {(tickets ?? []).map(ticket => (
                 <SupportTicketRow
                   key={ticket.id}
-                  organizationId={organization.slug}
+                  organizationSlug={organization.slug}
                   ticket={ticket}
                 />
               ))}
@@ -396,12 +396,12 @@ const SupportPageQuery = graphql(`
   }
 `);
 
-function SupportPageContent(props: { organizationId: string }) {
+function SupportPageContent(props: { organizationSlug: string }) {
   const [query, refetchQuery] = useQuery({
     query: SupportPageQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
     requestPolicy: 'cache-first',
@@ -412,7 +412,7 @@ function SupportPageContent(props: { organizationId: string }) {
   }, [refetchQuery]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -420,7 +420,7 @@ function SupportPageContent(props: { organizationId: string }) {
   return (
     <OrganizationLayout
       page={Page.Support}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex flex-col gap-y-10"
     >
       {currentOrganization ? (
@@ -430,11 +430,11 @@ function SupportPageContent(props: { organizationId: string }) {
   );
 }
 
-export function OrganizationSupportPage(props: { organizationId: string }) {
+export function OrganizationSupportPage(props: { organizationSlug: string }) {
   return (
     <>
       <Meta title="Support" />
-      <SupportPageContent organizationId={props.organizationId} />
+      <SupportPageContent organizationSlug={props.organizationSlug} />
     </>
   );
 }

--- a/packages/web/app/src/pages/organization-support.tsx
+++ b/packages/web/app/src/pages/organization-support.tsx
@@ -270,8 +270,8 @@ function SupportTicketRow(props: {
           asChild
         >
           <Link
-            to="/$organizationId/view/support/ticket/$ticketId"
-            params={{ organizationId: props.organizationId, ticketId: ticket.id }}
+            to="/$organizationSlug/view/support/ticket/$ticketId"
+            params={{ organizationSlug: props.organizationId, ticketId: ticket.id }}
           >
             {ticket.subject}
           </Link>

--- a/packages/web/app/src/pages/organization-transfer.tsx
+++ b/packages/web/app/src/pages/organization-transfer.tsx
@@ -47,16 +47,15 @@ const OrganizationTransferPage_AnswerRequest = graphql(`
   }
 `);
 
-export function OrganizationTransferPage(props: { organizationId: string; code: string }) {
+export function OrganizationTransferPage(props: { organizationSlug: string; code: string }) {
   const router = useRouter();
   const notify = useNotifications();
-  const orgId = props.organizationId;
   const code = props.code;
   const [query] = useQuery({
     query: OrganizationTransferPage_GetRequest,
     variables: {
       selector: {
-        organization: orgId,
+        organizationSlug: props.organizationSlug,
         code,
       },
     },
@@ -67,7 +66,7 @@ export function OrganizationTransferPage(props: { organizationId: string; code: 
       const result = await mutate({
         input: {
           code,
-          organization: orgId,
+          organizationSlug: props.organizationSlug,
           accept,
         },
       });
@@ -79,7 +78,7 @@ export function OrganizationTransferPage(props: { organizationId: string; code: 
           void router.navigate({
             to: '/$organizationSlug',
             params: {
-              organizationSlug: orgId,
+              organizationSlug: props.organizationSlug,
             },
           });
         } else {
@@ -91,7 +90,7 @@ export function OrganizationTransferPage(props: { organizationId: string; code: 
         notify('Failed to answer', 'error');
       }
     },
-    [mutate, orgId, code, router, notify],
+    [mutate, props.organizationSlug, code, router, notify],
   );
 
   const accept = useCallback(() => answer(true), [answer]);

--- a/packages/web/app/src/pages/organization-transfer.tsx
+++ b/packages/web/app/src/pages/organization-transfer.tsx
@@ -77,9 +77,9 @@ export function OrganizationTransferPage(props: { organizationId: string; code: 
             notify('The organization is now yours!', 'success');
           }
           void router.navigate({
-            to: '/$organizationId',
+            to: '/$organizationSlug',
             params: {
-              organizationId: orgId,
+              organizationSlug: orgId,
             },
           });
         } else {

--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -225,17 +225,17 @@ const ProjectCard = (props: {
 
 const OrganizationProjectsPageQuery = graphql(`
   query OrganizationProjectsPageQuery(
-    $organizationSlug: ID!
+    $organizationSlug: String!
     $chartResolution: Int!
     $period: DateRangeInput!
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
       }
     }
-    projects(selector: { organization: $organizationSlug }) {
+    projects(selector: { organizationSlug: $organizationSlug }) {
       total
       nodes {
         id
@@ -254,7 +254,7 @@ const OrganizationProjectsPageQuery = graphql(`
 
 function OrganizationPageContent(
   props: {
-    organizationId: string;
+    organizationSlug: string;
   } & RouteSearchProps,
 ) {
   const days = 14;
@@ -288,7 +288,7 @@ function OrganizationPageContent(
   const [query] = useQuery({
     query: OrganizationProjectsPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
+      organizationSlug: props.organizationSlug,
       chartResolution: days, // 14 days = 14 data points
       period: period.current,
     },
@@ -348,13 +348,13 @@ function OrganizationPageContent(
   }, [projectsConnection, props.search, sortKey, sortOrder]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
     <OrganizationLayout
       page={Page.Overview}
-      organizationId={props.organizationId}
+      organizationSlug={props.organizationSlug}
       className="flex justify-between gap-12"
     >
       <>
@@ -494,14 +494,14 @@ function OrganizationPageContent(
 
 export function OrganizationPage(
   props: {
-    organizationId: string;
+    organizationSlug: string;
   } & RouteSearchProps,
 ) {
   return (
     <>
       <Meta title="Organization" />
       <OrganizationPageContent
-        organizationId={props.organizationId}
+        organizationSlug={props.organizationSlug}
         search={props.search}
         sortBy={props.sortBy}
         sortOrder={props.sortOrder}

--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -82,10 +82,10 @@ const ProjectCard = (props: {
   return (
     <Card className="h-full self-start bg-gray-900/50 p-5 px-0 pt-4 hover:bg-gray-800/40 hover:shadow-md hover:shadow-gray-800/50">
       <Link
-        to="/$organizationId/$projectId"
+        to="/$organizationSlug/$projectSlug"
         params={{
-          organizationId: props.cleanOrganizationId ?? 'unknown-yet',
-          projectId: project?.slug ?? 'unknown-yet',
+          organizationSlug: props.cleanOrganizationId ?? 'unknown-yet',
+          projectSlug: project?.slug ?? 'unknown-yet',
         }}
       >
         <TooltipProvider>
@@ -225,17 +225,17 @@ const ProjectCard = (props: {
 
 const OrganizationProjectsPageQuery = graphql(`
   query OrganizationProjectsPageQuery(
-    $organizationId: ID!
+    $organizationSlug: ID!
     $chartResolution: Int!
     $period: DateRangeInput!
   ) {
-    organization(selector: { organization: $organizationId }) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
       }
     }
-    projects(selector: { organization: $organizationId }) {
+    projects(selector: { organization: $organizationSlug }) {
       total
       nodes {
         id
@@ -288,7 +288,7 @@ function OrganizationPageContent(
   const [query] = useQuery({
     query: OrganizationProjectsPageQuery,
     variables: {
-      organizationId: props.organizationId,
+      organizationSlug: props.organizationId,
       chartResolution: days, // 14 days = 14 data points
       period: period.current,
     },

--- a/packages/web/app/src/pages/project-alerts.tsx
+++ b/packages/web/app/src/pages/project-alerts.tsx
@@ -32,8 +32,8 @@ import { ProjectAccessScope, useProjectAccess } from '@/lib/access/project';
 import { useToggle } from '@/lib/hooks';
 
 function Channels(props: {
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
   channels: FragmentType<typeof ChannelsTable_AlertChannelFragment>[];
 }) {
   const [selected, setSelected] = useState<string[]>([]);
@@ -74,8 +74,8 @@ function Channels(props: {
           </Button>
           {channels.length > 0 && (
             <DeleteChannelsButton
-              organizationId={props.organizationId}
-              projectId={props.projectId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
               selected={selected}
               onSuccess={() => {
                 setSelected([]);
@@ -86,8 +86,8 @@ function Channels(props: {
       </CardFooter>
       {isModalOpen && (
         <CreateChannelModal
-          organizationId={props.organizationId}
-          projectId={props.projectId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
           isOpen={isModalOpen}
           toggleModalOpen={toggleModalOpen}
         />
@@ -100,8 +100,8 @@ function Alerts(props: {
   alerts: FragmentType<typeof AlertsTable_AlertFragment>[];
   channels: FragmentType<typeof CreateAlertModal_AlertChannelFragment>[];
   targets: FragmentType<typeof CreateAlertModal_TargetFragment>[];
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }) {
   const [selected, setSelected] = useState<string[]>([]);
   const [isModalOpen, toggleModalOpen] = useToggle();
@@ -139,8 +139,8 @@ function Alerts(props: {
               Create alert
             </Button>
             <DeleteAlertsButton
-              organizationId={props.organizationId}
-              projectId={props.projectId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
               selected={selected}
               onSuccess={() => {
                 setSelected([]);
@@ -151,8 +151,8 @@ function Alerts(props: {
       </Card>
       {isModalOpen && (
         <CreateAlertModal
-          projectId={props.projectId}
-          organizationId={props.organizationId}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           targets={props.targets}
           channels={props.channels}
           isOpen={isModalOpen}
@@ -175,13 +175,13 @@ const ProjectAlertsPage_OrganizationFragment = graphql(`
 `);
 
 const ProjectAlertsPageQuery = graphql(`
-  query ProjectAlertsPageQuery($organizationSlug: ID!, $projectSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query ProjectAlertsPageQuery($organizationSlug: String!, $projectSlug: String!) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         ...ProjectAlertsPage_OrganizationFragment
       }
     }
-    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
+    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
       targets {
         nodes {
@@ -199,12 +199,12 @@ const ProjectAlertsPageQuery = graphql(`
   }
 `);
 
-function AlertsPageContent(props: { organizationId: string; projectId: string }) {
+function AlertsPageContent(props: { organizationSlug: string; projectSlug: string }) {
   const [query] = useQuery({
     query: ProjectAlertsPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
     },
     requestPolicy: 'cache-and-network',
   });
@@ -220,12 +220,12 @@ function AlertsPageContent(props: { organizationId: string; projectId: string })
     scope: ProjectAccessScope.Alerts,
     member: organizationForAlerts?.me ?? null,
     redirect: true,
-    organizationId: props.organizationId,
-    projectId: props.projectId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const alerts = currentProject?.alerts || [];
@@ -234,8 +234,8 @@ function AlertsPageContent(props: { organizationId: string; projectId: string })
 
   return (
     <ProjectLayout
-      projectId={props.projectId}
-      organizationId={props.organizationId}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
       page={Page.Alerts}
       className="flex flex-col gap-y-10"
     >
@@ -247,13 +247,13 @@ function AlertsPageContent(props: { organizationId: string; projectId: string })
         {currentProject && currentOrganization && hasAccess ? (
           <div className="flex flex-col gap-y-4">
             <Channels
-              organizationId={props.organizationId}
-              projectId={props.projectId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
               channels={channels}
             />
             <Alerts
-              organizationId={props.organizationId}
-              projectId={props.projectId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
               alerts={alerts}
               channels={channels}
               targets={targets}
@@ -265,11 +265,14 @@ function AlertsPageContent(props: { organizationId: string; projectId: string })
   );
 }
 
-export function ProjectAlertsPage(props: { organizationId: string; projectId: string }) {
+export function ProjectAlertsPage(props: { organizationSlug: string; projectSlug: string }) {
   return (
     <>
       <Meta title="Alerts" />
-      <AlertsPageContent organizationId={props.organizationId} projectId={props.projectId} />
+      <AlertsPageContent
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+      />
     </>
   );
 }

--- a/packages/web/app/src/pages/project-alerts.tsx
+++ b/packages/web/app/src/pages/project-alerts.tsx
@@ -175,13 +175,13 @@ const ProjectAlertsPage_OrganizationFragment = graphql(`
 `);
 
 const ProjectAlertsPageQuery = graphql(`
-  query ProjectAlertsPageQuery($organizationId: ID!, $projectId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query ProjectAlertsPageQuery($organizationSlug: ID!, $projectSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         ...ProjectAlertsPage_OrganizationFragment
       }
     }
-    project(selector: { organization: $organizationId, project: $projectId }) {
+    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
       id
       targets {
         nodes {
@@ -203,8 +203,8 @@ function AlertsPageContent(props: { organizationId: string; projectId: string })
   const [query] = useQuery({
     query: ProjectAlertsPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
     },
     requestPolicy: 'cache-and-network',
   });

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -12,8 +12,8 @@ import { ProjectAccessScope, RegistryModel } from '@/gql/graphql';
 import { useProjectAccess } from '@/lib/access/project';
 
 const ProjectPolicyPageQuery = graphql(`
-  query ProjectPolicyPageQuery($organizationId: ID!, $projectId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query ProjectPolicyPageQuery($organizationSlug: ID!, $projectSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         me {
@@ -22,7 +22,7 @@ const ProjectPolicyPageQuery = graphql(`
         }
       }
     }
-    project(selector: { organization: $organizationId, project: $projectId }) {
+    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
       id
       registryModel
       schemaPolicy {
@@ -72,8 +72,8 @@ function ProjectPolicyContent(props: { organizationId: string; projectId: string
   const [query] = useQuery({
     query: ProjectPolicyPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
     },
     requestPolicy: 'cache-and-network',
   });

--- a/packages/web/app/src/pages/project-policy.tsx
+++ b/packages/web/app/src/pages/project-policy.tsx
@@ -12,8 +12,8 @@ import { ProjectAccessScope, RegistryModel } from '@/gql/graphql';
 import { useProjectAccess } from '@/lib/access/project';
 
 const ProjectPolicyPageQuery = graphql(`
-  query ProjectPolicyPageQuery($organizationSlug: ID!, $projectSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query ProjectPolicyPageQuery($organizationSlug: String!, $projectSlug: String!) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         me {
@@ -22,7 +22,7 @@ const ProjectPolicyPageQuery = graphql(`
         }
       }
     }
-    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
+    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
       registryModel
       schemaPolicy {
@@ -67,13 +67,13 @@ const UpdateSchemaPolicyForProject = graphql(`
   }
 `);
 
-function ProjectPolicyContent(props: { organizationId: string; projectId: string }) {
+function ProjectPolicyContent(props: { organizationSlug: string; projectSlug: string }) {
   const [mutation, mutate] = useMutation(UpdateSchemaPolicyForProject);
   const [query] = useQuery({
     query: ProjectPolicyPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
     },
     requestPolicy: 'cache-and-network',
   });
@@ -86,20 +86,20 @@ function ProjectPolicyContent(props: { organizationId: string; projectId: string
     scope: ProjectAccessScope.Settings,
     member: currentOrganization?.me ?? null,
     redirect: true,
-    organizationId: props.organizationId,
-    projectId: props.projectId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const isLegacyProject = currentProject?.registryModel === RegistryModel.Legacy;
 
   return (
     <ProjectLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
       page={Page.Policy}
       className="flex flex-col gap-y-10"
     >
@@ -159,8 +159,8 @@ function ProjectPolicyContent(props: { organizationId: string; projectId: string
                   onSave={async newPolicy => {
                     await mutate({
                       selector: {
-                        organization: props.organizationId,
-                        project: props.projectId,
+                        organizationSlug: props.organizationSlug,
+                        projectSlug: props.projectSlug,
                       },
                       policy: newPolicy,
                     }).then(result => {
@@ -198,11 +198,14 @@ function ProjectPolicyContent(props: { organizationId: string; projectId: string
   );
 }
 
-export function ProjectPolicyPage(props: { organizationId: string; projectId: string }) {
+export function ProjectPolicyPage(props: { organizationSlug: string; projectSlug: string }) {
   return (
     <>
       <Meta title="Project Schema Policy" />
-      <ProjectPolicyContent organizationId={props.organizationId} projectId={props.projectId} />
+      <ProjectPolicyContent
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+      />
     </>
   );
 }

--- a/packages/web/app/src/pages/project-settings.tsx
+++ b/packages/web/app/src/pages/project-settings.tsx
@@ -209,10 +209,7 @@ const SlugFormSchema = z.object({
 
 type SlugFormValues = z.infer<typeof SlugFormSchema>;
 
-function ProjectSettingsPage_SlugForm(props: {
-  organizationCleanId: string;
-  projectCleanId: string;
-}) {
+function ProjectSettingsPage_SlugForm(props: { organizationSlug: string; projectSlug: string }) {
   const { toast } = useToast();
   const router = useRouter();
   const [_slugMutation, slugMutate] = useMutation(ProjectSettingsPage_UpdateProjectSlugMutation);
@@ -221,7 +218,7 @@ function ProjectSettingsPage_SlugForm(props: {
     mode: 'all',
     resolver: zodResolver(SlugFormSchema),
     defaultValues: {
-      slug: props.projectCleanId,
+      slug: props.projectSlug,
     },
   });
 
@@ -230,8 +227,8 @@ function ProjectSettingsPage_SlugForm(props: {
       try {
         const result = await slugMutate({
           input: {
-            organization: props.organizationCleanId,
-            project: props.projectCleanId,
+            organization: props.organizationSlug,
+            project: props.projectSlug,
             slug: data.slug,
           },
         });
@@ -245,10 +242,10 @@ function ProjectSettingsPage_SlugForm(props: {
             description: 'Project slug updated',
           });
           void router.navigate({
-            to: '/$organizationId/$projectId/view/settings',
+            to: '/$organizationSlug/$projectSlug/view/settings',
             params: {
-              organizationId: props.organizationCleanId,
-              projectId: result.data.updateProjectSlug.ok.project.slug,
+              organizationSlug: props.organizationSlug,
+              projectSlug: result.data.updateProjectSlug.ok.project.slug,
             },
           });
         } else if (error) {
@@ -293,7 +290,7 @@ function ProjectSettingsPage_SlugForm(props: {
                   <FormControl>
                     <div className="flex items-center">
                       <div className="border-input text-muted-foreground h-10 rounded-md rounded-r-none border-y border-l bg-gray-900 px-3 py-2 text-sm">
-                        {env.appBaseUrl.replace(/https?:\/\//i, '')}/{props.organizationCleanId}/
+                        {env.appBaseUrl.replace(/https?:\/\//i, '')}/{props.organizationSlug}/
                       </div>
                       <Input placeholder="slug" className="w-48 rounded-l-none" {...field} />
                     </div>
@@ -339,13 +336,13 @@ const ProjectSettingsPage_ProjectFragment = graphql(`
 `);
 
 const ProjectSettingsPageQuery = graphql(`
-  query ProjectSettingsPageQuery($organizationId: ID!, $projectId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query ProjectSettingsPageQuery($organizationSlug: ID!, $projectSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         ...ProjectSettingsPage_OrganizationFragment
       }
     }
-    project(selector: { organization: $organizationId, project: $projectId }) {
+    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
       ...ProjectSettingsPage_ProjectFragment
     }
     isGitHubIntegrationFeatureEnabled
@@ -357,8 +354,8 @@ function ProjectSettingsContent(props: { organizationId: string; projectId: stri
   const [query] = useQuery({
     query: ProjectSettingsPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
     },
     requestPolicy: 'cache-and-network',
   });
@@ -398,8 +395,8 @@ function ProjectSettingsContent(props: { organizationId: string; projectId: stri
               <>
                 <ModelMigrationSettings project={project} organizationId={organization.slug} />
                 <ProjectSettingsPage_SlugForm
-                  organizationCleanId={props.organizationId}
-                  projectCleanId={props.projectId}
+                  organizationSlug={props.organizationId}
+                  projectSlug={props.projectId}
                 />
                 {query.data?.isGitHubIntegrationFeatureEnabled &&
                 !project.isProjectNameInGitHubCheckEnabled ? (
@@ -514,9 +511,9 @@ export function DeleteProjectModal(props: {
       });
       props.toggleModalOpen();
       void router.navigate({
-        to: '/$organizationId',
+        to: '/$organizationSlug',
         params: {
-          organizationId,
+          organizationSlug: organizationId,
         },
       });
     }

--- a/packages/web/app/src/pages/project.tsx
+++ b/packages/web/app/src/pages/project.tsx
@@ -67,11 +67,11 @@ const TargetCard = (props: {
       className="h-full self-start bg-gray-900/50 px-0 pt-4 hover:bg-gray-800/40 hover:shadow-md hover:shadow-gray-800/50"
     >
       <Link
-        to="/$organizationId/$projectId/$targetId"
+        to="/$organizationSlug/$projectSlug/$targetSlug"
         params={{
-          organizationId: props.organizationId ?? 'unknown-yet',
-          projectId: props.projectId ?? 'unknown-yet',
-          targetId: target?.slug ?? 'unknown-yet',
+          organizationSlug: props.organizationId ?? 'unknown-yet',
+          projectSlug: props.projectId ?? 'unknown-yet',
+          targetSlug: target?.slug ?? 'unknown-yet',
         }}
       >
         <TooltipProvider>
@@ -246,8 +246,8 @@ const ProjectsPageContent = (
   const [query] = useQuery({
     query: ProjectOverviewPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
       chartResolution: days, // 14 days = 14 data points
       period: period.current,
     },
@@ -457,12 +457,12 @@ const ProjectsPageContent = (
 
 const ProjectOverviewPageQuery = graphql(`
   query ProjectOverviewPageQuery(
-    $organizationId: ID!
-    $projectId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
     $chartResolution: Int!
     $period: DateRangeInput!
   ) {
-    targets(selector: { organization: $organizationId, project: $projectId }) {
+    targets(selector: { organization: $organizationSlug, project: $projectSlug }) {
       total
       nodes {
         id

--- a/packages/web/app/src/pages/project.tsx
+++ b/packages/web/app/src/pages/project.tsx
@@ -37,8 +37,8 @@ const TargetCard = (props: {
   requestsOverTime: { date: string; value: number }[] | null;
   schemaVersionsCount: number | null;
   days: number;
-  organizationId: string;
-  projectId: string;
+  organizationSlug: string;
+  projectSlug: string;
 }): ReactElement => {
   const target = useFragment(TargetCard_TargetFragment, props.target);
   const { highestNumberOfRequests } = props;
@@ -69,8 +69,8 @@ const TargetCard = (props: {
       <Link
         to="/$organizationSlug/$projectSlug/$targetSlug"
         params={{
-          organizationSlug: props.organizationId ?? 'unknown-yet',
-          projectSlug: props.projectId ?? 'unknown-yet',
+          organizationSlug: props.organizationSlug ?? 'unknown-yet',
+          projectSlug: props.projectSlug ?? 'unknown-yet',
           targetSlug: target?.slug ?? 'unknown-yet',
         }}
       >
@@ -214,7 +214,7 @@ export const ProjectIndexRouteSearch = z.object({
 type RouteSearchProps = z.infer<typeof ProjectIndexRouteSearch>;
 
 const ProjectsPageContent = (
-  props: { organizationId: string; projectId: string } & RouteSearchProps,
+  props: { organizationSlug: string; projectSlug: string } & RouteSearchProps,
 ) => {
   const period = useRef<{
     from: string;
@@ -246,8 +246,8 @@ const ProjectsPageContent = (
   const [query] = useQuery({
     query: ProjectOverviewPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
       chartResolution: days, // 14 days = 14 data points
       period: period.current,
     },
@@ -303,14 +303,14 @@ const ProjectsPageContent = (
   }, [targetConnection?.nodes]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
     <ProjectLayout
       page={Page.Targets}
-      organizationId={props.organizationId}
-      projectId={props.projectId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
       className="flex justify-between gap-12"
     >
       <div className="grow">
@@ -428,8 +428,8 @@ const ProjectsPageContent = (
                   highestNumberOfRequests={highestNumberOfRequests}
                   requestsOverTime={target.requestsOverTime}
                   schemaVersionsCount={target.schemaVersionsCount}
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
                 />
               ))
             )
@@ -443,8 +443,8 @@ const ProjectsPageContent = (
                   highestNumberOfRequests={highestNumberOfRequests}
                   requestsOverTime={null}
                   schemaVersionsCount={null}
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
                 />
               ))}
             </>
@@ -457,12 +457,12 @@ const ProjectsPageContent = (
 
 const ProjectOverviewPageQuery = graphql(`
   query ProjectOverviewPageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
     $chartResolution: Int!
     $period: DateRangeInput!
   ) {
-    targets(selector: { organization: $organizationSlug, project: $projectSlug }) {
+    targets(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       total
       nodes {
         id
@@ -480,14 +480,14 @@ const ProjectOverviewPageQuery = graphql(`
 `);
 
 export function ProjectPage(
-  props: { organizationId: string; projectId: string } & RouteSearchProps,
+  props: { organizationSlug: string; projectSlug: string } & RouteSearchProps,
 ): ReactElement {
   return (
     <>
       <Meta title="Targets" />
       <ProjectsPageContent
-        organizationId={props.organizationId}
-        projectId={props.projectId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
         search={props.search}
         sortBy={props.sortBy}
         sortOrder={props.sortOrder}

--- a/packages/web/app/src/pages/target-app-version.tsx
+++ b/packages/web/app/src/pages/target-app-version.tsx
@@ -31,22 +31,26 @@ import { Link, useRouter } from '@tanstack/react-router';
 
 const TargetAppsVersionQuery = graphql(`
   query TargetAppsVersionQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $appName: String!
     $appVersion: String!
     $first: Int
     $after: String
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         isAppDeploymentsEnabled
       }
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       appDeployment(appName: $appName, appVersion: $appVersion) {
@@ -73,18 +77,18 @@ const TargetAppsVersionQuery = graphql(`
 `);
 
 export function TargetAppVersionPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   appName: string;
   appVersion: string;
 }) {
   const [data] = useQuery({
     query: TargetAppsVersionQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       appName: props.appName,
       appVersion: props.appVersion,
       first: 20,
@@ -103,9 +107,9 @@ export function TargetAppVersionPage(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationSlug: props.organizationId,
-          projectSlug: props.projectId,
-          targetSlug: props.targetId,
+          organizationSlug: props.organizationSlug,
+          projectSlug: props.projectSlug,
+          targetSlug: props.targetSlug,
         },
         replace: true,
       });
@@ -121,9 +125,9 @@ export function TargetAppVersionPage(props: {
       <>
         <Meta title="App Version Not found" />
         <TargetLayout
-          targetId={props.targetId}
-          projectId={props.projectId}
-          organizationId={props.organizationId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           page={Page.Apps}
           className="min-h-content"
         >
@@ -150,9 +154,9 @@ export function TargetAppVersionPage(props: {
     <>
       <Meta title={title} />
       <TargetLayout
-        targetId={props.targetId}
-        projectId={props.projectId}
-        organizationId={props.organizationId}
+        targetSlug={props.targetSlug}
+        projectSlug={props.projectSlug}
+        organizationSlug={props.organizationSlug}
         page={Page.Apps}
         className="min-h-content"
       >
@@ -163,9 +167,9 @@ export function TargetAppVersionPage(props: {
                 <Link
                   to="/$organizationSlug/$projectSlug/$targetSlug/apps"
                   params={{
-                    organizationSlug: props.organizationId,
-                    projectSlug: props.projectId,
-                    targetSlug: props.targetId,
+                    organizationSlug: props.organizationSlug,
+                    projectSlug: props.projectSlug,
+                    targetSlug: props.targetSlug,
                   }}
                 >
                   App Deployments
@@ -268,9 +272,9 @@ export function TargetAppVersionPage(props: {
                                 <Link
                                   to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                                   params={{
-                                    organizationSlug: props.organizationId,
-                                    projectSlug: props.projectId,
-                                    targetSlug: props.targetId,
+                                    organizationSlug: props.organizationSlug,
+                                    projectSlug: props.projectSlug,
+                                    targetSlug: props.targetSlug,
                                   }}
                                   search={{
                                     operationString: edge.node.body,
@@ -283,9 +287,9 @@ export function TargetAppVersionPage(props: {
                                 <Link
                                   to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                                   params={{
-                                    organizationSlug: props.organizationId,
-                                    projectSlug: props.projectId,
-                                    targetSlug: props.targetId,
+                                    organizationSlug: props.organizationSlug,
+                                    projectSlug: props.projectSlug,
+                                    targetSlug: props.targetSlug,
                                     operationName: edge.node.operationName ?? edge.node.hash,
                                     operationHash: edge.node.insightsHash,
                                   }}
@@ -318,9 +322,9 @@ export function TargetAppVersionPage(props: {
                       setIsLoadingMore(true);
                       void client
                         .query(TargetAppsVersionQuery, {
-                          organizationSlug: props.organizationId,
-                          projectSlug: props.projectId,
-                          targetSlug: props.targetId,
+                          organizationSlug: props.organizationSlug,
+                          projectSlug: props.projectSlug,
+                          targetSlug: props.targetSlug,
                           appName: props.appName,
                           appVersion: props.appVersion,
                           first: 20,

--- a/packages/web/app/src/pages/target-app-version.tsx
+++ b/packages/web/app/src/pages/target-app-version.tsx
@@ -31,21 +31,23 @@ import { Link, useRouter } from '@tanstack/react-router';
 
 const TargetAppsVersionQuery = graphql(`
   query TargetAppsVersionQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $appName: String!
     $appVersion: String!
     $first: Int
     $after: String
   ) {
-    organization(selector: { organization: $organizationId }) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         isAppDeploymentsEnabled
       }
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       appDeployment(appName: $appName, appVersion: $appVersion) {
         id
@@ -80,9 +82,9 @@ export function TargetAppVersionPage(props: {
   const [data] = useQuery({
     query: TargetAppsVersionQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
       appName: props.appName,
       appVersion: props.appVersion,
       first: 20,
@@ -99,11 +101,11 @@ export function TargetAppVersionPage(props: {
   useEffect(() => {
     if (isAppDeploymentsEnabled) {
       void router.navigate({
-        to: '/$organizationId/$projectId/$targetId',
+        to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationId: props.organizationId,
-          projectId: props.projectId,
-          targetId: props.targetId,
+          organizationSlug: props.organizationId,
+          projectSlug: props.projectId,
+          targetSlug: props.targetId,
         },
         replace: true,
       });
@@ -159,11 +161,11 @@ export function TargetAppVersionPage(props: {
             subPageTitle={
               <span className="flex items-center">
                 <Link
-                  to="/$organizationId/$projectId/$targetId/apps"
+                  to="/$organizationSlug/$projectSlug/$targetSlug/apps"
                   params={{
-                    organizationId: props.organizationId,
-                    projectId: props.projectId,
-                    targetId: props.targetId,
+                    organizationSlug: props.organizationId,
+                    projectSlug: props.projectId,
+                    targetSlug: props.targetId,
                   }}
                 >
                   App Deployments
@@ -264,11 +266,11 @@ export function TargetAppVersionPage(props: {
                             <DropdownMenuContent>
                               <DropdownMenuItem asChild className="cursor-pointer">
                                 <Link
-                                  to="/$organizationId/$projectId/$targetId/laboratory"
+                                  to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                                   params={{
-                                    organizationId: props.organizationId,
-                                    projectId: props.projectId,
-                                    targetId: props.targetId,
+                                    organizationSlug: props.organizationId,
+                                    projectSlug: props.projectId,
+                                    targetSlug: props.targetId,
                                   }}
                                   search={{
                                     operationString: edge.node.body,
@@ -279,11 +281,11 @@ export function TargetAppVersionPage(props: {
                               </DropdownMenuItem>
                               <DropdownMenuItem asChild className="cursor-pointer">
                                 <Link
-                                  to="/$organizationId/$projectId/$targetId/insights/$operationName/$operationHash"
+                                  to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                                   params={{
-                                    organizationId: props.organizationId,
-                                    projectId: props.projectId,
-                                    targetId: props.targetId,
+                                    organizationSlug: props.organizationId,
+                                    projectSlug: props.projectId,
+                                    targetSlug: props.targetId,
                                     operationName: edge.node.operationName ?? edge.node.hash,
                                     operationHash: edge.node.insightsHash,
                                   }}
@@ -316,9 +318,9 @@ export function TargetAppVersionPage(props: {
                       setIsLoadingMore(true);
                       void client
                         .query(TargetAppsVersionQuery, {
-                          organizationId: props.organizationId,
-                          projectId: props.projectId,
-                          targetId: props.targetId,
+                          organizationSlug: props.organizationId,
+                          projectSlug: props.projectId,
+                          targetSlug: props.targetId,
                           appName: props.appName,
                           appVersion: props.appVersion,
                           first: 20,

--- a/packages/web/app/src/pages/target-apps.tsx
+++ b/packages/web/app/src/pages/target-apps.tsx
@@ -37,19 +37,23 @@ const AppTableRow_AppDeploymentFragment = graphql(`
 
 const TargetAppsViewQuery = graphql(`
   query TargetAppsViewQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $after: String
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         isAppDeploymentsEnabled
       }
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       latestSchemaVersion {
@@ -74,13 +78,17 @@ const TargetAppsViewQuery = graphql(`
 
 const TargetAppsViewFetchMoreQuery = graphql(`
   query TargetAppsViewFetchMoreQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $after: String!
   ) {
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       appDeployments(first: 20, after: $after) {
@@ -100,9 +108,9 @@ const TargetAppsViewFetchMoreQuery = graphql(`
 `);
 
 function AppTableRow(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   appDeployment: FragmentType<typeof AppTableRow_AppDeploymentFragment>;
 }) {
   const appDeployment = useFragment(AppTableRow_AppDeploymentFragment, props.appDeployment);
@@ -114,9 +122,9 @@ function AppTableRow(props: {
           className="font-mono text-xs font-bold"
           to="/$organizationSlug/$projectSlug/$targetSlug/apps/$appName/$appVersion"
           params={{
-            organizationSlug: props.organizationId,
-            projectSlug: props.projectId,
-            targetSlug: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
             appName: appDeployment.name,
             appVersion: appDeployment.version,
           }}
@@ -166,13 +174,17 @@ function AppTableRow(props: {
   );
 }
 
-function TargetAppsView(props: { organizationId: string; projectId: string; targetId: string }) {
+function TargetAppsView(props: {
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+}) {
   const [data] = useQuery({
     query: TargetAppsViewQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
   const client = useClient();
@@ -187,9 +199,9 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationSlug: props.organizationId,
-          projectSlug: props.projectId,
-          targetSlug: props.targetId,
+          organizationSlug: props.organizationSlug,
+          projectSlug: props.projectSlug,
+          targetSlug: props.targetSlug,
         },
         replace: true,
       });
@@ -260,9 +272,9 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
               <TableBody>
                 {data.data?.target?.appDeployments?.edges.map(edge => (
                   <AppTableRow
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                     appDeployment={edge.node}
                   />
                 ))}
@@ -283,9 +295,9 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
                   setIsLoadingMore(true);
                   void client
                     .query(TargetAppsViewFetchMoreQuery, {
-                      organizationSlug: props.organizationId,
-                      projectSlug: props.projectId,
-                      targetSlug: props.targetId,
+                      organizationSlug: props.organizationSlug,
+                      projectSlug: props.projectSlug,
+                      targetSlug: props.targetSlug,
                       after: data?.data?.target?.appDeployments?.pageInfo?.endCursor,
                     })
                     .toPromise()
@@ -311,23 +323,23 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
 }
 
 export function TargetAppsPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>
       <Meta title="App Deployments" />
       <TargetLayout
-        targetId={props.targetId}
-        projectId={props.projectId}
-        organizationId={props.organizationId}
+        targetSlug={props.targetSlug}
+        projectSlug={props.projectSlug}
+        organizationSlug={props.organizationSlug}
         page={Page.Apps}
       >
         <TargetAppsView
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
         />
       </TargetLayout>
     </>

--- a/packages/web/app/src/pages/target-apps.tsx
+++ b/packages/web/app/src/pages/target-apps.tsx
@@ -36,14 +36,21 @@ const AppTableRow_AppDeploymentFragment = graphql(`
 `);
 
 const TargetAppsViewQuery = graphql(`
-  query TargetAppsViewQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!, $after: String) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetAppsViewQuery(
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
+    $after: String
+  ) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         isAppDeploymentsEnabled
       }
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       latestSchemaVersion {
         id
@@ -67,12 +74,14 @@ const TargetAppsViewQuery = graphql(`
 
 const TargetAppsViewFetchMoreQuery = graphql(`
   query TargetAppsViewFetchMoreQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $after: String!
   ) {
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       appDeployments(first: 20, after: $after) {
         pageInfo {
@@ -103,11 +112,11 @@ function AppTableRow(props: {
       <TableCell>
         <Link
           className="font-mono text-xs font-bold"
-          to="/$organizationId/$projectId/$targetId/apps/$appName/$appVersion"
+          to="/$organizationSlug/$projectSlug/$targetSlug/apps/$appName/$appVersion"
           params={{
-            organizationId: props.organizationId,
-            projectId: props.projectId,
-            targetId: props.targetId,
+            organizationSlug: props.organizationId,
+            projectSlug: props.projectId,
+            targetSlug: props.targetId,
             appName: appDeployment.name,
             appVersion: appDeployment.version,
           }}
@@ -161,9 +170,9 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
   const [data] = useQuery({
     query: TargetAppsViewQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
   const client = useClient();
@@ -176,11 +185,11 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
   useEffect(() => {
     if (isAppDeploymentsEnabled) {
       void router.navigate({
-        to: '/$organizationId/$projectId/$targetId',
+        to: '/$organizationSlug/$projectSlug/$targetSlug',
         params: {
-          organizationId: props.organizationId,
-          projectId: props.projectId,
-          targetId: props.targetId,
+          organizationSlug: props.organizationId,
+          projectSlug: props.projectId,
+          targetSlug: props.targetId,
         },
         replace: true,
       });
@@ -274,9 +283,9 @@ function TargetAppsView(props: { organizationId: string; projectId: string; targ
                   setIsLoadingMore(true);
                   void client
                     .query(TargetAppsViewFetchMoreQuery, {
-                      organizationId: props.organizationId,
-                      projectId: props.projectId,
-                      targetId: props.targetId,
+                      organizationSlug: props.organizationId,
+                      projectSlug: props.projectId,
+                      targetSlug: props.targetId,
                       after: data?.data?.target?.appDeployments?.pageInfo?.endCursor,
                     })
                     .toPromise()

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -1002,18 +1002,20 @@ const ActiveSchemaCheck_SchemaCheckFragment = graphql(`
 
 const ActiveSchemaCheckQuery = graphql(`
   query ActiveSchemaCheck_ActiveSchemaCheckQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $schemaCheckId: ID!
   ) {
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       schemaCheck(id: $schemaCheckId) {
         ...ActiveSchemaCheck_SchemaCheckFragment
       }
     }
-    project(selector: { organization: $organizationId, project: $projectId }) {
+    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
       id
       type
     }
@@ -1030,9 +1032,9 @@ const ActiveSchemaCheck = (props: {
   const [query] = useQuery({
     query: ActiveSchemaCheckQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
       schemaCheckId: schemaCheckId ?? '',
     },
     pause: !schemaCheckId,

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -52,9 +52,9 @@ const ApproveFailedSchemaCheckMutation = graphql(`
 `);
 
 function ApproveFailedSchemaCheckModal(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   schemaCheckId: string;
   contextId: string | null | undefined;
   onClose(): void;
@@ -137,9 +137,9 @@ function ApproveFailedSchemaCheckModal(props: {
               onClick={() =>
                 approve({
                   input: {
-                    organization: props.organizationId,
-                    project: props.projectId,
-                    target: props.targetId,
+                    organizationSlug: props.organizationSlug,
+                    projectSlug: props.projectSlug,
+                    targetSlug: props.targetSlug,
                     schemaCheckId: props.schemaCheckId,
                     comment: approvalComment,
                   },
@@ -411,9 +411,9 @@ const DefaultSchemaView_SchemaCheckFragment = graphql(`
 function DefaultSchemaView(props: {
   schemaCheck: FragmentType<typeof DefaultSchemaView_SchemaCheckFragment>;
   projectType: ProjectType;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const schemaCheck = useFragment(DefaultSchemaView_SchemaCheckFragment, props.schemaCheck);
   const [selectedView, setSelectedView] = useState<string>('details');
@@ -495,9 +495,9 @@ function DefaultSchemaView(props: {
             {schemaCheck.breakingSchemaChanges?.nodes.length ? (
               <div className="mb-5">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title={<BreakingChangesTitle />}
                   criticality={CriticalityLevel.Breaking}
@@ -509,9 +509,9 @@ function DefaultSchemaView(props: {
             {schemaCheck.safeSchemaChanges ? (
               <div className="mb-5">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title="Safe Changes"
                   criticality={CriticalityLevel.Safe}
@@ -620,9 +620,9 @@ function ContractCheckView(props: {
   contractCheck: FragmentType<typeof ContractCheckView_ContractCheckFragment>;
   schemaCheck: FragmentType<typeof ContractCheckView_SchemaCheckFragment>;
   projectType: ProjectType;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const contractCheck = useFragment(ContractCheckView_ContractCheckFragment, props.contractCheck);
   const schemaCheck = useFragment(ContractCheckView_SchemaCheckFragment, props.schemaCheck);
@@ -690,9 +690,9 @@ function ContractCheckView(props: {
             {contractCheck.breakingSchemaChanges?.nodes.length && (
               <div className="mb-2">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title={<BreakingChangesTitle />}
                   criticality={CriticalityLevel.Breaking}
@@ -704,9 +704,9 @@ function ContractCheckView(props: {
             {contractCheck.safeSchemaChanges && (
               <div className="mb-2">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId={schemaCheck.id}
                   title="Safe Changes"
                   criticality={CriticalityLevel.Safe}
@@ -839,9 +839,9 @@ const SchemaChecksView_SchemaCheckFragment = graphql(`
 function SchemaChecksView(props: {
   schemaCheck: FragmentType<typeof SchemaChecksView_SchemaCheckFragment>;
   projectType: ProjectType;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const schemaCheck = useFragment(SchemaChecksView_SchemaCheckFragment, props.schemaCheck);
 
@@ -943,18 +943,18 @@ function SchemaChecksView(props: {
       </Tabs>
       {selectedContractCheckNode ? (
         <ContractCheckView
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           contractCheck={selectedContractCheckNode}
           schemaCheck={schemaCheck}
           projectType={props.projectType}
         />
       ) : (
         <DefaultSchemaView
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           schemaCheck={schemaCheck}
           projectType={props.projectType}
         />
@@ -1002,20 +1002,24 @@ const ActiveSchemaCheck_SchemaCheckFragment = graphql(`
 
 const ActiveSchemaCheckQuery = graphql(`
   query ActiveSchemaCheck_ActiveSchemaCheckQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $schemaCheckId: ID!
   ) {
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       schemaCheck(id: $schemaCheckId) {
         ...ActiveSchemaCheck_SchemaCheckFragment
       }
     }
-    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
+    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
       type
     }
@@ -1024,17 +1028,17 @@ const ActiveSchemaCheckQuery = graphql(`
 
 const ActiveSchemaCheck = (props: {
   schemaCheckId: string | null;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): React.ReactElement | null => {
   const { schemaCheckId } = props;
   const [query] = useQuery({
     query: ActiveSchemaCheckQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       schemaCheckId: schemaCheckId ?? '',
     },
     pause: !schemaCheckId,
@@ -1123,9 +1127,9 @@ const ActiveSchemaCheck = (props: {
                     <PopoverArrow />
                     <ApproveFailedSchemaCheckModal
                       onClose={() => setApprovalOpen(false)}
-                      organizationId={props.organizationId}
-                      projectId={props.projectId}
-                      targetId={props.targetId}
+                      organizationSlug={props.organizationSlug}
+                      projectSlug={props.projectSlug}
+                      targetSlug={props.targetSlug}
                       schemaCheckId={schemaCheck.id}
                       contextId={schemaCheck.contextId}
                     />
@@ -1175,9 +1179,9 @@ const ActiveSchemaCheck = (props: {
         ) : null}
       </div>
       <SchemaChecksView
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
         schemaCheck={schemaCheck}
         projectType={query.data.project.type}
       />
@@ -1186,18 +1190,18 @@ const ActiveSchemaCheck = (props: {
 };
 
 export function TargetChecksSinglePage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   schemaCheckId: string;
 }) {
   return (
     <>
       <Meta title={`Schema check ${props.schemaCheckId}`} />
       <ActiveSchemaCheck
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
         schemaCheckId={props.schemaCheckId}
       />
     </>

--- a/packages/web/app/src/pages/target-checks.tsx
+++ b/packages/web/app/src/pages/target-checks.tsx
@@ -18,14 +18,18 @@ import { Outlet, Link as RouterLink, useParams, useRouter } from '@tanstack/reac
 
 const SchemaChecks_NavigationQuery = graphql(`
   query SchemaChecks_NavigationQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $after: String
     $filters: SchemaChecksFilter
   ) {
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       schemaChecks(first: 20, after: $after, filters: $filters) {
@@ -68,17 +72,17 @@ const Navigation = (props: {
   isLastPage: boolean;
   onLoadMore: (cursor: string) => void;
   filters?: SchemaCheckFilters;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   schemaCheckId?: string;
 }) => {
   const [query] = useQuery({
     query: SchemaChecks_NavigationQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       after: props.after,
       filters: {
         changed: props.filters?.showOnlyChanged ?? false,
@@ -103,9 +107,9 @@ const Navigation = (props: {
                 key={edge.node.id}
                 to="/$organizationSlug/$projectSlug/$targetSlug/checks/$schemaCheckId"
                 params={{
-                  organizationSlug: props.organizationId,
-                  projectSlug: props.projectId,
-                  targetSlug: props.targetId,
+                  organizationSlug: props.organizationSlug,
+                  projectSlug: props.projectSlug,
+                  targetSlug: props.targetSlug,
                   schemaCheckId: edge.node.id,
                 }}
                 search={{
@@ -171,12 +175,12 @@ const Navigation = (props: {
 
 const ChecksPageQuery = graphql(`
   query ChecksPageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $filters: SchemaChecksFilter
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -185,7 +189,11 @@ const ChecksPageQuery = graphql(`
       }
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       schemaChecks(first: 1) {
@@ -206,7 +214,11 @@ const ChecksPageQuery = graphql(`
   }
 `);
 
-function ChecksPageContent(props: { organizationId: string; projectId: string; targetId: string }) {
+function ChecksPageContent(props: {
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+}) {
   const [paginationVariables, setPaginationVariables] = useState<Array<string | null>>(() => [
     null,
   ]);
@@ -230,9 +242,9 @@ function ChecksPageContent(props: { organizationId: string; projectId: string; t
   const [query] = useQuery({
     query: ChecksPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       filters: {
         changed: filters.showOnlyChanged ?? false,
         failed: filters.showOnlyFailed ?? false,
@@ -241,7 +253,7 @@ function ChecksPageContent(props: { organizationId: string; projectId: string; t
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const hasSchemaChecks = !!query.data?.target?.schemaChecks?.edges?.length;
@@ -282,9 +294,9 @@ function ChecksPageContent(props: { organizationId: string; projectId: string; t
   return (
     <>
       <TargetLayout
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
         page={Page.Checks}
         className={cn('flex', hasSchemaChecks || hasActiveSchemaCheck ? 'flex-row gap-x-6' : '')}
       >
@@ -327,9 +339,9 @@ function ChecksPageContent(props: { organizationId: string; projectId: string; t
                 <div className="flex w-[300px] grow flex-col gap-2.5 overflow-y-auto rounded-md border border-gray-800/50 p-2.5">
                   {paginationVariables.map((cursor, index) => (
                     <Navigation
-                      organizationId={props.organizationId}
-                      projectId={props.projectId}
-                      targetId={props.targetId}
+                      organizationSlug={props.organizationSlug}
+                      projectSlug={props.projectSlug}
+                      targetSlug={props.targetSlug}
                       schemaCheckId={schemaCheckId}
                       after={cursor}
                       isLastPage={index + 1 === paginationVariables.length}
@@ -376,9 +388,9 @@ function ChecksPageContent(props: { organizationId: string; projectId: string; t
 }
 
 export function TargetChecksPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>

--- a/packages/web/app/src/pages/target-checks.tsx
+++ b/packages/web/app/src/pages/target-checks.tsx
@@ -18,13 +18,15 @@ import { Outlet, Link as RouterLink, useParams, useRouter } from '@tanstack/reac
 
 const SchemaChecks_NavigationQuery = graphql(`
   query SchemaChecks_NavigationQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $after: String
     $filters: SchemaChecksFilter
   ) {
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       schemaChecks(first: 20, after: $after, filters: $filters) {
         edges {
@@ -74,9 +76,9 @@ const Navigation = (props: {
   const [query] = useQuery({
     query: SchemaChecks_NavigationQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
       after: props.after,
       filters: {
         changed: props.filters?.showOnlyChanged ?? false,
@@ -99,11 +101,11 @@ const Navigation = (props: {
             >
               <RouterLink
                 key={edge.node.id}
-                to="/$organizationId/$projectId/$targetId/checks/$schemaCheckId"
+                to="/$organizationSlug/$projectSlug/$targetSlug/checks/$schemaCheckId"
                 params={{
-                  organizationId: props.organizationId,
-                  projectId: props.projectId,
-                  targetId: props.targetId,
+                  organizationSlug: props.organizationId,
+                  projectSlug: props.projectId,
+                  targetSlug: props.targetId,
                   schemaCheckId: edge.node.id,
                 }}
                 search={{
@@ -169,12 +171,12 @@ const Navigation = (props: {
 
 const ChecksPageQuery = graphql(`
   query ChecksPageQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $filters: SchemaChecksFilter
   ) {
-    organization(selector: { organization: $organizationId }) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -182,7 +184,9 @@ const ChecksPageQuery = graphql(`
         }
       }
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       schemaChecks(first: 1) {
         edges {
@@ -226,9 +230,9 @@ function ChecksPageContent(props: { organizationId: string; projectId: string; t
   const [query] = useQuery({
     query: ChecksPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
       filters: {
         changed: filters.showOnlyChanged ?? false,
         failed: filters.showOnlyFailed ?? false,

--- a/packages/web/app/src/pages/target-explorer-deprecated.tsx
+++ b/packages/web/app/src/pages/target-explorer-deprecated.tsx
@@ -47,9 +47,9 @@ const DeprecatedSchemaView_DeprecatedSchemaExplorerFragment = graphql(`
 const DeprecatedSchemaView = memo(function _DeprecatedSchemaView(props: {
   explorer: FragmentType<typeof DeprecatedSchemaView_DeprecatedSchemaExplorerFragment>;
   totalRequests: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [selectedLetter, setSelectedLetter] = useState<string>();
   const { types } = useFragment(
@@ -136,9 +136,9 @@ const DeprecatedSchemaView = memo(function _DeprecatedSchemaView(props: {
               key={i}
               type={type}
               totalRequests={props.totalRequests}
-              organizationCleanId={props.organizationCleanId}
-              projectCleanId={props.projectCleanId}
-              targetCleanId={props.targetCleanId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
+              targetSlug={props.targetSlug}
               warnAboutDeprecatedArguments
               warnAboutUnusedArguments={false}
               styleDeprecated={false}
@@ -152,12 +152,14 @@ const DeprecatedSchemaView = memo(function _DeprecatedSchemaView(props: {
 
 const DeprecatedSchemaExplorer_DeprecatedSchemaQuery = graphql(`
   query DeprecatedSchemaExplorer_DeprecatedSchemaQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $period: DateRangeInput!
   ) {
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       slug
       latestSchemaVersion {
@@ -174,9 +176,9 @@ const DeprecatedSchemaExplorer_DeprecatedSchemaQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationId
-        project: $projectId
-        target: $targetId
+        organization: $organizationSlug
+        project: $projectSlug
+        target: $targetSlug
         period: $period
       }
     ) {
@@ -187,9 +189,9 @@ const DeprecatedSchemaExplorer_DeprecatedSchemaQuery = graphql(`
 
 function DeprecatedSchemaExplorer(props: {
   dataRetentionInDays: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const dateRangeController = useDateRangeController({
     dataRetentionInDays: props.dataRetentionInDays,
@@ -199,9 +201,9 @@ function DeprecatedSchemaExplorer(props: {
   const [query, refresh] = useQuery({
     query: DeprecatedSchemaExplorer_DeprecatedSchemaQuery,
     variables: {
-      organizationId: props.organizationCleanId,
-      projectId: props.projectCleanId,
-      targetId: props.targetCleanId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       period: dateRangeController.resolvedRange,
     },
   });
@@ -213,7 +215,7 @@ function DeprecatedSchemaExplorer(props: {
   }, [dateRangeController.resolvedRange]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationCleanId} error={query.error} />;
+    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
   }
 
   const latestSchemaVersion = query.data?.target?.latestSchemaVersion;
@@ -235,9 +237,9 @@ function DeprecatedSchemaExplorer(props: {
             onUpdate={args => dateRangeController.setSelectedPreset(args.preset)}
           />
           <SchemaVariantFilter
-            organizationId={props.organizationCleanId}
-            projectId={props.projectCleanId}
-            targetId={props.targetCleanId}
+            organizationId={props.organizationSlug}
+            projectId={props.projectSlug}
+            targetId={props.targetSlug}
             variant="deprecated"
           />
         </div>
@@ -259,11 +261,11 @@ function DeprecatedSchemaExplorer(props: {
                     <br />
                     <br />
                     <Link
-                      to="/$organizationId/$projectId/$targetId/history/$versionId"
+                      to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
                       params={{
-                        organizationId: props.organizationCleanId,
-                        projectId: props.projectCleanId,
-                        targetId: props.targetCleanId,
+                        organizationSlug: props.organizationSlug,
+                        projectSlug: props.projectSlug,
+                        targetSlug: props.targetSlug,
                         versionId: latestSchemaVersion.id,
                       }}
                     >
@@ -275,9 +277,9 @@ function DeprecatedSchemaExplorer(props: {
               <DeprecatedSchemaView
                 totalRequests={query.data?.operationsStats.totalRequests ?? 0}
                 explorer={latestValidSchemaVersion.deprecatedSchema}
-                organizationCleanId={props.organizationCleanId}
-                projectCleanId={props.projectCleanId}
-                targetCleanId={props.targetCleanId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
               />
             </>
           ) : (
@@ -291,11 +293,11 @@ function DeprecatedSchemaExplorer(props: {
 
 const TargetExplorerDeprecatedSchemaPageQuery = graphql(`
   query TargetExplorerDeprecatedSchemaPageQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
   ) {
-    organization(selector: { organization: $organizationId }) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -305,7 +307,7 @@ const TargetExplorerDeprecatedSchemaPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationId, project: $projectId, target: $targetId }
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
     )
   }
 `);
@@ -318,9 +320,9 @@ function ExplorerDeprecatedSchemaPageContent(props: {
   const [query] = useQuery({
     query: TargetExplorerDeprecatedSchemaPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -342,9 +344,9 @@ function ExplorerDeprecatedSchemaPageContent(props: {
         hasCollectedOperations ? (
           <DeprecatedSchemaExplorer
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationCleanId={props.organizationId}
-            projectCleanId={props.projectId}
-            targetCleanId={props.targetId}
+            organizationSlug={props.organizationId}
+            projectSlug={props.projectId}
+            targetSlug={props.targetId}
           />
         ) : (
           <div className="py-8">

--- a/packages/web/app/src/pages/target-explorer-deprecated.tsx
+++ b/packages/web/app/src/pages/target-explorer-deprecated.tsx
@@ -152,13 +152,17 @@ const DeprecatedSchemaView = memo(function _DeprecatedSchemaView(props: {
 
 const DeprecatedSchemaExplorer_DeprecatedSchemaQuery = graphql(`
   query DeprecatedSchemaExplorer_DeprecatedSchemaQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $period: DateRangeInput!
   ) {
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       slug
@@ -176,9 +180,9 @@ const DeprecatedSchemaExplorer_DeprecatedSchemaQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationSlug
-        project: $projectSlug
-        target: $targetSlug
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
         period: $period
       }
     ) {
@@ -215,7 +219,7 @@ function DeprecatedSchemaExplorer(props: {
   }, [dateRangeController.resolvedRange]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const latestSchemaVersion = query.data?.target?.latestSchemaVersion;
@@ -237,9 +241,9 @@ function DeprecatedSchemaExplorer(props: {
             onUpdate={args => dateRangeController.setSelectedPreset(args.preset)}
           />
           <SchemaVariantFilter
-            organizationId={props.organizationSlug}
-            projectId={props.projectSlug}
-            targetId={props.targetSlug}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             variant="deprecated"
           />
         </div>
@@ -293,11 +297,11 @@ function DeprecatedSchemaExplorer(props: {
 
 const TargetExplorerDeprecatedSchemaPageQuery = graphql(`
   query TargetExplorerDeprecatedSchemaPageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -307,27 +311,31 @@ const TargetExplorerDeprecatedSchemaPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     )
   }
 `);
 
 function ExplorerDeprecatedSchemaPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [query] = useQuery({
     query: TargetExplorerDeprecatedSchemaPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -335,18 +343,18 @@ function ExplorerDeprecatedSchemaPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Explorer}
     >
       {currentOrganization ? (
         hasCollectedOperations ? (
           <DeprecatedSchemaExplorer
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationSlug={props.organizationId}
-            projectSlug={props.projectId}
-            targetSlug={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
           />
         ) : (
           <div className="py-8">
@@ -363,9 +371,9 @@ function ExplorerDeprecatedSchemaPageContent(props: {
 }
 
 export function TargetExplorerDeprecatedPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   return (
     <>

--- a/packages/web/app/src/pages/target-explorer-type.tsx
+++ b/packages/web/app/src/pages/target-explorer-type.tsx
@@ -123,13 +123,13 @@ export function TypeRenderer(props: {
 
 const TargetExplorerTypenamePageQuery = graphql(`
   query TargetExplorerTypenamePageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $period: DateRangeInput!
     $typename: String!
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
@@ -139,7 +139,11 @@ const TargetExplorerTypenamePageQuery = graphql(`
       }
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       slug
@@ -156,9 +160,9 @@ const TargetExplorerTypenamePageQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationSlug
-        project: $projectSlug
-        target: $targetSlug
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
         period: $period
       }
     ) {
@@ -168,9 +172,9 @@ const TargetExplorerTypenamePageQuery = graphql(`
 `);
 
 function TypeExplorerPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   typename: string;
 }) {
   const { resolvedPeriod, dataRetentionInDays, setDataRetentionInDays } =
@@ -178,9 +182,9 @@ function TypeExplorerPageContent(props: {
   const [query] = useQuery({
     query: TargetExplorerTypenamePageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       period: resolvedPeriod,
       typename: props.typename,
     },
@@ -196,7 +200,7 @@ function TypeExplorerPageContent(props: {
   }, [setDataRetentionInDays, retentionInDays]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentTarget = query.data?.target;
@@ -205,9 +209,9 @@ function TypeExplorerPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Explorer}
     >
       <div className="flex flex-row items-center justify-between py-6">
@@ -219,9 +223,9 @@ function TypeExplorerPageContent(props: {
           {latestSchemaVersion && type ? (
             <>
               <TypeFilter
-                organizationId={props.organizationId}
-                projectId={props.projectId}
-                targetId={props.targetId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 period={resolvedPeriod}
                 typename={props.typename}
               />
@@ -229,9 +233,9 @@ function TypeExplorerPageContent(props: {
               <DateRangeFilter />
               <ArgumentVisibilityFilter />
               <SchemaVariantFilter
-                organizationId={props.organizationId}
-                projectId={props.projectId}
-                targetId={props.targetId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 variant="all"
               />
             </>
@@ -242,9 +246,9 @@ function TypeExplorerPageContent(props: {
         <TypeRenderer
           totalRequests={query.data?.operationsStats.totalRequests ?? 0}
           type={type}
-          organizationSlug={props.organizationId}
-          projectSlug={props.projectId}
-          targetSlug={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           warnAboutDeprecatedArguments={false}
           warnAboutUnusedArguments={false}
           styleDeprecated
@@ -259,9 +263,9 @@ function TypeExplorerPageContent(props: {
 }
 
 export function TargetExplorerTypePage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   typename: string;
 }) {
   return (

--- a/packages/web/app/src/pages/target-explorer-type.tsx
+++ b/packages/web/app/src/pages/target-explorer-type.tsx
@@ -39,9 +39,9 @@ export const TypeRenderFragment = graphql(`
 export function TypeRenderer(props: {
   type: FragmentType<typeof TypeRenderFragment>;
   totalRequests?: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   warnAboutUnusedArguments: boolean;
   warnAboutDeprecatedArguments: boolean;
   styleDeprecated: boolean;
@@ -53,9 +53,9 @@ export function TypeRenderer(props: {
         <GraphQLObjectTypeComponent
           type={ttype}
           totalRequests={props.totalRequests}
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           warnAboutUnusedArguments={props.warnAboutUnusedArguments}
           warnAboutDeprecatedArguments={props.warnAboutDeprecatedArguments}
           styleDeprecated={props.styleDeprecated}
@@ -66,9 +66,9 @@ export function TypeRenderer(props: {
         <GraphQLInterfaceTypeComponent
           type={ttype}
           totalRequests={props.totalRequests}
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           warnAboutUnusedArguments={props.warnAboutUnusedArguments}
           warnAboutDeprecatedArguments={props.warnAboutDeprecatedArguments}
           styleDeprecated={props.styleDeprecated}
@@ -79,9 +79,9 @@ export function TypeRenderer(props: {
         <GraphQLUnionTypeComponent
           type={ttype}
           totalRequests={props.totalRequests}
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
         />
       );
     case 'GraphQLEnumType':
@@ -89,9 +89,9 @@ export function TypeRenderer(props: {
         <GraphQLEnumTypeComponent
           type={ttype}
           totalRequests={props.totalRequests}
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           styleDeprecated={props.styleDeprecated}
         />
       );
@@ -100,9 +100,9 @@ export function TypeRenderer(props: {
         <GraphQLInputObjectTypeComponent
           type={ttype}
           totalRequests={props.totalRequests}
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           styleDeprecated={props.styleDeprecated}
         />
       );
@@ -111,9 +111,9 @@ export function TypeRenderer(props: {
         <GraphQLScalarTypeComponent
           type={ttype}
           totalRequests={props.totalRequests}
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
         />
       );
     default:
@@ -123,13 +123,13 @@ export function TypeRenderer(props: {
 
 const TargetExplorerTypenamePageQuery = graphql(`
   query TargetExplorerTypenamePageQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $period: DateRangeInput!
     $typename: String!
   ) {
-    organization(selector: { organization: $organizationId }) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
@@ -138,7 +138,9 @@ const TargetExplorerTypenamePageQuery = graphql(`
         }
       }
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       slug
       latestSchemaVersion {
@@ -154,9 +156,9 @@ const TargetExplorerTypenamePageQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationId
-        project: $projectId
-        target: $targetId
+        organization: $organizationSlug
+        project: $projectSlug
+        target: $targetSlug
         period: $period
       }
     ) {
@@ -176,9 +178,9 @@ function TypeExplorerPageContent(props: {
   const [query] = useQuery({
     query: TargetExplorerTypenamePageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
       period: resolvedPeriod,
       typename: props.typename,
     },
@@ -240,9 +242,9 @@ function TypeExplorerPageContent(props: {
         <TypeRenderer
           totalRequests={query.data?.operationsStats.totalRequests ?? 0}
           type={type}
-          organizationCleanId={props.organizationId}
-          projectCleanId={props.projectId}
-          targetCleanId={props.targetId}
+          organizationSlug={props.organizationId}
+          projectSlug={props.projectId}
+          targetSlug={props.targetId}
           warnAboutDeprecatedArguments={false}
           warnAboutUnusedArguments={false}
           styleDeprecated

--- a/packages/web/app/src/pages/target-explorer-unused.tsx
+++ b/packages/web/app/src/pages/target-explorer-unused.tsx
@@ -47,9 +47,9 @@ const UnusedSchemaView_UnusedSchemaExplorerFragment = graphql(`
 const UnusedSchemaView = memo(function _UnusedSchemaView(props: {
   explorer: FragmentType<typeof UnusedSchemaView_UnusedSchemaExplorerFragment>;
   totalRequests: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [selectedLetter, setSelectedLetter] = useState<string>();
   const { types } = useFragment(UnusedSchemaView_UnusedSchemaExplorerFragment, props.explorer);
@@ -132,9 +132,9 @@ const UnusedSchemaView = memo(function _UnusedSchemaView(props: {
             <TypeRenderer
               key={i}
               type={type}
-              organizationCleanId={props.organizationCleanId}
-              projectCleanId={props.projectCleanId}
-              targetCleanId={props.targetCleanId}
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
+              targetSlug={props.targetSlug}
               warnAboutDeprecatedArguments={false}
               warnAboutUnusedArguments
               styleDeprecated
@@ -148,12 +148,14 @@ const UnusedSchemaView = memo(function _UnusedSchemaView(props: {
 
 const UnusedSchemaExplorer_UnusedSchemaQuery = graphql(`
   query UnusedSchemaExplorer_UnusedSchemaQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $period: DateRangeInput!
   ) {
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       slug
       latestSchemaVersion {
@@ -170,9 +172,9 @@ const UnusedSchemaExplorer_UnusedSchemaQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationId
-        project: $projectId
-        target: $targetId
+        organization: $organizationSlug
+        project: $projectSlug
+        target: $targetSlug
         period: $period
       }
     ) {
@@ -183,9 +185,9 @@ const UnusedSchemaExplorer_UnusedSchemaQuery = graphql(`
 
 function UnusedSchemaExplorer(props: {
   dataRetentionInDays: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const dateRangeController = useDateRangeController({
     dataRetentionInDays: props.dataRetentionInDays,
@@ -195,9 +197,9 @@ function UnusedSchemaExplorer(props: {
   const [query, refresh] = useQuery({
     query: UnusedSchemaExplorer_UnusedSchemaQuery,
     variables: {
-      organizationId: props.organizationCleanId,
-      projectId: props.projectCleanId,
-      targetId: props.targetCleanId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       period: dateRangeController.resolvedRange,
     },
   });
@@ -209,7 +211,7 @@ function UnusedSchemaExplorer(props: {
   }, [dateRangeController.resolvedRange]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationCleanId} error={query.error} />;
+    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
   }
 
   const latestSchemaVersion = query.data?.target?.latestSchemaVersion;
@@ -233,9 +235,9 @@ function UnusedSchemaExplorer(props: {
             onUpdate={args => dateRangeController.setSelectedPreset(args.preset)}
           />
           <SchemaVariantFilter
-            organizationId={props.organizationCleanId}
-            projectId={props.projectCleanId}
-            targetId={props.targetCleanId}
+            organizationId={props.organizationSlug}
+            projectId={props.projectSlug}
+            targetId={props.targetSlug}
             variant="unused"
           />
         </div>
@@ -257,11 +259,11 @@ function UnusedSchemaExplorer(props: {
                     <br />
                     <br />
                     <Link
-                      to="/$organizationId/$projectId/$targetId/history/$versionId"
+                      to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
                       params={{
-                        organizationId: props.organizationCleanId,
-                        projectId: props.projectCleanId,
-                        targetId: props.targetCleanId,
+                        organizationSlug: props.organizationSlug,
+                        projectSlug: props.projectSlug,
+                        targetSlug: props.targetSlug,
                         versionId: latestSchemaVersion.id,
                       }}
                     >
@@ -273,9 +275,9 @@ function UnusedSchemaExplorer(props: {
               <UnusedSchemaView
                 totalRequests={query.data?.operationsStats.totalRequests ?? 0}
                 explorer={latestValidSchemaVersion.unusedSchema}
-                organizationCleanId={props.organizationCleanId}
-                projectCleanId={props.projectCleanId}
-                targetCleanId={props.targetCleanId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
               />
             </>
           ) : (
@@ -288,8 +290,12 @@ function UnusedSchemaExplorer(props: {
 }
 
 const TargetExplorerUnusedSchemaPageQuery = graphql(`
-  query TargetExplorerUnusedSchemaPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetExplorerUnusedSchemaPageQuery(
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
+  ) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -299,7 +305,7 @@ const TargetExplorerUnusedSchemaPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationId, project: $projectId, target: $targetId }
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
     )
   }
 `);
@@ -312,9 +318,9 @@ function ExplorerUnusedSchemaPageContent(props: {
   const [query] = useQuery({
     query: TargetExplorerUnusedSchemaPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -336,9 +342,9 @@ function ExplorerUnusedSchemaPageContent(props: {
         hasCollectedOperations ? (
           <UnusedSchemaExplorer
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationCleanId={props.organizationId}
-            projectCleanId={props.projectId}
-            targetCleanId={props.targetId}
+            organizationSlug={props.organizationId}
+            projectSlug={props.projectId}
+            targetSlug={props.targetId}
           />
         ) : (
           <div className="py-8">

--- a/packages/web/app/src/pages/target-explorer-unused.tsx
+++ b/packages/web/app/src/pages/target-explorer-unused.tsx
@@ -148,13 +148,17 @@ const UnusedSchemaView = memo(function _UnusedSchemaView(props: {
 
 const UnusedSchemaExplorer_UnusedSchemaQuery = graphql(`
   query UnusedSchemaExplorer_UnusedSchemaQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $period: DateRangeInput!
   ) {
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       slug
@@ -172,9 +176,9 @@ const UnusedSchemaExplorer_UnusedSchemaQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationSlug
-        project: $projectSlug
-        target: $targetSlug
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
         period: $period
       }
     ) {
@@ -211,7 +215,7 @@ function UnusedSchemaExplorer(props: {
   }, [dateRangeController.resolvedRange]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const latestSchemaVersion = query.data?.target?.latestSchemaVersion;
@@ -235,9 +239,9 @@ function UnusedSchemaExplorer(props: {
             onUpdate={args => dateRangeController.setSelectedPreset(args.preset)}
           />
           <SchemaVariantFilter
-            organizationId={props.organizationSlug}
-            projectId={props.projectSlug}
-            targetId={props.targetSlug}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             variant="unused"
           />
         </div>
@@ -291,11 +295,11 @@ function UnusedSchemaExplorer(props: {
 
 const TargetExplorerUnusedSchemaPageQuery = graphql(`
   query TargetExplorerUnusedSchemaPageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -305,27 +309,31 @@ const TargetExplorerUnusedSchemaPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     )
   }
 `);
 
 function ExplorerUnusedSchemaPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [query] = useQuery({
     query: TargetExplorerUnusedSchemaPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -333,18 +341,18 @@ function ExplorerUnusedSchemaPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Explorer}
     >
       {currentOrganization ? (
         hasCollectedOperations ? (
           <UnusedSchemaExplorer
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationSlug={props.organizationId}
-            projectSlug={props.projectId}
-            targetSlug={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
           />
         ) : (
           <div className="py-8">
@@ -361,9 +369,9 @@ function ExplorerUnusedSchemaPageContent(props: {
 }
 
 export function TargetExplorerUnusedPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>

--- a/packages/web/app/src/pages/target-explorer.tsx
+++ b/packages/web/app/src/pages/target-explorer.tsx
@@ -96,12 +96,12 @@ function SchemaView(props: {
 
 const TargetExplorerPageQuery = graphql(`
   query TargetExplorerPageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $period: DateRangeInput!
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -111,7 +111,11 @@ const TargetExplorerPageQuery = graphql(`
       }
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       slug
@@ -129,9 +133,9 @@ const TargetExplorerPageQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationSlug
-        project: $projectSlug
-        target: $targetSlug
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
         period: $period
       }
     ) {
@@ -141,18 +145,18 @@ const TargetExplorerPageQuery = graphql(`
 `);
 
 function ExplorerPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const { resolvedPeriod, dataRetentionInDays, setDataRetentionInDays } =
     useSchemaExplorerContext();
   const [query] = useQuery({
     query: TargetExplorerPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       period: resolvedPeriod,
     },
   });
@@ -170,7 +174,7 @@ function ExplorerPageContent(props: {
   const isFilterVisible = useRef(false);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentTarget = query.data?.target;
@@ -183,9 +187,9 @@ function ExplorerPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Explorer}
     >
       <div className="flex flex-row items-center justify-between py-6">
@@ -197,18 +201,18 @@ function ExplorerPageContent(props: {
           {isFilterVisible.current && (
             <>
               <TypeFilter
-                organizationId={props.organizationId}
-                projectId={props.projectId}
-                targetId={props.targetId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 period={resolvedPeriod}
               />
               <FieldByNameFilter />
               <DateRangeFilter />
               <ArgumentVisibilityFilter />
               <SchemaVariantFilter
-                organizationId={props.organizationId}
-                projectId={props.projectId}
-                targetId={props.targetId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
                 variant="all"
               />
             </>
@@ -234,9 +238,9 @@ function ExplorerPageContent(props: {
                     <Link
                       to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
                       params={{
-                        organizationSlug: props.organizationId,
-                        projectSlug: props.projectId,
-                        targetSlug: props.targetId,
+                        organizationSlug: props.organizationSlug,
+                        projectSlug: props.projectSlug,
+                        targetSlug: props.targetSlug,
                         versionId: latestSchemaVersion.id,
                       }}
                     >
@@ -248,9 +252,9 @@ function ExplorerPageContent(props: {
               <SchemaView
                 totalRequests={query.data?.operationsStats.totalRequests ?? 0}
                 explorer={latestValidSchemaVersion.explorer}
-                organizationSlug={props.organizationId}
-                projectSlug={props.projectId}
-                targetSlug={props.targetId}
+                organizationSlug={props.organizationSlug}
+                projectSlug={props.projectSlug}
+                targetSlug={props.targetSlug}
               />
             </>
           ) : latestSchemaVersion ? (
@@ -265,9 +269,9 @@ function ExplorerPageContent(props: {
 }
 
 export function TargetExplorerPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>

--- a/packages/web/app/src/pages/target-explorer.tsx
+++ b/packages/web/app/src/pages/target-explorer.tsx
@@ -39,9 +39,9 @@ const ExplorerPage_SchemaExplorerFragment = graphql(`
 function SchemaView(props: {
   explorer: FragmentType<typeof ExplorerPage_SchemaExplorerFragment>;
   totalRequests: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const { query, mutation, subscription } = useFragment(
     ExplorerPage_SchemaExplorerFragment,
@@ -56,9 +56,9 @@ function SchemaView(props: {
           type={query}
           totalRequests={totalRequests}
           collapsed
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           warnAboutDeprecatedArguments={false}
           warnAboutUnusedArguments={false}
           styleDeprecated
@@ -69,9 +69,9 @@ function SchemaView(props: {
           type={mutation}
           totalRequests={totalRequests}
           collapsed
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           warnAboutDeprecatedArguments={false}
           warnAboutUnusedArguments={false}
           styleDeprecated
@@ -82,9 +82,9 @@ function SchemaView(props: {
           type={subscription}
           totalRequests={totalRequests}
           collapsed
-          targetCleanId={props.targetCleanId}
-          projectCleanId={props.projectCleanId}
-          organizationCleanId={props.organizationCleanId}
+          targetSlug={props.targetSlug}
+          projectSlug={props.projectSlug}
+          organizationSlug={props.organizationSlug}
           warnAboutDeprecatedArguments={false}
           warnAboutUnusedArguments={false}
           styleDeprecated
@@ -96,12 +96,12 @@ function SchemaView(props: {
 
 const TargetExplorerPageQuery = graphql(`
   query TargetExplorerPageQuery(
-    $organizationId: ID!
-    $projectId: ID!
-    $targetId: ID!
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
     $period: DateRangeInput!
   ) {
-    organization(selector: { organization: $organizationId }) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         rateLimit {
@@ -110,7 +110,9 @@ const TargetExplorerPageQuery = graphql(`
         slug
       }
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       slug
       latestSchemaVersion {
@@ -127,9 +129,9 @@ const TargetExplorerPageQuery = graphql(`
     }
     operationsStats(
       selector: {
-        organization: $organizationId
-        project: $projectId
-        target: $targetId
+        organization: $organizationSlug
+        project: $projectSlug
+        target: $targetSlug
         period: $period
       }
     ) {
@@ -148,9 +150,9 @@ function ExplorerPageContent(props: {
   const [query] = useQuery({
     query: TargetExplorerPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
       period: resolvedPeriod,
     },
   });
@@ -230,11 +232,11 @@ function ExplorerPageContent(props: {
                     <br />
                     <br />
                     <Link
-                      to="/$organizationId/$projectId/$targetId/history/$versionId"
+                      to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
                       params={{
-                        organizationId: props.organizationId,
-                        projectId: props.projectId,
-                        targetId: props.targetId,
+                        organizationSlug: props.organizationId,
+                        projectSlug: props.projectId,
+                        targetSlug: props.targetId,
                         versionId: latestSchemaVersion.id,
                       }}
                     >
@@ -246,9 +248,9 @@ function ExplorerPageContent(props: {
               <SchemaView
                 totalRequests={query.data?.operationsStats.totalRequests ?? 0}
                 explorer={latestValidSchemaVersion.explorer}
-                organizationCleanId={props.organizationId}
-                projectCleanId={props.projectId}
-                targetCleanId={props.targetId}
+                organizationSlug={props.organizationId}
+                projectSlug={props.projectId}
+                targetSlug={props.targetId}
               />
             </>
           ) : latestSchemaVersion ? (

--- a/packages/web/app/src/pages/target-history-version.tsx
+++ b/packages/web/app/src/pages/target-history-version.tsx
@@ -60,9 +60,9 @@ const SchemaVersionView_SchemaVersionFragment = graphql(`
 function SchemaVersionView(props: {
   schemaVersion: FragmentType<typeof SchemaVersionView_SchemaVersionFragment>;
   projectType: ProjectType;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const schemaVersion = useFragment(SchemaVersionView_SchemaVersionFragment, props.schemaVersion);
 
@@ -159,15 +159,15 @@ function SchemaVersionView(props: {
         <ContractVersionView
           contractVersion={contractVersionNode}
           projectType={props.projectType}
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
         />
       ) : (
         <DefaultSchemaVersionView
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           schemaVersion={schemaVersion}
           projectType={props.projectType}
           hasContracts={!!schemaVersion.contractVersions?.edges}
@@ -222,9 +222,9 @@ const DefaultSchemaVersionView_SchemaVersionFragment = graphql(`
 function DefaultSchemaVersionView(props: {
   schemaVersion: FragmentType<typeof DefaultSchemaVersionView_SchemaVersionFragment>;
   projectType: ProjectType;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   hasContracts: boolean;
 }) {
   const schemaVersion = useFragment(
@@ -326,9 +326,9 @@ function DefaultSchemaVersionView(props: {
             {schemaVersion.breakingSchemaChanges?.nodes.length && (
               <div className="mb-2">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Breaking Changes"
                   criticality={CriticalityLevel.Breaking}
@@ -339,9 +339,9 @@ function DefaultSchemaVersionView(props: {
             {schemaVersion.safeSchemaChanges?.nodes?.length && (
               <div className="mb-2">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Safe Changes"
                   criticality={CriticalityLevel.Safe}
@@ -410,9 +410,9 @@ const ContractVersionView_ContractVersionFragment = graphql(`
 function ContractVersionView(props: {
   contractVersion: FragmentType<typeof ContractVersionView_ContractVersionFragment>;
   projectType: ProjectType;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const contractVersion = useFragment(
     ContractVersionView_ContractVersionFragment,
@@ -500,9 +500,9 @@ function ContractVersionView(props: {
             {contractVersion.breakingSchemaChanges?.nodes.length && (
               <div className="mb-2">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Breaking Changes"
                   criticality={CriticalityLevel.Breaking}
@@ -513,9 +513,9 @@ function ContractVersionView(props: {
             {contractVersion.safeSchemaChanges?.nodes?.length && (
               <div className="mb-2">
                 <ChangesBlock
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                   schemaCheckId=""
                   title="Safe Changes"
                   criticality={CriticalityLevel.Safe}
@@ -546,19 +546,25 @@ function ContractVersionView(props: {
 
 const ActiveSchemaVersion_SchemaVersionQuery = graphql(`
   query ActiveSchemaVersion_SchemaVersionQuery(
-    $organization: ID!
-    $project: ID!
-    $target: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $versionId: ID!
   ) {
-    target(selector: { organization: $organization, project: $project, target: $target }) {
+    target(
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
+    ) {
       id
       schemaVersion(id: $versionId) {
         id
         ...SchemaVersionView_SchemaVersionFragment
       }
     }
-    project(selector: { organization: $organization, project: $project }) {
+    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
       type
     }
@@ -567,16 +573,16 @@ const ActiveSchemaVersion_SchemaVersionQuery = graphql(`
 
 function ActiveSchemaVersion(props: {
   versionId: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [query] = useQuery({
     query: ActiveSchemaVersion_SchemaVersionQuery,
     variables: {
-      organization: props.organizationId,
-      project: props.projectId,
-      target: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       versionId: props.versionId,
     },
   });
@@ -615,9 +621,9 @@ function ActiveSchemaVersion(props: {
 
   return schemaVersion ? (
     <SchemaVersionView
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       schemaVersion={schemaVersion}
       projectType={projectType}
     />
@@ -625,9 +631,9 @@ function ActiveSchemaVersion(props: {
 }
 
 export function TargetHistoryVersionPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   versionId: string;
 }) {
   return <ActiveSchemaVersion {...props} />;

--- a/packages/web/app/src/pages/target-history.tsx
+++ b/packages/web/app/src/pages/target-history.tsx
@@ -95,11 +95,11 @@ function ListPage(props: {
         >
           <Link
             key={version.id}
-            to="/$organizationId/$projectId/$targetId/history/$versionId"
+            to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
             params={{
-              organizationId: props.organizationId,
-              projectId: props.projectId,
-              targetId: props.targetId,
+              organizationSlug: props.organizationId,
+              projectSlug: props.projectId,
+              targetSlug: props.targetId,
               versionId: version.id,
             }}
           >
@@ -158,8 +158,10 @@ function ListPage(props: {
 }
 
 const TargetHistoryPageQuery = graphql(`
-  query TargetHistoryPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+  query TargetHistoryPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       latestSchemaVersion {
         id
@@ -177,9 +179,9 @@ function HistoryPageContent(props: {
   const [query] = useQuery({
     query: TargetHistoryPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
   const [pageVariables, setPageVariables] = useState([{ first: 10, after: null as string | null }]);
@@ -193,11 +195,11 @@ function HistoryPageContent(props: {
   useEffect(() => {
     if (!versionId && currentTarget?.latestSchemaVersion?.id) {
       void router.navigate({
-        to: '/$organizationId/$projectId/$targetId/history/$versionId',
+        to: '/$organizationSlug/$projectSlug/$targetSlug/history/$versionId',
         params: {
-          organizationId: props.organizationId,
-          projectId: props.projectId,
-          targetId: props.targetId,
+          organizationSlug: props.organizationId,
+          projectSlug: props.projectId,
+          targetSlug: props.targetId,
           versionId: currentTarget.latestSchemaVersion.id,
         },
       });

--- a/packages/web/app/src/pages/target-history.tsx
+++ b/packages/web/app/src/pages/target-history.tsx
@@ -15,13 +15,19 @@ import { Link, Outlet, useParams, useRouter } from '@tanstack/react-router';
 
 const HistoryPage_VersionsPageQuery = graphql(`
   query HistoryPage_VersionsPageQuery(
-    $organization: ID!
-    $project: ID!
-    $target: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
     $first: Int!
     $after: String
   ) {
-    target(selector: { organization: $organization, project: $project, target: $target }) {
+    target(
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
+    ) {
       id
       schemaVersions(first: $first, after: $after) {
         edges {
@@ -64,17 +70,17 @@ function ListPage(props: {
   isLastPage: boolean;
   onLoadMore: (after: string) => void;
   versionId?: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const { variables, isLastPage, onLoadMore, versionId } = props;
   const [versionsQuery] = useQuery({
     query: HistoryPage_VersionsPageQuery,
     variables: {
-      organization: props.organizationId,
-      project: props.projectId,
-      target: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
       ...variables,
     },
     requestPolicy: 'cache-and-network',
@@ -97,9 +103,9 @@ function ListPage(props: {
             key={version.id}
             to="/$organizationSlug/$projectSlug/$targetSlug/history/$versionId"
             params={{
-              organizationSlug: props.organizationId,
-              projectSlug: props.projectId,
-              targetSlug: props.targetId,
+              organizationSlug: props.organizationSlug,
+              projectSlug: props.projectSlug,
+              targetSlug: props.targetSlug,
               versionId: version.id,
             }}
           >
@@ -158,9 +164,17 @@ function ListPage(props: {
 }
 
 const TargetHistoryPageQuery = graphql(`
-  query TargetHistoryPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+  query TargetHistoryPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       latestSchemaVersion {
@@ -171,17 +185,17 @@ const TargetHistoryPageQuery = graphql(`
 `);
 
 function HistoryPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const router = useRouter();
   const [query] = useQuery({
     query: TargetHistoryPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
   const [pageVariables, setPageVariables] = useState([{ first: 10, after: null as string | null }]);
@@ -197,9 +211,9 @@ function HistoryPageContent(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug/history/$versionId',
         params: {
-          organizationSlug: props.organizationId,
-          projectSlug: props.projectId,
-          targetSlug: props.targetId,
+          organizationSlug: props.organizationSlug,
+          projectSlug: props.projectSlug,
+          targetSlug: props.targetSlug,
           versionId: currentTarget.latestSchemaVersion.id,
         },
       });
@@ -207,14 +221,14 @@ function HistoryPageContent(props: {
   }, [versionId, currentTarget?.latestSchemaVersion?.id]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.History}
       className="flex flex-row gap-x-6"
     >
@@ -236,9 +250,9 @@ function HistoryPageContent(props: {
                       setPageVariables([...pageVariables, { after, first: 10 }]);
                     }}
                     versionId={versionId}
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                   />
                 ))}
               </div>
@@ -260,9 +274,9 @@ function HistoryPageContent(props: {
 }
 
 export function TargetHistoryPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>

--- a/packages/web/app/src/pages/target-insights-client.tsx
+++ b/packages/web/app/src/pages/target-insights-client.tsx
@@ -62,9 +62,9 @@ function ClientView(props: {
     query: ClientView_ClientStatsQuery,
     variables: {
       selector: {
-        organization: props.organizationSlug,
-        project: props.projectSlug,
-        target: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
         client: props.clientName,
         period: dateRangeController.resolvedRange,
       },
@@ -93,7 +93,7 @@ function ClientView(props: {
   const totalOperations = query.data?.clientStats?.operations.nodes.length ?? 0;
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
@@ -335,8 +335,12 @@ function ClientView(props: {
 }
 
 const ClientInsightsPageQuery = graphql(`
-  query ClientInsightsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query ClientInsightsPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
@@ -346,28 +350,32 @@ const ClientInsightsPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     )
   }
 `);
 
 function ClientInsightsPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   name: string;
 }) {
   const [query] = useQuery({
     query: ClientInsightsPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -375,9 +383,9 @@ function ClientInsightsPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Insights}
     >
       {currentOrganization ? (
@@ -385,9 +393,9 @@ function ClientInsightsPageContent(props: {
           <ClientView
             clientName={props.name}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationSlug={props.organizationId}
-            projectSlug={props.projectId}
-            targetSlug={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
           />
         ) : (
           <div className="py-8">
@@ -404,9 +412,9 @@ function ClientInsightsPageContent(props: {
 }
 
 export function TargetInsightsClientPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   name: string;
 }) {
   return (

--- a/packages/web/app/src/pages/target-insights-client.tsx
+++ b/packages/web/app/src/pages/target-insights-client.tsx
@@ -48,9 +48,9 @@ const ClientView_ClientStatsQuery = graphql(`
 function ClientView(props: {
   clientName: string;
   dataRetentionInDays: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const styles = useChartStyles();
   const dateRangeController = useDateRangeController({
@@ -62,9 +62,9 @@ function ClientView(props: {
     query: ClientView_ClientStatsQuery,
     variables: {
       selector: {
-        organization: props.organizationCleanId,
-        project: props.projectCleanId,
-        target: props.targetCleanId,
+        organization: props.organizationSlug,
+        project: props.projectSlug,
+        target: props.targetSlug,
         client: props.clientName,
         period: dateRangeController.resolvedRange,
       },
@@ -93,7 +93,7 @@ function ClientView(props: {
   const totalOperations = query.data?.clientStats?.operations.nodes.length ?? 0;
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationCleanId} error={query.error} />;
+    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
   }
 
   return (
@@ -273,11 +273,11 @@ function ClientView(props: {
                         <p className="truncate text-sm font-medium">
                           <Link
                             className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                            to="/$organizationId/$projectId/$targetId/insights/$operationName/$operationHash"
+                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                             params={{
-                              organizationId: props.organizationCleanId,
-                              projectId: props.projectCleanId,
-                              targetId: props.targetCleanId,
+                              organizationSlug: props.organizationSlug,
+                              projectSlug: props.projectSlug,
+                              targetSlug: props.targetSlug,
                               operationName: operation.name,
                               operationHash: operation.operationHash ?? '_',
                             }}
@@ -335,8 +335,8 @@ function ClientView(props: {
 }
 
 const ClientInsightsPageQuery = graphql(`
-  query ClientInsightsPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query ClientInsightsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
@@ -346,7 +346,7 @@ const ClientInsightsPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationId, project: $projectId, target: $targetId }
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
     )
   }
 `);
@@ -360,9 +360,9 @@ function ClientInsightsPageContent(props: {
   const [query] = useQuery({
     query: ClientInsightsPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -385,9 +385,9 @@ function ClientInsightsPageContent(props: {
           <ClientView
             clientName={props.name}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationCleanId={props.organizationId}
-            projectCleanId={props.projectId}
-            targetCleanId={props.targetId}
+            organizationSlug={props.organizationId}
+            projectSlug={props.projectId}
+            targetSlug={props.targetId}
           />
         ) : (
           <div className="py-8">

--- a/packages/web/app/src/pages/target-insights-coordinate.tsx
+++ b/packages/web/app/src/pages/target-insights-coordinate.tsx
@@ -65,9 +65,9 @@ const SchemaCoordinateView_SchemaCoordinateStatsQuery = graphql(`
 function SchemaCoordinateView(props: {
   coordinate: string;
   dataRetentionInDays: number;
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const styles = useChartStyles();
   const dateRangeController = useDateRangeController({
@@ -79,16 +79,16 @@ function SchemaCoordinateView(props: {
     query: SchemaCoordinateView_SchemaCoordinateStatsQuery,
     variables: {
       selector: {
-        organization: props.organizationCleanId,
-        project: props.projectCleanId,
-        target: props.targetCleanId,
+        organization: props.organizationSlug,
+        project: props.projectSlug,
+        target: props.targetSlug,
         schemaCoordinate: props.coordinate,
         period: dateRangeController.resolvedRange,
       },
       targetSelector: {
-        organization: props.organizationCleanId,
-        project: props.projectCleanId,
-        target: props.targetCleanId,
+        organization: props.organizationSlug,
+        project: props.projectSlug,
+        target: props.targetSlug,
       },
       resolution: dateRangeController.resolution,
     },
@@ -114,7 +114,7 @@ function SchemaCoordinateView(props: {
   const totalClients = query.data?.schemaCoordinateStats?.clients.nodes.length ?? 0;
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationCleanId} error={query.error} />;
+    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
   }
 
   return (
@@ -314,11 +314,11 @@ function SchemaCoordinateView(props: {
                         <p className="truncate text-sm font-medium">
                           <Link
                             className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                            to="/$organizationId/$projectId/$targetId/insights/$operationName/$operationHash"
+                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/$operationName/$operationHash"
                             params={{
-                              organizationId: props.organizationCleanId,
-                              projectId: props.projectCleanId,
-                              targetId: props.targetCleanId,
+                              organizationSlug: props.organizationSlug,
+                              projectSlug: props.projectSlug,
+                              targetSlug: props.targetSlug,
                               operationName: operation.name,
                               operationHash: operation.operationHash ?? '_',
                             }}
@@ -356,11 +356,11 @@ function SchemaCoordinateView(props: {
                         <p className="truncate text-sm font-medium">
                           <Link
                             className="text-orange-500 hover:text-orange-500 hover:underline hover:underline-offset-2"
-                            to="/$organizationId/$projectId/$targetId/insights/client/$name"
+                            to="/$organizationSlug/$projectSlug/$targetSlug/insights/client/$name"
                             params={{
-                              organizationId: props.organizationCleanId,
-                              projectId: props.projectCleanId,
-                              targetId: props.targetCleanId,
+                              organizationSlug: props.organizationSlug,
+                              projectSlug: props.projectSlug,
+                              targetSlug: props.targetSlug,
                               name: client.name,
                             }}
                           >
@@ -385,8 +385,12 @@ function SchemaCoordinateView(props: {
 }
 
 const TargetSchemaCoordinatePageQuery = graphql(`
-  query TargetSchemaCoordinatePageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetSchemaCoordinatePageQuery(
+    $organizationSlug: ID!
+    $projectSlug: ID!
+    $targetSlug: ID!
+  ) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
@@ -396,7 +400,7 @@ const TargetSchemaCoordinatePageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationId, project: $projectId, target: $targetId }
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
     )
   }
 `);
@@ -410,9 +414,9 @@ function TargetSchemaCoordinatePageContent(props: {
   const [query] = useQuery({
     query: TargetSchemaCoordinatePageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -435,9 +439,9 @@ function TargetSchemaCoordinatePageContent(props: {
           <SchemaCoordinateView
             coordinate={props.coordinate}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationCleanId={props.organizationId}
-            projectCleanId={props.projectId}
-            targetCleanId={props.targetId}
+            organizationSlug={props.organizationId}
+            projectSlug={props.projectId}
+            targetSlug={props.targetId}
           />
         ) : (
           <div className="py-8">

--- a/packages/web/app/src/pages/target-insights-coordinate.tsx
+++ b/packages/web/app/src/pages/target-insights-coordinate.tsx
@@ -79,16 +79,16 @@ function SchemaCoordinateView(props: {
     query: SchemaCoordinateView_SchemaCoordinateStatsQuery,
     variables: {
       selector: {
-        organization: props.organizationSlug,
-        project: props.projectSlug,
-        target: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
         schemaCoordinate: props.coordinate,
         period: dateRangeController.resolvedRange,
       },
       targetSelector: {
-        organization: props.organizationSlug,
-        project: props.projectSlug,
-        target: props.targetSlug,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       },
       resolution: dateRangeController.resolution,
     },
@@ -114,7 +114,7 @@ function SchemaCoordinateView(props: {
   const totalClients = query.data?.schemaCoordinateStats?.clients.nodes.length ?? 0;
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationSlug} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
@@ -386,11 +386,11 @@ function SchemaCoordinateView(props: {
 
 const TargetSchemaCoordinatePageQuery = graphql(`
   query TargetSchemaCoordinatePageQuery(
-    $organizationSlug: ID!
-    $projectSlug: ID!
-    $targetSlug: ID!
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
   ) {
-    organization(selector: { organization: $organizationSlug }) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
@@ -400,28 +400,32 @@ const TargetSchemaCoordinatePageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     )
   }
 `);
 
 function TargetSchemaCoordinatePageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   coordinate: string;
 }) {
   const [query] = useQuery({
     query: TargetSchemaCoordinatePageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -429,9 +433,9 @@ function TargetSchemaCoordinatePageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Insights}
     >
       {currentOrganization ? (
@@ -439,9 +443,9 @@ function TargetSchemaCoordinatePageContent(props: {
           <SchemaCoordinateView
             coordinate={props.coordinate}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
-            organizationSlug={props.organizationId}
-            projectSlug={props.projectId}
-            targetSlug={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
           />
         ) : (
           <div className="py-8">
@@ -458,9 +462,9 @@ function TargetSchemaCoordinatePageContent(props: {
 }
 
 export function TargetInsightsCoordinatePage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   coordinate: string;
 }) {
   return (

--- a/packages/web/app/src/pages/target-insights-operation.tsx
+++ b/packages/web/app/src/pages/target-insights-operation.tsx
@@ -77,9 +77,9 @@ function OperationView({
     query: Operation_View_OperationBodyQuery,
     variables: {
       selector: {
-        organization: organizationSlug,
-        project: projectSlug,
-        target: targetSlug,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
       },
       hash: operationHash,
     },
@@ -102,9 +102,9 @@ function OperationView({
               period={dateRangeController.resolvedRange}
               selected={selectedClients}
               onFilter={setSelectedClients}
-              organizationId={organizationSlug}
-              projectId={projectSlug}
-              targetId={targetSlug}
+              organizationSlug={organizationSlug}
+              projectSlug={projectSlug}
+              targetSlug={targetSlug}
             />
             <DateRangePicker
               validUnits={['y', 'M', 'w', 'd', 'h']}
@@ -121,9 +121,9 @@ function OperationView({
       </div>
       {!result.fetching && isNotNoQueryOrMutation === false ? (
         <OperationsStats
-          organization={organizationSlug}
-          project={projectSlug}
-          target={targetSlug}
+          organizationSlug={organizationSlug}
+          projectSlug={projectSlug}
+          targetSlug={targetSlug}
           period={dateRangeController.resolvedRange}
           dateRangeText={dateRangeController.selectedPreset.label}
           operationsFilter={operationsList}
@@ -154,8 +154,12 @@ function OperationView({
 }
 
 const OperationInsightsPageQuery = graphql(`
-  query OperationInsightsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query OperationInsightsPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
@@ -165,29 +169,33 @@ const OperationInsightsPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     )
   }
 `);
 
 function OperationInsightsContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   operationHash: string;
   operationName: string;
 }) {
   const [query] = useQuery({
     query: OperationInsightsPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -195,17 +203,17 @@ function OperationInsightsContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Insights}
     >
       {currentOrganization ? (
         hasCollectedOperations ? (
           <OperationView
-            organizationSlug={props.organizationId}
-            projectSlug={props.projectId}
-            targetSlug={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
             operationHash={props.operationHash}
             operationName={props.operationName}
@@ -225,9 +233,9 @@ function OperationInsightsContent(props: {
 }
 
 export function TargetInsightsOperationPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   operationHash: string;
   operationName: string;
 }) {

--- a/packages/web/app/src/pages/target-insights-operation.tsx
+++ b/packages/web/app/src/pages/target-insights-operation.tsx
@@ -52,16 +52,16 @@ const Operation_View_OperationBodyQuery = graphql(`
 `);
 
 function OperationView({
-  organizationCleanId,
-  projectCleanId,
-  targetCleanId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   dataRetentionInDays,
   operationHash,
   operationName,
 }: {
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   dataRetentionInDays: number;
   operationHash: string;
   operationName: string;
@@ -77,9 +77,9 @@ function OperationView({
     query: Operation_View_OperationBodyQuery,
     variables: {
       selector: {
-        organization: organizationCleanId,
-        project: projectCleanId,
-        target: targetCleanId,
+        organization: organizationSlug,
+        project: projectSlug,
+        target: targetSlug,
       },
       hash: operationHash,
     },
@@ -102,9 +102,9 @@ function OperationView({
               period={dateRangeController.resolvedRange}
               selected={selectedClients}
               onFilter={setSelectedClients}
-              organizationId={organizationCleanId}
-              projectId={projectCleanId}
-              targetId={targetCleanId}
+              organizationId={organizationSlug}
+              projectId={projectSlug}
+              targetId={targetSlug}
             />
             <DateRangePicker
               validUnits={['y', 'M', 'w', 'd', 'h']}
@@ -121,9 +121,9 @@ function OperationView({
       </div>
       {!result.fetching && isNotNoQueryOrMutation === false ? (
         <OperationsStats
-          organization={organizationCleanId}
-          project={projectCleanId}
-          target={targetCleanId}
+          organization={organizationSlug}
+          project={projectSlug}
+          target={targetSlug}
           period={dateRangeController.resolvedRange}
           dateRangeText={dateRangeController.selectedPreset.label}
           operationsFilter={operationsList}
@@ -154,8 +154,8 @@ function OperationView({
 }
 
 const OperationInsightsPageQuery = graphql(`
-  query OperationInsightsPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query OperationInsightsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
@@ -165,7 +165,7 @@ const OperationInsightsPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationId, project: $projectId, target: $targetId }
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
     )
   }
 `);
@@ -180,9 +180,9 @@ function OperationInsightsContent(props: {
   const [query] = useQuery({
     query: OperationInsightsPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -203,9 +203,9 @@ function OperationInsightsContent(props: {
       {currentOrganization ? (
         hasCollectedOperations ? (
           <OperationView
-            organizationCleanId={props.organizationId}
-            projectCleanId={props.projectId}
-            targetCleanId={props.targetId}
+            organizationSlug={props.organizationId}
+            projectSlug={props.projectId}
+            targetSlug={props.targetId}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
             operationHash={props.operationHash}
             operationName={props.operationName}

--- a/packages/web/app/src/pages/target-insights.tsx
+++ b/packages/web/app/src/pages/target-insights.tsx
@@ -19,14 +19,14 @@ import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
 import { useSearchParamsFilter } from '@/lib/hooks/use-search-params-filters';
 
 function OperationsView({
-  organizationCleanId,
-  projectCleanId,
-  targetCleanId,
+  organizationSlug,
+  projectSlug,
+  targetSlug,
   dataRetentionInDays,
 }: {
-  organizationCleanId: string;
-  projectCleanId: string;
-  targetCleanId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   dataRetentionInDays: number;
 }): ReactElement {
   const [selectedOperations, setSelectedOperations] = useSearchParamsFilter<string[]>(
@@ -48,17 +48,17 @@ function OperationsView({
         </div>
         <div className="flex justify-end gap-x-4">
           <OperationsFilterTrigger
-            organizationId={organizationCleanId}
-            projectId={projectCleanId}
-            targetId={targetCleanId}
+            organizationId={organizationSlug}
+            projectId={projectSlug}
+            targetId={targetSlug}
             period={dateRangeController.resolvedRange}
             selected={selectedOperations}
             onFilter={setSelectedOperations}
           />
           <ClientsFilterTrigger
-            organizationId={organizationCleanId}
-            projectId={projectCleanId}
-            targetId={targetCleanId}
+            organizationId={organizationSlug}
+            projectId={projectSlug}
+            targetId={targetSlug}
             period={dateRangeController.resolvedRange}
             selected={selectedClients}
             onFilter={setSelectedClients}
@@ -76,9 +76,9 @@ function OperationsView({
         </div>
       </div>
       <OperationsStats
-        organization={organizationCleanId}
-        project={projectCleanId}
-        target={targetCleanId}
+        organization={organizationSlug}
+        project={projectSlug}
+        target={targetSlug}
         period={dateRangeController.resolvedRange}
         operationsFilter={selectedOperations}
         clientNamesFilter={selectedClients}
@@ -89,9 +89,9 @@ function OperationsView({
       <OperationsList
         className="mt-12"
         period={dateRangeController.resolvedRange}
-        organization={organizationCleanId}
-        project={projectCleanId}
-        target={targetCleanId}
+        organization={organizationSlug}
+        project={projectSlug}
+        target={targetSlug}
         operationsFilter={selectedOperations}
         clientNamesFilter={selectedClients}
         selectedPeriod={dateRangeController.selectedPreset.range}
@@ -101,8 +101,8 @@ function OperationsView({
 }
 
 const TargetOperationsPageQuery = graphql(`
-  query TargetOperationsPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetOperationsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
@@ -112,7 +112,7 @@ const TargetOperationsPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationId, project: $projectId, target: $targetId }
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
     )
   }
 `);
@@ -125,9 +125,9 @@ function TargetOperationsPageContent(props: {
   const [query] = useQuery({
     query: TargetOperationsPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -148,9 +148,9 @@ function TargetOperationsPageContent(props: {
       {currentOrganization ? (
         hasCollectedOperations ? (
           <OperationsView
-            organizationCleanId={props.organizationId}
-            projectCleanId={props.projectId}
-            targetCleanId={props.targetId}
+            organizationSlug={props.organizationId}
+            projectSlug={props.projectId}
+            targetSlug={props.targetId}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
           />
         ) : (

--- a/packages/web/app/src/pages/target-insights.tsx
+++ b/packages/web/app/src/pages/target-insights.tsx
@@ -48,17 +48,17 @@ function OperationsView({
         </div>
         <div className="flex justify-end gap-x-4">
           <OperationsFilterTrigger
-            organizationId={organizationSlug}
-            projectId={projectSlug}
-            targetId={targetSlug}
+            organizationSlug={organizationSlug}
+            projectSlug={projectSlug}
+            targetSlug={targetSlug}
             period={dateRangeController.resolvedRange}
             selected={selectedOperations}
             onFilter={setSelectedOperations}
           />
           <ClientsFilterTrigger
-            organizationId={organizationSlug}
-            projectId={projectSlug}
-            targetId={targetSlug}
+            organizationSlug={organizationSlug}
+            projectSlug={projectSlug}
+            targetSlug={targetSlug}
             period={dateRangeController.resolvedRange}
             selected={selectedClients}
             onFilter={setSelectedClients}
@@ -76,9 +76,9 @@ function OperationsView({
         </div>
       </div>
       <OperationsStats
-        organization={organizationSlug}
-        project={projectSlug}
-        target={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         period={dateRangeController.resolvedRange}
         operationsFilter={selectedOperations}
         clientNamesFilter={selectedClients}
@@ -89,9 +89,9 @@ function OperationsView({
       <OperationsList
         className="mt-12"
         period={dateRangeController.resolvedRange}
-        organization={organizationSlug}
-        project={projectSlug}
-        target={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         operationsFilter={selectedOperations}
         clientNamesFilter={selectedClients}
         selectedPeriod={dateRangeController.selectedPreset.range}
@@ -101,8 +101,12 @@ function OperationsView({
 }
 
 const TargetOperationsPageQuery = graphql(`
-  query TargetOperationsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query TargetOperationsPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
@@ -112,27 +116,31 @@ const TargetOperationsPageQuery = graphql(`
       }
     }
     hasCollectedOperations(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     )
   }
 `);
 
 function TargetOperationsPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [query] = useQuery({
     query: TargetOperationsPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -140,17 +148,17 @@ function TargetOperationsPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Insights}
     >
       {currentOrganization ? (
         hasCollectedOperations ? (
           <OperationsView
-            organizationSlug={props.organizationId}
-            projectSlug={props.projectId}
-            targetSlug={props.targetId}
+            organizationSlug={props.organizationSlug}
+            projectSlug={props.projectSlug}
+            targetSlug={props.targetSlug}
             dataRetentionInDays={currentOrganization.rateLimit.retentionInDays}
           />
         ) : (
@@ -168,9 +176,9 @@ function TargetOperationsPageContent(props: {
 }
 
 export function TargetInsightsPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -98,29 +98,29 @@ const UpdateOperationMutation = graphql(`
 `);
 
 function Save(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }): ReactElement {
   const router = useRouter();
   const [operationModalOpen, toggleOperationModal] = useToggle();
   const { collections } = useCollections({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const notify = useNotifications();
   const currentOperation = useCurrentOperation({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const [, mutateUpdate] = useMutation(UpdateOperationMutation);
   const { queryEditor, variableEditor, headerEditor, updateActiveTabValues } = useEditorContext()!;
   const { clearOperation } = useSyncOperationState({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const operationFromQueryString = useOperationFromQueryString();
 
@@ -133,9 +133,9 @@ function Save(props: {
         void router.navigate({
           to: '/$organizationSlug/$projectSlug/$targetSlug/laboratory',
           params: {
-            organizationSlug: props.organizationId,
-            projectSlug: props.projectId,
-            targetSlug: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
           },
           search: { operation: id },
         });
@@ -194,9 +194,9 @@ function Save(props: {
             }
             const { error, data } = await mutateUpdate({
               selector: {
-                target: props.targetId,
-                organization: props.organizationId,
-                project: props.projectId,
+                targetSlug: props.targetSlug,
+                organizationSlug: props.organizationSlug,
+                projectSlug: props.projectSlug,
               },
               input: {
                 name: currentOperation.name,
@@ -231,9 +231,9 @@ function Save(props: {
         </DropdownMenuItem>
       </DropdownMenuContent>
       <CreateOperationModal
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
         isOpen={operationModalOpen}
         close={toggleOperationModal}
         onSaveSuccess={onSaveSuccess}
@@ -243,25 +243,25 @@ function Save(props: {
 }
 
 function LaboratoryPageContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const [query] = useQuery({
     query: TargetLaboratoryPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
   const router = useRouter();
   const [isConnectLabModalOpen, toggleConnectLabModal] = useToggle();
   const [isFullScreen, setIsFullScreen] = useState(false);
   const { collections } = useCollections({
-    organizationId: props.organizationId,
-    projectId: props.projectId,
-    targetId: props.targetId,
+    organizationSlug: props.organizationSlug,
+    projectSlug: props.projectSlug,
+    targetSlug: props.targetSlug,
   });
   const userOperations = useMemo(() => {
     const operations = collections.flatMap(collection =>
@@ -277,7 +277,7 @@ function LaboratoryPageContent(props: {
     query.data?.target?.graphqlEndpointUrl ?? null,
   );
 
-  const mockEndpoint = `${location.origin}/api/lab/${props.organizationId}/${props.projectId}/${props.targetId}`;
+  const mockEndpoint = `${location.origin}/api/lab/${props.organizationSlug}/${props.projectSlug}/${props.targetSlug}`;
 
   const fetcher = useMemo<Fetcher>(() => {
     return async (params, opts) => {
@@ -315,7 +315,7 @@ function LaboratoryPageContent(props: {
   }, [query.data?.target?.graphqlEndpointUrl, actualSelectedApiEndpoint]);
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const FullScreenIcon = isFullScreen ? ExitFullScreenIcon : EnterFullScreenIcon;
@@ -327,9 +327,9 @@ function LaboratoryPageContent(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug/$targetSlug/laboratory',
         params: {
-          organizationSlug: props.organizationId,
-          projectSlug: props.projectId,
-          targetSlug: props.targetId,
+          organizationSlug: props.organizationSlug,
+          projectSlug: props.projectSlug,
+          targetSlug: props.targetSlug,
         },
         search: userOperations.has(activeTab.id) ? { operation: activeTab.id } : {},
       });
@@ -339,9 +339,9 @@ function LaboratoryPageContent(props: {
 
   return (
     <TargetLayout
-      organizationId={props.organizationId}
-      projectId={props.projectId}
-      targetId={props.targetId}
+      organizationSlug={props.organizationSlug}
+      projectSlug={props.projectSlug}
+      targetSlug={props.targetSlug}
       page={Page.Laboratory}
       className="flex h-[--content-height] flex-col pb-0"
     >
@@ -361,9 +361,9 @@ function LaboratoryPageContent(props: {
               <RouterLink
                 to="/$organizationSlug/$projectSlug/$targetSlug/settings"
                 params={{
-                  organizationSlug: props.organizationId,
-                  projectSlug: props.projectId,
-                  targetSlug: props.targetId,
+                  organizationSlug: props.organizationSlug,
+                  projectSlug: props.projectSlug,
+                  targetSlug: props.targetSlug,
                 }}
                 search={{ page: 'general' }}
               >
@@ -468,9 +468,9 @@ function LaboratoryPageContent(props: {
             {({ prettify }) => (
               <>
                 <Save
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
+                  organizationSlug={props.organizationSlug}
+                  projectSlug={props.projectSlug}
+                  targetSlug={props.targetSlug}
                 />
                 <Share />
                 {prettify}
@@ -490,9 +490,9 @@ function LaboratoryPageContent(props: {
 }
 
 export function TargetLaboratoryPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   return (
     <>

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -131,11 +131,11 @@ function Save(props: {
           updateActiveTabValues({ id, title: name });
         }
         void router.navigate({
-          to: '/$organizationId/$projectId/$targetId/laboratory',
+          to: '/$organizationSlug/$projectSlug/$targetSlug/laboratory',
           params: {
-            organizationId: props.organizationId,
-            projectId: props.projectId,
-            targetId: props.targetId,
+            organizationSlug: props.organizationId,
+            projectSlug: props.projectId,
+            targetSlug: props.targetId,
           },
           search: { operation: id },
         });
@@ -250,9 +250,9 @@ function LaboratoryPageContent(props: {
   const [query] = useQuery({
     query: TargetLaboratoryPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
   const router = useRouter();
@@ -325,11 +325,11 @@ function LaboratoryPageContent(props: {
       const activeTab = tabs.find((_, index) => index === activeTabIndex)!;
       // Set search params while clicking on tab
       void router.navigate({
-        to: '/$organizationId/$projectId/$targetId/laboratory',
+        to: '/$organizationSlug/$projectSlug/$targetSlug/laboratory',
         params: {
-          organizationId: props.organizationId,
-          projectId: props.projectId,
-          targetId: props.targetId,
+          organizationSlug: props.organizationId,
+          projectSlug: props.projectId,
+          targetSlug: props.targetId,
         },
         search: userOperations.has(activeTab.id) ? { operation: activeTab.id } : {},
       });
@@ -359,11 +359,11 @@ function LaboratoryPageContent(props: {
           <div>
             {query.data && !query.data.target?.graphqlEndpointUrl ? (
               <RouterLink
-                to="/$organizationId/$projectId/$targetId/settings"
+                to="/$organizationSlug/$projectSlug/$targetSlug/settings"
                 params={{
-                  organizationId: props.organizationId,
-                  projectId: props.projectId,
-                  targetId: props.targetId,
+                  organizationSlug: props.organizationId,
+                  projectSlug: props.projectId,
+                  targetSlug: props.targetId,
                 }}
                 search={{ page: 'general' }}
               >

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -86,9 +86,9 @@ export const DeleteTokensDocument = graphql(`
   mutation deleteTokens($input: DeleteTokensInput!) {
     deleteTokens(input: $input) {
       selector {
-        organization
-        project
-        target
+        organizationSlug
+        projectSlug
+        targetSlug
       }
       deletedTokens
     }
@@ -112,9 +112,9 @@ export const TokensDocument = graphql(`
 
 function RegistryAccessTokens(props: {
   me: FragmentType<typeof RegistryAccessTokens_MeFragment>;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const me = useFragment(RegistryAccessTokens_MeFragment, props.me);
   const [{ fetching: deleting }, mutate] = useMutation(DeleteTokensDocument);
@@ -125,9 +125,9 @@ function RegistryAccessTokens(props: {
     query: TokensDocument,
     variables: {
       selector: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       },
     },
   });
@@ -137,14 +137,14 @@ function RegistryAccessTokens(props: {
   const deleteTokens = useCallback(async () => {
     await mutate({
       input: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
-        tokens: checked,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
+        tokenIds: checked,
       },
     });
     setChecked([]);
-  }, [checked, mutate, props.organizationId, props.projectId, props.targetId]);
+  }, [checked, mutate, props.organizationSlug, props.projectSlug, props.targetSlug]);
 
   const canManage = canAccessTarget(TargetAccessScope.TokensWrite, me);
 
@@ -214,9 +214,9 @@ function RegistryAccessTokens(props: {
       </Table>
       {isModalOpen && (
         <CreateAccessTokenModal
-          organizationId={props.organizationId}
-          projectId={props.projectId}
-          targetId={props.targetId}
+          organizationSlug={props.organizationSlug}
+          projectSlug={props.projectSlug}
+          targetSlug={props.targetSlug}
           isOpen={isModalOpen}
           toggleModalOpen={toggleModalOpen}
         />
@@ -243,9 +243,9 @@ const Settings_UpdateBaseSchemaMutation = graphql(`
 
 const ExtendBaseSchema = (props: {
   baseSchema: string;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) => {
   const [mutation, mutate] = useMutation(Settings_UpdateBaseSchemaMutation);
   const [baseSchema, setBaseSchema] = useState(props.baseSchema);
@@ -296,9 +296,9 @@ const ExtendBaseSchema = (props: {
           onClick={async () => {
             await mutate({
               input: {
-                organization: props.organizationId,
-                project: props.projectId,
-                target: props.targetId,
+                organizationSlug: props.organizationSlug,
+                projectSlug: props.projectSlug,
+                targetSlug: props.targetSlug,
                 newBase: baseSchema,
               },
             }).then(result => {
@@ -348,9 +348,9 @@ const ClientExclusion_AvailableClientNamesQuery = graphql(`
 function ClientExclusion(
   props: PropsWithoutRef<
     {
-      organizationId: string;
-      projectId: string;
-      selectedTargets: string[];
+      organizationSlug: string;
+      projectSlug: string;
+      selectedTargetIds: string[];
       clientsFromSettings: string[];
       value: string[];
     } & Pick<ComponentProps<typeof Combobox>, 'name' | 'disabled' | 'onBlur' | 'onChange'>
@@ -361,9 +361,9 @@ function ClientExclusion(
     query: ClientExclusion_AvailableClientNamesQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
-        project: props.projectId,
-        targetIds: props.selectedTargets,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetIds: props.selectedTargetIds,
         period: {
           from: formatISO(subDays(now, 90)),
           to: formatISO(now),
@@ -462,9 +462,9 @@ function floorDate(date: Date): Date {
 }
 
 const ConditionalBreakingChanges = (props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) => {
   const [targetValidation, setValidation] = useMutation(SetTargetValidationMutation);
   const [mutation, updateValidation] = useMutation(
@@ -474,16 +474,16 @@ const ConditionalBreakingChanges = (props: {
     query: TargetSettingsPage_TargetSettingsQuery,
     variables: {
       selector: {
-        organization: props.organizationId,
-        project: props.projectId,
-        target: props.targetId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
+        targetSlug: props.targetSlug,
       },
       targetsSelector: {
-        organization: props.organizationId,
-        project: props.projectId,
+        organizationSlug: props.organizationSlug,
+        projectSlug: props.projectSlug,
       },
       organizationSelector: {
-        organization: props.organizationId,
+        organizationSlug: props.organizationSlug,
       },
     },
   });
@@ -508,7 +508,7 @@ const ConditionalBreakingChanges = (props: {
     initialValues: {
       percentage: settings?.percentage || 0,
       period: settings?.period || 0,
-      targets: settings?.targets.map(t => t.id) || [],
+      targetIds: settings?.targets.map(t => t.id) || [],
       excludedClients: settings?.excludedClients ?? [],
     },
     validationSchema: Yup.object().shape({
@@ -526,15 +526,15 @@ const ConditionalBreakingChanges = (props: {
           return Number(num.toFixed(2)) === num;
         })
         .required(),
-      targets: Yup.array().of(Yup.string()).min(1),
+      targetIds: Yup.array().of(Yup.string()).min(1),
       excludedClients: Yup.array().of(Yup.string()),
     }),
     onSubmit: values =>
       updateValidation({
         input: {
-          organization: props.organizationId,
-          project: props.projectId,
-          target: props.targetId,
+          organizationSlug: props.organizationSlug,
+          projectSlug: props.projectSlug,
+          targetSlug: props.targetSlug,
           ...values,
         },
       }).then(result => {
@@ -586,9 +586,9 @@ const ConditionalBreakingChanges = (props: {
               onCheckedChange={async enabled => {
                 await setValidation({
                   input: {
-                    target: props.targetId, // targetId is the target we are updating
-                    project: props.projectId,
-                    organization: props.organizationId,
+                    targetSlug: props.targetSlug,
+                    projectSlug: props.projectSlug,
+                    organizationSlug: props.organizationSlug,
                     enabled,
                   },
                 });
@@ -652,11 +652,11 @@ const ConditionalBreakingChanges = (props: {
                   </div>
                 </div>
                 <div className="max-w-[420px]">
-                  {values.targets.length > 0 ? (
+                  {values.targetIds.length > 0 ? (
                     <ClientExclusion
-                      organizationId={props.organizationId}
-                      projectId={props.projectId}
-                      selectedTargets={values.targets}
+                      organizationSlug={props.organizationSlug}
+                      projectSlug={props.projectSlug}
+                      selectedTargetIds={values.targetIds}
                       clientsFromSettings={settings?.excludedClients ?? []}
                       name="excludedClients"
                       value={values.excludedClients}
@@ -689,13 +689,13 @@ const ConditionalBreakingChanges = (props: {
                 {possibleTargets?.map(pt => (
                   <div key={pt.id} className="flex items-center gap-x-2">
                     <Checkbox
-                      checked={values.targets.includes(pt.id)}
+                      checked={values.targetIds.includes(pt.id)}
                       onCheckedChange={async isChecked => {
                         await setFieldValue(
                           'targets',
                           isChecked
-                            ? [...values.targets, pt.id]
-                            : values.targets.filter(value => value !== pt.id),
+                            ? [...values.targetIds, pt.id]
+                            : values.targetIds.filter(value => value !== pt.id),
                         );
                       }}
                       onBlur={() => setFieldTouched('targets', true)}
@@ -706,8 +706,8 @@ const ConditionalBreakingChanges = (props: {
               </div>
             </div>
           </div>
-          {touched.targets && errors.targets && (
-            <div className="text-red-500">{errors.targets}</div>
+          {touched.targetIds && errors.targetIds && (
+            <div className="text-red-500">{errors.targetIds}</div>
           )}
           <div className="mb-3 mt-5 space-y-2 rounded border-l-2 border-l-gray-800 bg-gray-600/10 py-2 pl-5 text-gray-400">
             <div>
@@ -753,7 +753,7 @@ const SlugFormSchema = z.object({
 });
 type SlugFormValues = z.infer<typeof SlugFormSchema>;
 
-function TargetSlug(props: { organizationId: string; projectId: string; targetId: string }) {
+function TargetSlug(props: { organizationSlug: string; projectSlug: string; targetSlug: string }) {
   const router = useRouter();
   const { toast } = useToast();
 
@@ -762,7 +762,7 @@ function TargetSlug(props: { organizationId: string; projectId: string; targetId
     mode: 'all',
     resolver: zodResolver(SlugFormSchema),
     defaultValues: {
-      slug: props.targetId,
+      slug: props.targetSlug,
     },
   });
 
@@ -771,9 +771,9 @@ function TargetSlug(props: { organizationId: string; projectId: string; targetId
       try {
         const result = await slugMutate({
           input: {
-            organization: props.organizationId,
-            project: props.projectId,
-            target: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
             slug: data.slug,
           },
         });
@@ -789,8 +789,8 @@ function TargetSlug(props: { organizationId: string; projectId: string; targetId
           void router.navigate({
             to: '/$organizationSlug/$projectSlug/$targetSlug/settings',
             params: {
-              organizationSlug: props.organizationId,
-              projectSlug: props.projectId,
+              organizationSlug: props.organizationSlug,
+              projectSlug: props.projectSlug,
               targetSlug: result.data.updateTargetSlug.ok.target.slug,
             },
             search: {
@@ -842,8 +842,8 @@ function TargetSlug(props: { organizationId: string; projectId: string; targetId
                   <FormControl>
                     <div className="flex items-center">
                       <div className="border-input text-muted-foreground h-10 rounded-md rounded-r-none border-y border-l bg-gray-900 px-3 py-2 text-sm">
-                        {env.appBaseUrl.replace(/https?:\/\//i, '')}/{props.organizationId}/
-                        {props.projectId}/
+                        {env.appBaseUrl.replace(/https?:\/\//i, '')}/{props.organizationSlug}/
+                        {props.projectSlug}/
                       </div>
                       <Input placeholder="slug" className="w-48 rounded-l-none" {...field} />
                     </div>
@@ -882,9 +882,9 @@ const TargetSettingsPage_UpdateTargetGraphQLEndpointUrl = graphql(`
 
 function GraphQLEndpointUrl(props: {
   graphqlEndpointUrl: string | null;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
   const { toast } = useToast();
   const [mutation, mutate] = useMutation(TargetSettingsPage_UpdateTargetGraphQLEndpointUrl);
@@ -903,9 +903,9 @@ function GraphQLEndpointUrl(props: {
       onSubmit: values =>
         mutate({
           input: {
-            organization: props.organizationId,
-            project: props.projectId,
-            target: props.targetId,
+            organizationSlug: props.organizationSlug,
+            projectSlug: props.projectSlug,
+            targetSlug: props.targetSlug,
             graphqlEndpointUrl: values.graphqlEndpointUrl === '' ? null : values.graphqlEndpointUrl,
           },
         }).then(result => {
@@ -937,9 +937,9 @@ function GraphQLEndpointUrl(props: {
               <Link
                 to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                 params={{
-                  organizationSlug: props.organizationId,
-                  projectSlug: props.projectId,
-                  targetSlug: props.targetId,
+                  organizationSlug: props.organizationSlug,
+                  projectSlug: props.projectSlug,
+                  targetSlug: props.targetSlug,
                 }}
               >
                 Hive Laboratory
@@ -988,9 +988,9 @@ const TargetSettingsPage_UpdateTargetSlugMutation = graphql(`
     updateTargetSlug(input: $input) {
       ok {
         selector {
-          organization
-          project
-          target
+          organizationSlug
+          projectSlug
+          targetSlug
         }
         target {
           id
@@ -1022,7 +1022,11 @@ const TargetSettingsPage_OrganizationFragment = graphql(`
   }
 `);
 
-function TargetDelete(props: { organizationId: string; projectId: string; targetId: string }) {
+function TargetDelete(props: {
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+}) {
   const [isModalOpen, toggleModalOpen] = useToggle();
 
   return (
@@ -1051,9 +1055,9 @@ function TargetDelete(props: { organizationId: string; projectId: string; target
       </Button>
 
       <DeleteTargetModal
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
         isOpen={isModalOpen}
         toggleModalOpen={toggleModalOpen}
       />
@@ -1062,8 +1066,12 @@ function TargetDelete(props: { organizationId: string; projectId: string; target
 }
 
 const TargetSettingsPageQuery = graphql(`
-  query TargetSettingsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query TargetSettingsPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         id
         slug
@@ -1073,13 +1081,17 @@ const TargetSettingsPageQuery = graphql(`
         }
       }
     }
-    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
+    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       id
       slug
       type
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       id
       slug
@@ -1119,18 +1131,18 @@ const subPages = [
 type SubPage = (typeof subPages)[number]['key'];
 
 function TargetSettingsContent(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   page?: SubPage;
 }) {
   const router = useRouter();
   const [query] = useQuery({
     query: TargetSettingsPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
@@ -1166,14 +1178,14 @@ function TargetSettingsContent(props: {
   );
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   return (
     <TargetLayout
-      targetId={props.targetId}
-      projectId={props.projectId}
-      organizationId={props.organizationId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
       page={Page.Settings}
     >
       {currentOrganization && currentProject && currentTarget && organizationForSettings ? (
@@ -1215,21 +1227,21 @@ function TargetSettingsContent(props: {
                 {props.page === 'general' && hasSettingsAccess ? (
                   <>
                     <TargetSlug
-                      targetId={props.targetId}
-                      projectId={props.projectId}
-                      organizationId={props.organizationId}
+                      targetSlug={props.targetSlug}
+                      projectSlug={props.projectSlug}
+                      organizationSlug={props.organizationSlug}
                     />
                     <GraphQLEndpointUrl
-                      targetId={currentTarget.slug}
-                      projectId={currentProject.slug}
-                      organizationId={currentOrganization.slug}
+                      targetSlug={currentTarget.slug}
+                      projectSlug={currentProject.slug}
+                      organizationSlug={currentOrganization.slug}
                       graphqlEndpointUrl={currentTarget.graphqlEndpointUrl ?? null}
                     />
                     {hasDeleteAccess && (
                       <TargetDelete
-                        targetId={currentTarget.slug}
-                        projectId={currentProject.slug}
-                        organizationId={currentOrganization.slug}
+                        targetSlug={currentTarget.slug}
+                        projectSlug={currentProject.slug}
+                        organizationSlug={currentOrganization.slug}
                       />
                     )}
                   </>
@@ -1237,39 +1249,39 @@ function TargetSettingsContent(props: {
                 {props.page === 'cdn' && hasReadAccess ? (
                   <CDNAccessTokens
                     me={organizationForSettings.me}
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                   />
                 ) : null}
                 {props.page === 'registry-token' && hasTokensWriteAccess ? (
                   <RegistryAccessTokens
                     me={organizationForSettings.me}
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                   />
                 ) : null}
                 {props.page === 'breaking-changes' && hasSettingsAccess ? (
                   <ConditionalBreakingChanges
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                   />
                 ) : null}
                 {props.page === 'base-schema' && hasRegistryWriteAccess ? (
                   <ExtendBaseSchema
                     baseSchema={targetForSettings?.baseSchema ?? ''}
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                   />
                 ) : null}
                 {props.page === 'schema-contracts' && hasSettingsAccess ? (
                   <SchemaContracts
-                    organizationId={props.organizationId}
-                    projectId={props.projectId}
-                    targetId={props.targetId}
+                    organizationSlug={props.organizationSlug}
+                    projectSlug={props.projectSlug}
+                    targetSlug={props.targetSlug}
                   />
                 ) : null}
               </div>
@@ -1282,18 +1294,18 @@ function TargetSettingsContent(props: {
 }
 
 export function TargetSettingsPage(props: {
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
   page?: SubPage;
 }) {
   return (
     <>
       <Meta title="Settings" />
       <TargetSettingsContent
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
         page={props.page}
       />
     </>
@@ -1303,11 +1315,6 @@ export function TargetSettingsPage(props: {
 export const DeleteTargetMutation = graphql(`
   mutation deleteTarget($selector: TargetSelectorInput!) {
     deleteTarget(selector: $selector) {
-      selector {
-        organization
-        project
-        target
-      }
       deletedTarget {
         __typename
         id
@@ -1319,11 +1326,11 @@ export const DeleteTargetMutation = graphql(`
 export function DeleteTargetModal(props: {
   isOpen: boolean;
   toggleModalOpen: () => void;
-  organizationId: string;
-  projectId: string;
-  targetId: string;
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
 }) {
-  const { organizationId, projectId, targetId } = props;
+  const { organizationSlug, projectSlug, targetSlug } = props;
   const [, mutate] = useMutation(DeleteTargetMutation);
   const { toast } = useToast();
   const router = useRouter();
@@ -1331,9 +1338,9 @@ export function DeleteTargetModal(props: {
   const handleDelete = async () => {
     const { error } = await mutate({
       selector: {
-        organization: organizationId,
-        project: projectId,
-        target: targetId,
+        organizationSlug,
+        projectSlug,
+        targetSlug,
       },
     });
     if (error) {
@@ -1351,8 +1358,8 @@ export function DeleteTargetModal(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug',
         params: {
-          organizationSlug: organizationId,
-          projectSlug: projectId,
+          organizationSlug: organizationSlug,
+          projectSlug: projectSlug,
         },
       });
     }

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -1358,8 +1358,8 @@ export function DeleteTargetModal(props: {
       void router.navigate({
         to: '/$organizationSlug/$projectSlug',
         params: {
-          organizationSlug: organizationSlug,
-          projectSlug: projectSlug,
+          organizationSlug,
+          projectSlug,
         },
       });
     }

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -787,11 +787,11 @@ function TargetSlug(props: { organizationId: string; projectId: string; targetId
             description: 'Target slug updated',
           });
           void router.navigate({
-            to: '/$organizationId/$projectId/$targetId/settings',
+            to: '/$organizationSlug/$projectSlug/$targetSlug/settings',
             params: {
-              organizationId: props.organizationId,
-              projectId: props.projectId,
-              targetId: result.data.updateTargetSlug.ok.target.slug,
+              organizationSlug: props.organizationId,
+              projectSlug: props.projectId,
+              targetSlug: result.data.updateTargetSlug.ok.target.slug,
             },
             search: {
               page: 'general',
@@ -935,11 +935,11 @@ function GraphQLEndpointUrl(props: {
             <CardDescription>
               The endpoint url will be used for querying the target from the{' '}
               <Link
-                to="/$organizationId/$projectId/$targetId/laboratory"
+                to="/$organizationSlug/$projectSlug/$targetSlug/laboratory"
                 params={{
-                  organizationId: props.organizationId,
-                  projectId: props.projectId,
-                  targetId: props.targetId,
+                  organizationSlug: props.organizationId,
+                  projectSlug: props.projectId,
+                  targetSlug: props.targetId,
                 }}
               >
                 Hive Laboratory
@@ -1062,8 +1062,8 @@ function TargetDelete(props: { organizationId: string; projectId: string; target
 }
 
 const TargetSettingsPageQuery = graphql(`
-  query TargetSettingsPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetSettingsPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         id
         slug
@@ -1073,12 +1073,14 @@ const TargetSettingsPageQuery = graphql(`
         }
       }
     }
-    project(selector: { organization: $organizationId, project: $projectId }) {
+    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
       id
       slug
       type
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       id
       slug
       graphqlEndpointUrl
@@ -1126,9 +1128,9 @@ function TargetSettingsContent(props: {
   const [query] = useQuery({
     query: TargetSettingsPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -1347,10 +1349,10 @@ export function DeleteTargetModal(props: {
       });
       props.toggleModalOpen();
       void router.navigate({
-        to: '/$organizationId/$projectId',
+        to: '/$organizationSlug/$projectSlug',
         params: {
-          organizationId,
-          projectId,
+          organizationSlug: organizationId,
+          projectSlug: projectId,
         },
       });
     }

--- a/packages/web/app/src/pages/target.tsx
+++ b/packages/web/app/src/pages/target.tsx
@@ -287,16 +287,18 @@ function SchemaView(props: {
 }
 
 const TargetSchemaPageQuery = graphql(`
-  query TargetSchemaPageQuery($organizationId: ID!, $projectId: ID!, $targetId: ID!) {
-    organization(selector: { organization: $organizationId }) {
+  query TargetSchemaPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
+    organization(selector: { organization: $organizationSlug }) {
       organization {
         ...SchemaView_OrganizationFragment
       }
     }
-    project(selector: { organization: $organizationId, project: $projectId }) {
+    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
       ...SchemaView_ProjectFragment
     }
-    target(selector: { organization: $organizationId, project: $projectId, target: $targetId }) {
+    target(
+      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+    ) {
       ...SchemaView_TargetFragment
     }
   }
@@ -306,9 +308,9 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
   const [query] = useQuery({
     query: TargetSchemaPageQuery,
     variables: {
-      organizationId: props.organizationId,
-      projectId: props.projectId,
-      targetId: props.targetId,
+      organizationSlug: props.organizationId,
+      projectSlug: props.projectId,
+      targetSlug: props.targetId,
     },
   });
 
@@ -335,11 +337,11 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
         <div className="flex flex-row items-center gap-x-4">
           <Button variant="outline" asChild>
             <Link
-              to="/$organizationId/$projectId/$targetId/explorer/unused"
+              to="/$organizationSlug/$projectSlug/$targetSlug/explorer/unused"
               params={{
-                organizationId: props.organizationId,
-                projectId: props.projectId,
-                targetId: props.targetId,
+                organizationSlug: props.organizationId,
+                projectSlug: props.projectId,
+                targetSlug: props.targetId,
               }}
             >
               Unused schema
@@ -348,11 +350,11 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
           <span className="italic">|</span>
           <Button variant="outline" asChild>
             <Link
-              to="/$organizationId/$projectId/$targetId/explorer/deprecated"
+              to="/$organizationSlug/$projectSlug/$targetSlug/explorer/deprecated"
               params={{
-                organizationId: props.organizationId,
-                projectId: props.projectId,
-                targetId: props.targetId,
+                organizationSlug: props.organizationId,
+                projectSlug: props.projectId,
+                targetSlug: props.targetId,
               }}
             >
               Deprecated schema

--- a/packages/web/app/src/pages/target.tsx
+++ b/packages/web/app/src/pages/target.tsx
@@ -188,9 +188,9 @@ function SchemaView(props: {
     scope: TargetAccessScope.RegistryWrite,
     member: organization.me,
     redirect: false,
-    organizationId: organization.slug,
-    projectId: project.slug,
-    targetId: target.slug,
+    organizationSlug: organization.slug,
+    projectSlug: project.slug,
+    targetSlug: target.slug,
   });
 
   const { latestSchemaVersion } = target;
@@ -272,9 +272,9 @@ function SchemaView(props: {
           {canMarkAsValid ? (
             <>
               <MarkAsValid
-                organizationId={organization.slug}
-                projectId={project.slug}
-                targetId={target.slug}
+                organizationSlug={organization.slug}
+                projectSlug={project.slug}
+                targetSlug={target.slug}
                 version={latestSchemaVersion}
               />{' '}
             </>
@@ -287,35 +287,47 @@ function SchemaView(props: {
 }
 
 const TargetSchemaPageQuery = graphql(`
-  query TargetSchemaPageQuery($organizationSlug: ID!, $projectSlug: ID!, $targetSlug: ID!) {
-    organization(selector: { organization: $organizationSlug }) {
+  query TargetSchemaPageQuery(
+    $organizationSlug: String!
+    $projectSlug: String!
+    $targetSlug: String!
+  ) {
+    organization(selector: { organizationSlug: $organizationSlug }) {
       organization {
         ...SchemaView_OrganizationFragment
       }
     }
-    project(selector: { organization: $organizationSlug, project: $projectSlug }) {
+    project(selector: { organizationSlug: $organizationSlug, projectSlug: $projectSlug }) {
       ...SchemaView_ProjectFragment
     }
     target(
-      selector: { organization: $organizationSlug, project: $projectSlug, target: $targetSlug }
+      selector: {
+        organizationSlug: $organizationSlug
+        projectSlug: $projectSlug
+        targetSlug: $targetSlug
+      }
     ) {
       ...SchemaView_TargetFragment
     }
   }
 `);
 
-function TargetSchemaPage(props: { organizationId: string; projectId: string; targetId: string }) {
+function TargetSchemaPage(props: {
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+}) {
   const [query] = useQuery({
     query: TargetSchemaPageQuery,
     variables: {
-      organizationSlug: props.organizationId,
-      projectSlug: props.projectId,
-      targetSlug: props.targetId,
+      organizationSlug: props.organizationSlug,
+      projectSlug: props.projectSlug,
+      targetSlug: props.targetSlug,
     },
   });
 
   if (query.error) {
-    return <QueryError organizationId={props.organizationId} error={query.error} />;
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
   }
 
   const currentOrganization = query.data?.organization?.organization;
@@ -324,9 +336,9 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
 
   return (
     <TargetLayout
-      targetId={props.targetId}
-      projectId={props.projectId}
-      organizationId={props.organizationId}
+      targetSlug={props.targetSlug}
+      projectSlug={props.projectSlug}
+      organizationSlug={props.organizationSlug}
       page={Page.Schema}
     >
       <div className="flex flex-row items-center justify-between py-6">
@@ -339,9 +351,9 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
             <Link
               to="/$organizationSlug/$projectSlug/$targetSlug/explorer/unused"
               params={{
-                organizationSlug: props.organizationId,
-                projectSlug: props.projectId,
-                targetSlug: props.targetId,
+                organizationSlug: props.organizationSlug,
+                projectSlug: props.projectSlug,
+                targetSlug: props.targetSlug,
               }}
             >
               Unused schema
@@ -352,9 +364,9 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
             <Link
               to="/$organizationSlug/$projectSlug/$targetSlug/explorer/deprecated"
               params={{
-                organizationSlug: props.organizationId,
-                projectSlug: props.projectId,
-                targetSlug: props.targetId,
+                organizationSlug: props.organizationSlug,
+                projectSlug: props.projectSlug,
+                targetSlug: props.targetSlug,
               }}
             >
               Deprecated schema
@@ -371,14 +383,18 @@ function TargetSchemaPage(props: { organizationId: string; projectId: string; ta
   );
 }
 
-export function TargetPage(props: { organizationId: string; projectId: string; targetId: string }) {
+export function TargetPage(props: {
+  organizationSlug: string;
+  projectSlug: string;
+  targetSlug: string;
+}) {
   return (
     <>
       <Meta title="Schema" />
       <TargetSchemaPage
-        organizationId={props.organizationId}
-        projectId={props.projectId}
-        targetId={props.targetId}
+        organizationSlug={props.organizationSlug}
+        projectSlug={props.projectSlug}
+        targetSlug={props.targetSlug}
       />
     </>
   );

--- a/packages/web/app/src/router.tsx
+++ b/packages/web/app/src/router.tsx
@@ -328,16 +328,16 @@ const joinOrganizationRoute = createRoute({
 
 const transferOrganizationRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
-  path: 'action/transfer/$organizationId/$code',
+  path: 'action/transfer/$organizationSlug/$code',
   component: function TransferOrganizationRoute() {
-    const { organizationId, code } = transferOrganizationRoute.useParams();
-    return <OrganizationTransferPage organizationId={organizationId} code={code} />;
+    const { organizationSlug, code } = transferOrganizationRoute.useParams();
+    return <OrganizationTransferPage organizationId={organizationSlug} code={code} />;
   },
 });
 
 const organizationRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
-  path: '$organizationId',
+  path: '$organizationSlug',
   notFoundComponent: NotFound,
   errorComponent: ErrorComponent,
 });
@@ -347,11 +347,11 @@ const organizationIndexRoute = createRoute({
   path: '/',
   validateSearch: OrganizationIndexRouteSearch.parse,
   component: function OrganizationRoute() {
-    const { organizationId } = organizationRoute.useParams();
+    const { organizationSlug } = organizationRoute.useParams();
     const { search, sortBy, sortOrder } = organizationIndexRoute.useSearch();
     return (
       <OrganizationPage
-        organizationId={organizationId}
+        organizationId={organizationSlug}
         search={search}
         sortBy={sortBy}
         sortOrder={sortOrder}
@@ -366,8 +366,8 @@ const organizationSupportRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/support',
   component: function OrganizationSupportRoute() {
-    const { organizationId } = organizationSupportRoute.useParams();
-    return <OrganizationSupportPage organizationId={organizationId} />;
+    const { organizationSlug } = organizationSupportRoute.useParams();
+    return <OrganizationSupportPage organizationId={organizationSlug} />;
   },
 });
 
@@ -375,8 +375,8 @@ const organizationSupportTicketRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/support/ticket/$ticketId',
   component: function OrganizationSupportTicketRoute() {
-    const { organizationId, ticketId } = organizationSupportTicketRoute.useParams();
-    return <OrganizationSupportTicketPage organizationId={organizationId} ticketId={ticketId} />;
+    const { organizationSlug, ticketId } = organizationSupportTicketRoute.useParams();
+    return <OrganizationSupportTicketPage organizationId={organizationSlug} ticketId={ticketId} />;
   },
 });
 
@@ -384,8 +384,8 @@ const organizationSubscriptionRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/subscription',
   component: function OrganizationSubscriptionRoute() {
-    const { organizationId } = organizationSubscriptionRoute.useParams();
-    return <OrganizationSubscriptionPage organizationId={organizationId} />;
+    const { organizationSlug } = organizationSubscriptionRoute.useParams();
+    return <OrganizationSubscriptionPage organizationId={organizationSlug} />;
   },
 });
 
@@ -393,8 +393,10 @@ const organizationSubscriptionManageLegacyRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/subscription/manage',
   component: function OrganizationSubscriptionManageLegacyRoute() {
-    const { organizationId } = organizationSubscriptionManageLegacyRoute.useParams();
-    return <Navigate to="/$organizationId/view/manage-subscription" params={{ organizationId }} />;
+    const { organizationSlug } = organizationSubscriptionManageLegacyRoute.useParams();
+    return (
+      <Navigate to="/$organizationSlug/view/manage-subscription" params={{ organizationSlug }} />
+    );
   },
 });
 
@@ -402,8 +404,8 @@ const organizationSubscriptionManageRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/manage-subscription',
   component: function OrganizationSubscriptionManageRoute() {
-    const { organizationId } = organizationSubscriptionManageRoute.useParams();
-    return <OrganizationSubscriptionManagePage organizationId={organizationId} />;
+    const { organizationSlug } = organizationSubscriptionManageRoute.useParams();
+    return <OrganizationSubscriptionManagePage organizationId={organizationSlug} />;
   },
 });
 
@@ -411,8 +413,8 @@ const organizationPolicyRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/policy',
   component: function OrganizationPolicyRoute() {
-    const { organizationId } = organizationPolicyRoute.useParams();
-    return <OrganizationPolicyPage organizationId={organizationId} />;
+    const { organizationSlug } = organizationPolicyRoute.useParams();
+    return <OrganizationPolicyPage organizationId={organizationSlug} />;
   },
 });
 
@@ -420,8 +422,8 @@ const organizationSettingsRoute = createRoute({
   getParentRoute: () => organizationRoute,
   path: 'view/settings',
   component: function OrganizationSettingsRoute() {
-    const { organizationId } = organizationSettingsRoute.useParams();
-    return <OrganizationSettingsPage organizationId={organizationId} />;
+    const { organizationSlug } = organizationSettingsRoute.useParams();
+    return <OrganizationSettingsPage organizationId={organizationSlug} />;
   },
 });
 
@@ -436,7 +438,7 @@ const organizationMembersRoute = createRoute({
     return OrganizationMembersRouteSearch.parse(search);
   },
   component: function OrganizationMembersRoute() {
-    const { organizationId } = organizationMembersRoute.useParams();
+    const { organizationSlug } = organizationMembersRoute.useParams();
     const { page } = organizationMembersRoute.useSearch();
     const navigate = useNavigate({ from: organizationMembersRoute.fullPath });
     const onPageChange = useCallback(
@@ -448,7 +450,7 @@ const organizationMembersRoute = createRoute({
 
     return (
       <OrganizationMembersPage
-        organizationId={organizationId}
+        organizationId={organizationSlug}
         page={page}
         onPageChange={onPageChange}
       />
@@ -458,7 +460,7 @@ const organizationMembersRoute = createRoute({
 
 const projectRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
-  path: '$organizationId/$projectId',
+  path: '$organizationSlug/$projectSlug',
   notFoundComponent: NotFound,
   errorComponent: ErrorComponent,
 });
@@ -468,12 +470,12 @@ const projectIndexRoute = createRoute({
   path: '/',
   validateSearch: ProjectIndexRouteSearch.parse,
   component: function ProjectRoute() {
-    const { organizationId, projectId } = projectIndexRoute.useParams();
+    const { organizationSlug, projectSlug } = projectIndexRoute.useParams();
     const { search, sortBy, sortOrder } = projectIndexRoute.useSearch();
     return (
       <ProjectPage
-        organizationId={organizationId}
-        projectId={projectId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
         search={search}
         sortBy={sortBy}
         sortOrder={sortOrder}
@@ -486,8 +488,8 @@ const projectSettingsRoute = createRoute({
   getParentRoute: () => projectRoute,
   path: 'view/settings',
   component: function ProjectSettingsRoute() {
-    const { organizationId, projectId } = projectSettingsRoute.useParams();
-    return <ProjectSettingsPage organizationId={organizationId} projectId={projectId} />;
+    const { organizationSlug, projectSlug } = projectSettingsRoute.useParams();
+    return <ProjectSettingsPage organizationId={organizationSlug} projectId={projectSlug} />;
   },
 });
 
@@ -495,8 +497,8 @@ const projectPolicyRoute = createRoute({
   getParentRoute: () => projectRoute,
   path: 'view/policy',
   component: function ProjectPolicyRoute() {
-    const { organizationId, projectId } = projectPolicyRoute.useParams();
-    return <ProjectPolicyPage organizationId={organizationId} projectId={projectId} />;
+    const { organizationSlug, projectSlug } = projectPolicyRoute.useParams();
+    return <ProjectPolicyPage organizationId={organizationSlug} projectId={projectSlug} />;
   },
 });
 
@@ -504,14 +506,14 @@ const projectAlertsRoute = createRoute({
   getParentRoute: () => projectRoute,
   path: 'view/alerts',
   component: function ProjectAlertsRoute() {
-    const { organizationId, projectId } = projectAlertsRoute.useParams();
-    return <ProjectAlertsPage organizationId={organizationId} projectId={projectId} />;
+    const { organizationSlug, projectSlug } = projectAlertsRoute.useParams();
+    return <ProjectAlertsPage organizationId={organizationSlug} projectId={projectSlug} />;
   },
 });
 
 const targetRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
-  path: '$organizationId/$projectId/$targetId',
+  path: '$organizationSlug/$projectSlug/$targetSlug',
   notFoundComponent: NotFound,
   errorComponent: ErrorComponent,
 });
@@ -520,8 +522,10 @@ const targetIndexRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: '/',
   component: function TargetRoute() {
-    const { organizationId, projectId, targetId } = targetIndexRoute.useParams();
-    return <TargetPage organizationId={organizationId} projectId={projectId} targetId={targetId} />;
+    const { organizationSlug, projectSlug, targetSlug } = targetIndexRoute.useParams();
+    return (
+      <TargetPage organizationId={organizationSlug} projectId={projectSlug} targetId={targetSlug} />
+    );
   },
 });
 
@@ -546,14 +550,14 @@ const targetSettingsRoute = createRoute({
     return TargetSettingRouteSearch.parse(search);
   },
   component: function TargetSettingsRoute() {
-    const { organizationId, projectId, targetId } = targetSettingsRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetSettingsRoute.useParams();
     const { page } = targetSettingsRoute.useSearch();
 
     return (
       <TargetSettingsPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         page={page}
       />
     );
@@ -564,12 +568,12 @@ const targetLaboratoryRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'laboratory',
   component: function TargetLaboratoryRoute() {
-    const { organizationId, projectId, targetId } = targetLaboratoryRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetLaboratoryRoute.useParams();
     return (
       <TargetLaboratoryPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
       />
     );
   },
@@ -579,9 +583,13 @@ const targetAppsRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'apps',
   component: function TargetAppsRoute() {
-    const { organizationId, projectId, targetId } = targetAppsRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetAppsRoute.useParams();
     return (
-      <TargetAppsPage organizationId={organizationId} projectId={projectId} targetId={targetId} />
+      <TargetAppsPage
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
+      />
     );
   },
 });
@@ -590,13 +598,13 @@ const targetAppVersionRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'apps/$appName/$appVersion',
   component: function TargetAppVersionRoute() {
-    const { organizationId, projectId, targetId, appName, appVersion } =
+    const { organizationSlug, projectSlug, targetSlug, appName, appVersion } =
       targetAppVersionRoute.useParams();
     return (
       <TargetAppVersionPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         appName={appName}
         appVersion={appVersion}
       />
@@ -608,12 +616,12 @@ const targetInsightsRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'insights',
   component: function TargetInsightsRoute() {
-    const { organizationId, projectId, targetId } = targetInsightsRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetInsightsRoute.useParams();
     return (
       <TargetInsightsPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
       />
     );
   },
@@ -623,13 +631,13 @@ const targetInsightsCoordinateRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'insights/schema-coordinate/$coordinate',
   component: function TargetInsightsRoute() {
-    const { organizationId, projectId, targetId, coordinate } =
+    const { organizationSlug, projectSlug, targetSlug, coordinate } =
       targetInsightsCoordinateRoute.useParams();
     return (
       <TargetInsightsCoordinatePage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         coordinate={coordinate}
       />
     );
@@ -640,12 +648,13 @@ const targetInsightsClientRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'insights/client/$name',
   component: function TargetInsightsRoute() {
-    const { organizationId, projectId, targetId, name } = targetInsightsClientRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug, name } =
+      targetInsightsClientRoute.useParams();
     return (
       <TargetInsightsClientPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         name={name}
       />
     );
@@ -656,13 +665,13 @@ const targetInsightsOperationsRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'insights/$operationName/$operationHash',
   component: function TargetInsightsRoute() {
-    const { organizationId, projectId, targetId, operationName, operationHash } =
+    const { organizationSlug, projectSlug, targetSlug, operationName, operationHash } =
       targetInsightsOperationsRoute.useParams();
     return (
       <TargetInsightsOperationPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         operationName={operationName}
         operationHash={operationHash}
       />
@@ -674,12 +683,12 @@ const targetHistoryRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'history',
   component: function TargetHistoryRoute() {
-    const { organizationId, projectId, targetId } = targetHistoryRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetHistoryRoute.useParams();
     return (
       <TargetHistoryPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
       />
     );
   },
@@ -689,13 +698,13 @@ const targetHistoryVersionRoute = createRoute({
   getParentRoute: () => targetHistoryRoute,
   path: '$versionId',
   component: function TargetHistoryVersionRoute() {
-    const { organizationId, projectId, targetId, versionId } =
+    const { organizationSlug, projectSlug, targetSlug, versionId } =
       targetHistoryVersionRoute.useParams();
     return (
       <TargetHistoryVersionPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         versionId={versionId}
       />
     );
@@ -706,12 +715,12 @@ const targetExplorerRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'explorer',
   component: function TargetExplorerRoute() {
-    const { organizationId, projectId, targetId } = targetExplorerRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetExplorerRoute.useParams();
     return (
       <TargetExplorerPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
       />
     );
   },
@@ -721,12 +730,13 @@ const targetExplorerTypeRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'explorer/$typename',
   component: function TargetExplorerTypeRoute() {
-    const { organizationId, projectId, targetId, typename } = targetExplorerTypeRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug, typename } =
+      targetExplorerTypeRoute.useParams();
     return (
       <TargetExplorerTypePage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         typename={typename}
       />
     );
@@ -737,12 +747,12 @@ const targetExplorerDeprecatedRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'explorer/deprecated',
   component: function TargetExplorerDeprecatedRoute() {
-    const { organizationId, projectId, targetId } = targetExplorerDeprecatedRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetExplorerDeprecatedRoute.useParams();
     return (
       <TargetExplorerDeprecatedPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
       />
     );
   },
@@ -752,12 +762,12 @@ const targetExplorerUnusedRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'explorer/unused',
   component: function TargetExplorerUnusedRoute() {
-    const { organizationId, projectId, targetId } = targetExplorerUnusedRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetExplorerUnusedRoute.useParams();
     return (
       <TargetExplorerUnusedPage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
       />
     );
   },
@@ -767,9 +777,13 @@ const targetChecksRoute = createRoute({
   getParentRoute: () => targetRoute,
   path: 'checks',
   component: function TargetChecksRoute() {
-    const { organizationId, projectId, targetId } = targetChecksRoute.useParams();
+    const { organizationSlug, projectSlug, targetSlug } = targetChecksRoute.useParams();
     return (
-      <TargetChecksPage organizationId={organizationId} projectId={projectId} targetId={targetId} />
+      <TargetChecksPage
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
+      />
     );
   },
 });
@@ -778,13 +792,13 @@ const targetChecksSingleRoute = createRoute({
   getParentRoute: () => targetChecksRoute,
   path: '$schemaCheckId',
   component: function TargetChecksSingleRoute() {
-    const { organizationId, projectId, targetId, schemaCheckId } =
+    const { organizationSlug, projectSlug, targetSlug, schemaCheckId } =
       targetChecksSingleRoute.useParams();
     return (
       <TargetChecksSinglePage
-        organizationId={organizationId}
-        projectId={projectId}
-        targetId={targetId}
+        organizationId={organizationSlug}
+        projectId={projectSlug}
+        targetId={targetSlug}
         schemaCheckId={schemaCheckId}
       />
     );

--- a/packages/web/app/src/router.tsx
+++ b/packages/web/app/src/router.tsx
@@ -331,7 +331,7 @@ const transferOrganizationRoute = createRoute({
   path: 'action/transfer/$organizationSlug/$code',
   component: function TransferOrganizationRoute() {
     const { organizationSlug, code } = transferOrganizationRoute.useParams();
-    return <OrganizationTransferPage organizationId={organizationSlug} code={code} />;
+    return <OrganizationTransferPage organizationSlug={organizationSlug} code={code} />;
   },
 });
 
@@ -351,7 +351,7 @@ const organizationIndexRoute = createRoute({
     const { search, sortBy, sortOrder } = organizationIndexRoute.useSearch();
     return (
       <OrganizationPage
-        organizationId={organizationSlug}
+        organizationSlug={organizationSlug}
         search={search}
         sortBy={sortBy}
         sortOrder={sortOrder}
@@ -367,7 +367,7 @@ const organizationSupportRoute = createRoute({
   path: 'view/support',
   component: function OrganizationSupportRoute() {
     const { organizationSlug } = organizationSupportRoute.useParams();
-    return <OrganizationSupportPage organizationId={organizationSlug} />;
+    return <OrganizationSupportPage organizationSlug={organizationSlug} />;
   },
 });
 
@@ -376,7 +376,9 @@ const organizationSupportTicketRoute = createRoute({
   path: 'view/support/ticket/$ticketId',
   component: function OrganizationSupportTicketRoute() {
     const { organizationSlug, ticketId } = organizationSupportTicketRoute.useParams();
-    return <OrganizationSupportTicketPage organizationId={organizationSlug} ticketId={ticketId} />;
+    return (
+      <OrganizationSupportTicketPage organizationSlug={organizationSlug} ticketId={ticketId} />
+    );
   },
 });
 
@@ -385,7 +387,7 @@ const organizationSubscriptionRoute = createRoute({
   path: 'view/subscription',
   component: function OrganizationSubscriptionRoute() {
     const { organizationSlug } = organizationSubscriptionRoute.useParams();
-    return <OrganizationSubscriptionPage organizationId={organizationSlug} />;
+    return <OrganizationSubscriptionPage organizationSlug={organizationSlug} />;
   },
 });
 
@@ -405,7 +407,7 @@ const organizationSubscriptionManageRoute = createRoute({
   path: 'view/manage-subscription',
   component: function OrganizationSubscriptionManageRoute() {
     const { organizationSlug } = organizationSubscriptionManageRoute.useParams();
-    return <OrganizationSubscriptionManagePage organizationId={organizationSlug} />;
+    return <OrganizationSubscriptionManagePage organizationSlug={organizationSlug} />;
   },
 });
 
@@ -414,7 +416,7 @@ const organizationPolicyRoute = createRoute({
   path: 'view/policy',
   component: function OrganizationPolicyRoute() {
     const { organizationSlug } = organizationPolicyRoute.useParams();
-    return <OrganizationPolicyPage organizationId={organizationSlug} />;
+    return <OrganizationPolicyPage organizationSlug={organizationSlug} />;
   },
 });
 
@@ -423,7 +425,7 @@ const organizationSettingsRoute = createRoute({
   path: 'view/settings',
   component: function OrganizationSettingsRoute() {
     const { organizationSlug } = organizationSettingsRoute.useParams();
-    return <OrganizationSettingsPage organizationId={organizationSlug} />;
+    return <OrganizationSettingsPage organizationSlug={organizationSlug} />;
   },
 });
 
@@ -450,7 +452,7 @@ const organizationMembersRoute = createRoute({
 
     return (
       <OrganizationMembersPage
-        organizationId={organizationSlug}
+        organizationSlug={organizationSlug}
         page={page}
         onPageChange={onPageChange}
       />
@@ -474,8 +476,8 @@ const projectIndexRoute = createRoute({
     const { search, sortBy, sortOrder } = projectIndexRoute.useSearch();
     return (
       <ProjectPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
         search={search}
         sortBy={sortBy}
         sortOrder={sortOrder}
@@ -489,7 +491,7 @@ const projectSettingsRoute = createRoute({
   path: 'view/settings',
   component: function ProjectSettingsRoute() {
     const { organizationSlug, projectSlug } = projectSettingsRoute.useParams();
-    return <ProjectSettingsPage organizationId={organizationSlug} projectId={projectSlug} />;
+    return <ProjectSettingsPage organizationSlug={organizationSlug} projectSlug={projectSlug} />;
   },
 });
 
@@ -498,7 +500,7 @@ const projectPolicyRoute = createRoute({
   path: 'view/policy',
   component: function ProjectPolicyRoute() {
     const { organizationSlug, projectSlug } = projectPolicyRoute.useParams();
-    return <ProjectPolicyPage organizationId={organizationSlug} projectId={projectSlug} />;
+    return <ProjectPolicyPage organizationSlug={organizationSlug} projectSlug={projectSlug} />;
   },
 });
 
@@ -507,7 +509,7 @@ const projectAlertsRoute = createRoute({
   path: 'view/alerts',
   component: function ProjectAlertsRoute() {
     const { organizationSlug, projectSlug } = projectAlertsRoute.useParams();
-    return <ProjectAlertsPage organizationId={organizationSlug} projectId={projectSlug} />;
+    return <ProjectAlertsPage organizationSlug={organizationSlug} projectSlug={projectSlug} />;
   },
 });
 
@@ -524,7 +526,11 @@ const targetIndexRoute = createRoute({
   component: function TargetRoute() {
     const { organizationSlug, projectSlug, targetSlug } = targetIndexRoute.useParams();
     return (
-      <TargetPage organizationId={organizationSlug} projectId={projectSlug} targetId={targetSlug} />
+      <TargetPage
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
+      />
     );
   },
 });
@@ -555,9 +561,9 @@ const targetSettingsRoute = createRoute({
 
     return (
       <TargetSettingsPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         page={page}
       />
     );
@@ -571,9 +577,9 @@ const targetLaboratoryRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetLaboratoryRoute.useParams();
     return (
       <TargetLaboratoryPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -586,9 +592,9 @@ const targetAppsRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetAppsRoute.useParams();
     return (
       <TargetAppsPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -602,9 +608,9 @@ const targetAppVersionRoute = createRoute({
       targetAppVersionRoute.useParams();
     return (
       <TargetAppVersionPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         appName={appName}
         appVersion={appVersion}
       />
@@ -619,9 +625,9 @@ const targetInsightsRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetInsightsRoute.useParams();
     return (
       <TargetInsightsPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -635,9 +641,9 @@ const targetInsightsCoordinateRoute = createRoute({
       targetInsightsCoordinateRoute.useParams();
     return (
       <TargetInsightsCoordinatePage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         coordinate={coordinate}
       />
     );
@@ -652,9 +658,9 @@ const targetInsightsClientRoute = createRoute({
       targetInsightsClientRoute.useParams();
     return (
       <TargetInsightsClientPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         name={name}
       />
     );
@@ -669,9 +675,9 @@ const targetInsightsOperationsRoute = createRoute({
       targetInsightsOperationsRoute.useParams();
     return (
       <TargetInsightsOperationPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         operationName={operationName}
         operationHash={operationHash}
       />
@@ -686,9 +692,9 @@ const targetHistoryRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetHistoryRoute.useParams();
     return (
       <TargetHistoryPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -702,9 +708,9 @@ const targetHistoryVersionRoute = createRoute({
       targetHistoryVersionRoute.useParams();
     return (
       <TargetHistoryVersionPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         versionId={versionId}
       />
     );
@@ -718,9 +724,9 @@ const targetExplorerRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetExplorerRoute.useParams();
     return (
       <TargetExplorerPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -734,9 +740,9 @@ const targetExplorerTypeRoute = createRoute({
       targetExplorerTypeRoute.useParams();
     return (
       <TargetExplorerTypePage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         typename={typename}
       />
     );
@@ -750,9 +756,9 @@ const targetExplorerDeprecatedRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetExplorerDeprecatedRoute.useParams();
     return (
       <TargetExplorerDeprecatedPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -765,9 +771,9 @@ const targetExplorerUnusedRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetExplorerUnusedRoute.useParams();
     return (
       <TargetExplorerUnusedPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -780,9 +786,9 @@ const targetChecksRoute = createRoute({
     const { organizationSlug, projectSlug, targetSlug } = targetChecksRoute.useParams();
     return (
       <TargetChecksPage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
       />
     );
   },
@@ -796,9 +802,9 @@ const targetChecksSingleRoute = createRoute({
       targetChecksSingleRoute.useParams();
     return (
       <TargetChecksSinglePage
-        organizationId={organizationSlug}
-        projectId={projectSlug}
-        targetId={targetSlug}
+        organizationSlug={organizationSlug}
+        projectSlug={projectSlug}
+        targetSlug={targetSlug}
         schemaCheckId={schemaCheckId}
       />
     );

--- a/packages/web/app/src/server/github.ts
+++ b/packages/web/app/src/server/github.ts
@@ -24,8 +24,8 @@ const SetupCallbackQuery = z.object({
 });
 
 const ConnectParams = z.object({
-  organizationId: z.string({
-    required_error: 'Invalid organizationId',
+  organizationSlug: z.string({
+    required_error: 'Invalid organizationSlug',
   }),
 });
 
@@ -38,16 +38,16 @@ export function connectGithub(server: FastifyInstance) {
       return;
     }
 
-    const { installation_id: installationId, state: orgId } = queryResult.data;
+    const { installation_id: installationId, state: organizationSlug } = queryResult.data;
 
     // const installationId = req.query.installation_id as string;
     // const orgId = req.query.state as string;
 
     await ensureGithubIntegration(req, {
       installationId,
-      orgId,
+      organizationSlug,
     });
-    void res.redirect(`/${orgId}/view/settings`);
+    void res.redirect(`/${organizationSlug}/view/settings`);
   });
 
   server.get('/api/github/setup-callback', async (req, res) => {
@@ -58,14 +58,18 @@ export function connectGithub(server: FastifyInstance) {
       return;
     }
 
-    let { installation_id: installationId, state: orgId } = queryResult.data;
+    let { installation_id: installationId, state: organizationSlug } = queryResult.data;
 
-    req.log.info('GitHub setup callback (installationId=%s, orgId=%s)', installationId, orgId);
+    req.log.info(
+      'GitHub setup callback (installationId=%s, organizationSlug=%s)',
+      installationId,
+      organizationSlug,
+    );
 
-    if (orgId) {
+    if (organizationSlug) {
       await ensureGithubIntegration(req, {
         installationId,
-        orgId,
+        organizationSlug,
       });
     } else {
       const result = await graphql<{
@@ -94,17 +98,17 @@ export function connectGithub(server: FastifyInstance) {
         },
       });
 
-      orgId = result.data?.organizationByGitHubInstallationId?.slug;
+      organizationSlug = result.data?.organizationByGitHubInstallationId?.slug;
     }
 
-    if (orgId) {
-      void res.redirect(`/${orgId}/view/settings`);
+    if (organizationSlug) {
+      void res.redirect(`/${organizationSlug}/view/settings`);
     } else {
       void res.redirect('/');
     }
   });
 
-  server.get('/api/github/connect/:organizationId', async (req, res) => {
+  server.get('/api/github/connect/:organizationSlug', async (req, res) => {
     if (!env.github) {
       req.log.error('GitHub is not set up.');
       throw new Error('GitHub is not set up.');
@@ -117,15 +121,15 @@ export function connectGithub(server: FastifyInstance) {
       return;
     }
 
-    const { organizationId } = paramsResult.data;
+    const { organizationSlug } = paramsResult.data;
 
-    req.log.info('Connect to GitHub (orgId=%s)', organizationId);
+    req.log.info('Connect to GitHub (organizationSlug=%s)', organizationSlug);
 
     const url = `https://github.com/apps/${env.github.appName}/installations/new`;
 
     const redirectUrl = `${env.appBaseUrl}/api/github/callback`;
 
-    void res.redirect(`${url}?state=${organizationId}&redirect_url=${redirectUrl}`);
+    void res.redirect(`${url}?state=${organizationSlug}&redirect_url=${redirectUrl}`);
   });
 }
 
@@ -133,10 +137,10 @@ async function ensureGithubIntegration(
   req: FastifyRequest,
   input: {
     installationId: string;
-    orgId: string;
+    organizationSlug: string;
   },
 ) {
-  const { orgId, installationId } = input;
+  const { organizationSlug, installationId } = input;
   await graphql({
     url: env.graphqlPublicEndpoint,
     headers: {
@@ -153,7 +157,7 @@ async function ensureGithubIntegration(
     `,
     variables: {
       input: {
-        organization: orgId,
+        organizationSlug,
         installationId,
       },
     },

--- a/packages/web/app/src/server/lab.ts
+++ b/packages/web/app/src/server/lab.ts
@@ -5,14 +5,17 @@ import { env } from '@/env/backend';
 import { addMocksToSchema } from '@graphql-tools/mock';
 
 const LabParams = z.object({
-  organizationId: z.string({
-    required_error: 'Missing organizationId (format /api/lab/:organizationId/:projectId/:targetId)',
+  organizationSlug: z.string({
+    required_error:
+      'Missing organizationSlug (format /api/lab/:organizationSlug/:projectSlug/:targetSlug)',
   }),
-  projectId: z.string({
-    required_error: 'Missing projectId (format /api/lab/:organizationId/:projectId/:targetId)',
+  projectSlug: z.string({
+    required_error:
+      'Missing projectSlug (format /api/lab/:organizationSlug/:projectSlug/:targetSlug)',
   }),
-  targetId: z.string({
-    required_error: 'Missing targetId (format /api/lab/:organizationId/:projectId/:targetId)',
+  targetSlug: z.string({
+    required_error:
+      'Missing targetSlug (format /api/lab/:organizationSlug/:projectSlug/:targetSlug)',
   }),
 });
 
@@ -25,7 +28,7 @@ const LabBody = z.object({
 });
 
 export function connectLab(server: FastifyInstance) {
-  server.all('/api/lab/:organizationId/:projectId/:targetId', async (req, res) => {
+  server.all('/api/lab/:organizationSlug/:projectSlug/:targetSlug', async (req, res) => {
     const url = env.graphqlPublicEndpoint;
 
     const labParamsResult = LabParams.safeParse(req.params);
@@ -35,7 +38,7 @@ export function connectLab(server: FastifyInstance) {
       return;
     }
 
-    const { organizationId, projectId, targetId } = labParamsResult.data;
+    const { organizationSlug, projectSlug, targetSlug } = labParamsResult.data;
 
     const headers: Record<string, string> = {};
 
@@ -57,9 +60,9 @@ export function connectLab(server: FastifyInstance) {
       `,
       variables: {
         selector: {
-          organization: organizationId,
-          project: projectId,
-          target: targetId,
+          organizationSlug: organizationSlug,
+          projectSlug: projectSlug,
+          targetSlug: targetSlug,
         },
       },
     };

--- a/packages/web/app/src/server/lab.ts
+++ b/packages/web/app/src/server/lab.ts
@@ -60,9 +60,9 @@ export function connectLab(server: FastifyInstance) {
       `,
       variables: {
         selector: {
-          organizationSlug: organizationSlug,
-          projectSlug: projectSlug,
-          targetSlug: targetSlug,
+          organizationSlug,
+          projectSlug,
+          targetSlug,
         },
       },
     };

--- a/packages/web/app/src/server/slack.ts
+++ b/packages/web/app/src/server/slack.ts
@@ -66,7 +66,7 @@ export function connectSlack(server: FastifyInstance) {
       `,
       variables: {
         input: {
-          organizationSlug: organizationSlug,
+          organizationSlug,
           token,
         },
       },

--- a/packages/web/app/src/server/slack.ts
+++ b/packages/web/app/src/server/slack.ts
@@ -14,8 +14,8 @@ const CallBackQuery = z.object({
 });
 
 const ConnectParams = z.object({
-  organizationId: z.string({
-    required_error: 'Invalid organizationId',
+  organizationSlug: z.string({
+    required_error: 'Invalid organizationSlug',
   }),
 });
 
@@ -32,9 +32,9 @@ export function connectSlack(server: FastifyInstance) {
       return;
     }
 
-    const { code, state: orgId } = queryResult.data;
+    const { code, state: organizationSlug } = queryResult.data;
 
-    req.log.info('Fetching data from Slack API (orgId=%s)', orgId);
+    req.log.info('Fetching data from Slack API (orgId=%s)', organizationSlug);
 
     const slackResponse = await fetch('https://slack.com/api/oauth.v2.access', {
       method: 'POST',
@@ -66,15 +66,15 @@ export function connectSlack(server: FastifyInstance) {
       `,
       variables: {
         input: {
-          organization: orgId,
+          organizationSlug: organizationSlug,
           token,
         },
       },
     });
-    void res.redirect(`/${orgId}/view/settings`);
+    void res.redirect(`/${organizationSlug}/view/settings`);
   });
 
-  server.get('/api/slack/connect/:organizationId', async (req, res) => {
+  server.get('/api/slack/connect/:organizationSlug', async (req, res) => {
     req.log.info('Connect to Slack');
     if (env.slack === null) {
       req.log.error('The Slack integration is not enabled.');
@@ -87,12 +87,12 @@ export function connectSlack(server: FastifyInstance) {
       return;
     }
 
-    const { organizationId } = paramsResult.data;
-    req.log.info('Connect organization to Slack (id=%s)', organizationId);
+    const { organizationSlug } = paramsResult.data;
+    req.log.info('Connect organization to Slack (id=%s)', organizationSlug);
 
     const slackUrl = `https://slack.com/oauth/v2/authorize?scope=incoming-webhook,chat:write,chat:write.public,commands&client_id=${env.slack.clientId}`;
     const redirectUrl = `${env.appBaseUrl}/api/slack/callback`;
 
-    void res.redirect(`${slackUrl}&state=${organizationId}&redirect_uri=${redirectUrl}`);
+    void res.redirect(`${slackUrl}&state=${organizationSlug}&redirect_uri=${redirectUrl}`);
   });
 }

--- a/packages/web/app/src/stories/leave-organization.stories.tsx
+++ b/packages/web/app/src/stories/leave-organization.stories.tsx
@@ -23,7 +23,7 @@ export const Default: Story = {
           <LeaveOrganizationModalContent
             isOpen={openModal}
             onSubmit={() => console.log('submit')}
-            organizationCleanId="test-organization"
+            organizationSlug="test-organization"
             toggleModalOpen={toggleModalOpen}
           />
         )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1847,7 +1847,7 @@ importers:
         version: 4.3.1(vite@5.4.6(@types/node@20.16.1)(less@4.2.0)(terser@5.31.1))
       autoprefixer:
         specifier: 10.4.20
-        version: 10.4.20(postcss@8.4.47)
+        version: 10.4.20(postcss@8.4.41)
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -25275,8 +25275,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4)
       eslint: 8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)
       eslint-config-prettier: 9.1.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
       eslint-plugin-jsonc: 2.11.1(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
       eslint-plugin-mdx: 3.0.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
@@ -26406,16 +26406,6 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.0.1
       postcss: 8.4.41
-      postcss-value-parser: 4.2.0
-
-  autoprefixer@10.4.20(postcss@8.4.47):
-    dependencies:
-      browserslist: 4.23.3
-      caniuse-lite: 1.0.30001651
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.0.1
-      postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.5: {}
@@ -28300,13 +28290,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)):
     dependencies:
       debug: 4.3.6(supports-color@8.1.1)
       enhanced-resolve: 5.17.0
       eslint: 8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -28337,14 +28327,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4)
       eslint: 8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
     transitivePeerDependencies:
       - supports-color
 
@@ -28360,7 +28350,7 @@ snapshots:
       eslint: 8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)
       eslint-compat-utils: 0.1.2(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -28370,7 +28360,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))(typescript@5.5.4))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva)))(eslint@8.57.0(patch_hash=fjbpfrtrjd6idngyeqxnwopfva))
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
Continues #5684 and #5681 

- Adds `slug`
- Deprecates `cleanId`
- The `cleanId` resolvers use `slug` for backwards-compatibility
- Replaces all usage of `cleanId` with `slug`
- Input object types use now `projectSlug` instead of just `project`.
- Input object fields like `version`, `user`, `role` or `targets` (and others) that represent IDs are renamed and contain the `*Id` suffix.
- web/app: props like `organizationId: string`, `organization: string` or `organizationCleanId: string` that hold the value of `cleanId` is now renamed to `organizationSlug` (same for projectSlug and targetSlug).