### PR TITLE
clean warnings from codegen `the following anonymous operation is skipped:`

### DIFF
--- a/codegen.mts
+++ b/codegen.mts
@@ -242,11 +242,8 @@ const config: CodegenConfig = {
       plugins: ['typescript', 'typescript-operations'],
     },
     // Integration tests
-    'integration-tests/testkit/gql/': {
-      documents: [
-        'integration-tests/(testkit|tests)/**/*.ts',
-        '!integration-tests/tests/api/target/usage.spec.ts',
-      ],
+    './integration-tests/testkit/gql/': {
+      documents: ['./integration-tests/(testkit|tests)/**/*.ts'],
       preset: 'client',
       plugins: [],
       config: {

--- a/codegen.mts
+++ b/codegen.mts
@@ -242,8 +242,11 @@ const config: CodegenConfig = {
       plugins: ['typescript', 'typescript-operations'],
     },
     // Integration tests
-    './integration-tests/testkit/gql/': {
-      documents: ['./integration-tests/(testkit|tests)/**/*.ts'],
+    'integration-tests/testkit/gql/': {
+      documents: [
+        'integration-tests/(testkit|tests)/**/*.ts',
+        '!integration-tests/tests/api/target/usage.spec.ts',
+      ],
       preset: 'client',
       plugins: [],
       config: {

--- a/integration-tests/tests/api/artifacts-cdn.spec.ts
+++ b/integration-tests/tests/api/artifacts-cdn.spec.ts
@@ -404,7 +404,7 @@ function runArtifactsCDNTests(
             'content-type': 'application/json',
           },
           body: JSON.stringify({
-            query: /* GraphQL */ `
+            query: `
               {
                 __schema {
                   types {

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -159,58 +159,58 @@ test.concurrent(
       organizationScopes: [OrganizationAccessScope.Read],
     });
 
-    const raw_document = `
-    query outfit {
-      recommendations(
-        input: {
-          strategies: [{ name: "asd" }]
-          articleId: "asd"
-          customerId: "asd"
-          phoenixEnabled: true
-          sessionId: "asd"
-        }
-      ) {
-        ... on RecommendationResponse {
-          frequentlyBoughtTogether {
-            recommendedProducts {
-              id
+    const raw_document = /*GraphQL*/ `
+      query outfit {
+        recommendations(
+          input: {
+            strategies: [{ name: "asd" }]
+            articleId: "asd"
+            customerId: "asd"
+            phoenixEnabled: true
+            sessionId: "asd"
+          }
+        ) {
+          ... on RecommendationResponse {
+            frequentlyBoughtTogether {
+              recommendedProducts {
+                id
+              }
+              strategyMessage
             }
-            strategyMessage
-          }
-          outfit {
-            strategyMessage
-          }
-          outfit {
-            recommendedProducts {
-              articleId
-              id
-              imageUrl
-              name
-              productUrl
-              rating
-              tCode
+            outfit {
+              strategyMessage
             }
-            strategyMessage
-          }
-          similar {
-            recommendedProducts {
-              articleId
-              id
-              imageUrl
-              name
-              productUrl
-              rating
-              tCode
+            outfit {
+              recommendedProducts {
+                articleId
+                id
+                imageUrl
+                name
+                productUrl
+                rating
+                tCode
+              }
+              strategyMessage
             }
-            strategyMessage
-          }
-          visualSearch {
-            strategyMessage
+            similar {
+              recommendedProducts {
+                articleId
+                id
+                imageUrl
+                name
+                productUrl
+                rating
+                tCode
+              }
+              strategyMessage
+            }
+            visualSearch {
+              strategyMessage
+            }
           }
         }
       }
-    }
-  `;
+    `;
 
     const normalized_document = normalizeOperation({
       document: parse(raw_document),

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -159,7 +159,7 @@ test.concurrent(
       organizationScopes: [OrganizationAccessScope.Read],
     });
 
-    const raw_document = /*GraphQL*/ `
+    const raw_document = `
       query outfit {
         recommendations(
           input: {
@@ -2567,11 +2567,7 @@ test.concurrent(
 
     client.collectSubscriptionUsage({
       args: {
-        document: parse(/* GraphQL */ `
-          subscription {
-            a
-          }
-        `),
+        document: parse('subscription { a }'),
         schema,
         contextValue: {
           request,
@@ -2653,11 +2649,7 @@ test.concurrent(
 
     client.collectUsage()(
       {
-        document: parse(/* GraphQL */ `
-          query {
-            a
-          }
-        `),
+        document: parse('{ a }'),
         schema,
         contextValue: {
           request,
@@ -2667,11 +2659,7 @@ test.concurrent(
     );
     client.collectUsage()(
       {
-        document: parse(/* GraphQL */ `
-          query {
-            a
-          }
-        `),
+        document: parse('{ a }'),
         schema,
         contextValue: {
           request,
@@ -2681,11 +2669,7 @@ test.concurrent(
     );
     client.collectUsage()(
       {
-        document: parse(/* GraphQL */ `
-          query {
-            a
-          }
-        `),
+        document: parse('{ a }'),
         schema,
         contextValue: {
           request,
@@ -2734,11 +2718,7 @@ test.concurrent(
 
     client.collectSubscriptionUsage({
       args: {
-        document: parse(/* GraphQL */ `
-          subscription {
-            a
-          }
-        `),
+        document: parse('subscription { a }'),
         schema,
         contextValue: {
           request,
@@ -2747,11 +2727,7 @@ test.concurrent(
     });
     client.collectSubscriptionUsage({
       args: {
-        document: parse(/* GraphQL */ `
-          subscription {
-            a
-          }
-        `),
+        document: parse('subscription { a }'),
         schema,
         contextValue: {
           request,
@@ -2760,11 +2736,7 @@ test.concurrent(
     });
     client.collectSubscriptionUsage({
       args: {
-        document: parse(/* GraphQL */ `
-          subscription {
-            a
-          }
-        `),
+        document: parse('subscription { a }'),
         schema,
         contextValue: {
           request,


### PR DESCRIPTION
to remove these warnings https://guild-oss.slack.com/archives/C01E8ATBQGN/p1729585730974249

```sh
  ❯ Generate to ./integration-tests/testkit/gql/
    ✔ Load GraphQL schemas
    ✔ Load GraphQL documents
    ⠼ Generate
[client-preset] the following anonymous operation is skipped: 
              {
                __schema {
                  types {
                    name
                    fields {
                      name
                    }
                  }
                }
              }
            
[client-preset] the following anonymous operation is skipped: 
      query {
        a
      }
    
[client-preset] the following anonymous operation is skipped: 
      query {
        b
      }
    
[client-preset] the following anonymous operation is skipped: 
          subscription {
            a
          }
        
[client-preset] the following anonymous operation is skipped: 
          query {
            a
          }
        
[client-preset] the following anonymous operation is skipped: 
          query {
            a
          }
        
[client-preset] the following anonymous operation is skipped: 
          query {
            a
          }
        
✔ Parse Configuration
✔ Generate outputs
```