### PR TITLE
Hive Gateway has been moved to ghcr.io/graphql-hive/gateway

### DIFF
--- a/packages/web/docs/src/pages/docs/gateway/deployment/docker.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/deployment/docker.mdx
@@ -29,8 +29,8 @@ For example, changing the supergraph to use the `my-schema.graphql` schema inste
 ```sh
 docker run \
   -p 4000:4000 \
-  -v "$(pwd)/my-schema.graphql:/serve/my-schema.graphql" \
-  ghcr.io/ardatan/hive-gateway supergraph my-schema.graphql
+  -v "$(pwd)/my-schema.graphql:/gateway/my-schema.graphql" \
+  ghcr.io/graphql-hive/gateway supergraph my-schema.graphql
 ```
 
 For a full list of CLI arguments, please refer to the
@@ -56,8 +56,8 @@ export const gatewayConfig = defineConfig({
 ```sh
 docker run \
   -p 4000:4000 \
-  -v "$(pwd)/gateway.config.ts:/serve/gateway.config.ts" \
-  ghcr.io/ardatan/hive-gateway proxy
+  -v "$(pwd)/gateway.config.ts:/gateway/gateway.config.ts" \
+  ghcr.io/graphql-hive/gateway proxy
 ```
 
 For a full list of CLI arguments, please refer to the
@@ -76,8 +76,8 @@ running the image:
 ```sh
 docker run \
   -p 8080:8080 \
-  -v "$(pwd)/supergraph.graphql:/serve/supergraph.graphql" \
-  ghcr.io/ardatan/hive-gateway supergraph --port=8080
+  -v "$(pwd)/supergraph.graphql:/gateway/supergraph.graphql" \
+  ghcr.io/graphql-hive/gateway supergraph --port=8080
 ```
 
 ## Running
@@ -88,8 +88,8 @@ running the Docker image is as easy as:
 ```sh
 docker run \
   -p 4000:4000 \
-  -v "$(pwd)/supergraph.graphql:/serve/gateway.config.ts" \
-  ghcr.io/ardatan/hive-gateway supergraph
+  -v "$(pwd)/supergraph.graphql:/gateway/gateway.config.ts" \
+  ghcr.io/graphql-hive/gateway supergraph
 ```
 
 ## Docker Compose
@@ -102,7 +102,7 @@ Start by defining the `docker-compose.yml`
 ```yaml
 services:
   hive-gateway:
-    image: ghcr.io/ardatan/hive-gateway
+    image: ghcr.io/graphql-hive/gateway
     command: supergraph
     ports:
       - '4000:4000'
@@ -112,7 +112,7 @@ services:
     #   HIVE_CDN_KEY: <secret>
     #   HIVE_REGISTRY_TOKEN: <secret>
     volumes:
-      - ./gateway.config.ts:/serve/gateway.config.ts
+      - ./gateway.config.ts:/gateway/gateway.config.ts
 ```
 
 And then simply start the services with:
@@ -126,7 +126,7 @@ docker compose up
 ### Install Plugin
 
 You may want to add additional functionality, or plugins to the base image - you just need to create
-a new Dockerfile basing the image off `ghcr.io/ardatan/hive-gateway`.
+a new Dockerfile basing the image off `ghcr.io/graphql-hive/gateway`.
 
 If need only a handful of plugins (or some other dependencies), you can simply extend the image and
 install the modules with `npm i`:
@@ -136,7 +136,7 @@ For example, adding
 the container would look like this:
 
 ```dockerfile filename="Dockerfile"
-FROM ghcr.io/ardatan/hive-gateway
+FROM ghcr.io/graphql-hive/gateway
 
 RUN npm i @escape.tech/graphql-armor-block-field-suggestions
 ```
@@ -168,7 +168,7 @@ And then simply start the new image with the config file mounted:
 ```sh
 docker run \
   -p 4000:4000 \
-  -v "$(pwd)/gateway.config.ts:/serve/gateway.config.ts" \
+  -v "$(pwd)/gateway.config.ts:/gateway/gateway.config.ts" \
   hive-gateway-w-block-suggestions supergraph
 ```
 
@@ -242,7 +242,7 @@ export const gatewayConfig = defineConfig({
 Your Dockerfile should then look something like this:
 
 ```dockerfile filename="Dockerfile"
-FROM ghcr.io/ardatan/hive-gateway
+FROM ghcr.io/graphql-hive/gateway
 
 # we dont install dev deps because:
 #   1. we need them for type checking only
@@ -272,8 +272,8 @@ docker run -p 4000:4000 hive-gateway-w-my-timing supergraph
 
 ```sh
 docker run -p 4000:4000 \
-  -v "$(pwd)/gateway.config.ts":/serve/gateway.config.ts \
-  -v "$(pwd)/my-timing.ts":/serve/my-timing.ts \
+  -v "$(pwd)/gateway.config.ts":/gateway/gateway.config.ts \
+  -v "$(pwd)/my-timing.ts":/gateway/my-timing.ts \
   hive-gateway-w-my-timing supergraph
 ```
 
@@ -321,7 +321,7 @@ export const gatewayConfig = defineConfig({ additionalResolvers })
 Your Dockerfile should then look something like this:
 
 ```dockerfile filename="Dockerfile"
-FROM ghcr.io/ardatan/hive-gateway
+FROM ghcr.io/graphql-hive/gateway
 
 # we dont install dev deps because:
 #   1. we need them for type checking only

--- a/packages/web/docs/src/pages/docs/gateway/index.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/index.mdx
@@ -62,7 +62,7 @@ curl -sSL https://graphql-hive.com/install-gateway.sh | sh
 You can use the official Docker image to run Hive Gateway.
 
 ```sh
-docker pull ghcr.io/ardatan/hive-gateway
+docker pull ghcr.io/graphql-hive/gateway
 ```
 
 </Tabs.Tab>
@@ -125,7 +125,7 @@ hive-gateway supergraph \
 
 ```sh filename="Run Apollo Federation Gateway with the Hive Gateway Docker Image"
 docker run --rm --name hive-gateway -p 4000:4000 \
-  ghcr.io/ardatan/hive-gateway supergraph \
+  ghcr.io/graphql-hive/gateway supergraph \
   http://cdn.graphql-hive.com/artifacts/v1/12713322-4f6a-459b-9d7c-8aa3cf039c2e/supergraph \
   --hive-cdn-key "YOUR HIVE CDN KEY"
 ```
@@ -178,7 +178,7 @@ hive-gateway proxy https://localhost:3000/graphql \
 
 ```sh filename="Run Proxy Gateway with the Hive Gateway Binary"
 docker run --rm --name hive-gateway -p 4000:4000 \
-  ghcr.io/ardatan/hive-gateway proxy https://localhost:3000/graphql \
+  ghcr.io/graphql-hive/gateway proxy https://localhost:3000/graphql \
   --hive-cdn-endpoint http://cdn.graphql-hive.com/artifacts/v1/12713322-4f6a-459b-9d7c-8aa3cf039c2e/sdl \
   --hive-cdn-key "YOUR HIVE CDN KEY"
 ```
@@ -255,8 +255,8 @@ For docker, we need to mount the configuration file into the container.
 
 ```sh filename="Run Proxy Gateway with the Hive Gateway Binary" {2}
 docker run --rm --name hive-gateway -p 4000:4000 \
-  -v $(pwd)/gateway.config.ts:/serve/gateway.config.ts \
-  ghcr.io/ardatan/hive-gateway supergraph
+  -v $(pwd)/gateway.config.ts:/gateway/gateway.config.ts \
+  ghcr.io/graphql-hive/gateway supergraph
 ```
 
 </Tabs.Tab>
@@ -311,8 +311,8 @@ For docker, we need to mount the configuration file into the container.
 
 ```sh filename="Run Proxy Gateway with the Hive Gateway Binary" {2}
 docker run --rm --name hive-gateway -p 4000:4000 \
-  -v $(pwd)/gateway.config.ts:/serve/gateway.config.ts \
-  ghcr.io/ardatan/hive-gateway proxy https://localhost:3000/graphql \
+  -v $(pwd)/gateway.config.ts:/gateway/gateway.config.ts \
+  ghcr.io/graphql-hive/gateway proxy https://localhost:3000/graphql \
   --hive-cdn-endpoint http://cdn.graphql-hive.com/artifacts/v1/12713322-4f6a-459b-9d7c-8aa3cf039c2e/sdl \
   --hive-cdn-key "YOUR HIVE CDN KEY"
 ```

--- a/packages/web/docs/src/pages/docs/gateway/persisted-documents.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/persisted-documents.mdx
@@ -42,7 +42,7 @@ hive-gateway supergraph "<cdn_endpoint>" \
 
 ```sh filename="Run the Hive Gateway CLI" {3,4}
 docker run --rm --name hive-gateway -p 4000:4000 \
-  ghcr.io/ardatan/hive-gateway supergraph "<cdn_endpoint>" \
+  ghcr.io/graphql-hive/gateway supergraph "<cdn_endpoint>" \
   --hive-persisted-documents-endpoint "<cdn_endpoint>" \
   --hive-persisted-documents-token "<cdn_access_token>"
 ```

--- a/packages/web/docs/src/pages/docs/gateway/usage-reporting.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/usage-reporting.mdx
@@ -41,7 +41,7 @@ hive-gateway supergraph \
 
 ```sh filename="Run Hive Gateway with Usage Reporting enabled." {5}
 docker run --rm --name hive-gateway -p 4000:4000 \
-  ghcr.io/ardatan/hive-gateway supergraph \
+  ghcr.io/graphql-hive/gateway supergraph \
   http://cdn.graphql-hive.com/artifacts/v1/12713322-4f6a-459b-9d7c-8aa3cf039c2e/supergraph \
   --hive-cdn-key "YOUR HIVE CDN KEY" \
   --hive-registry-token "YOUR HIVE REGISTRY TOKEN"

--- a/packages/web/docs/src/pages/docs/get-started/apollo-federation.mdx
+++ b/packages/web/docs/src/pages/docs/get-started/apollo-federation.mdx
@@ -471,7 +471,7 @@ Hive Gateway is the Federation Gateway that seamlessly integrates with the Hive 
 run Hive Gateay either as a Docker image, binary or NPM package.
 
 <Tabs items={['Binary', 'Docker', 'Node.js Package']}>
-  
+
 {/* Binary */}
 
 <Tabs.Tab>
@@ -507,7 +507,7 @@ following command to start a Hive Gateway instance from your existing Hive targe
 
 ```sh
 docker run --name hive-gateway -rm \
-  ghcr.io/ardatan/hive-gateway supergraph \
+  ghcr.io/graphql-hive/gateway supergraph \
   "<hive_cdn_endpoint>" \
   --hive-cdn-key "<hive_cdn_access_key>"
 ```
@@ -631,7 +631,7 @@ following command to start a Hive Gateway instance from your existing Hive targe
 
 ```sh
 docker run --name hive-gateway -rm \
-  ghcr.io/ardatan/hive-gateway supergraph \
+  ghcr.io/graphql-hive/gateway supergraph \
   "<hive_cdn_endpoint>" \
   --hive-cdn-key "<hive_cdn_access_key>" \
   --hive-registry-token "<hive_registry_token>"


### PR DESCRIPTION
https://github.com/graphql-hive/gateway

Also, the workdir in the Docker image has been moved from `/serve` to `/gateway`. Not a breaking change at the moment because [`/serve` is symlinked to `/gateway`](https://github.com/graphql-hive/gateway/blob/048eec06630a0d4859a334f25a8b20d423e2718d/packages/gateway/Dockerfile#L23-L25).