### PR TITLE
Fix Conditional Breaking Changes form

### DIFF
--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -692,13 +692,13 @@ const ConditionalBreakingChanges = (props: {
                       checked={values.targetIds.includes(pt.id)}
                       onCheckedChange={async isChecked => {
                         await setFieldValue(
-                          'targets',
+                          'targetIds',
                           isChecked
                             ? [...values.targetIds, pt.id]
                             : values.targetIds.filter(value => value !== pt.id),
                         );
                       }}
-                      onBlur={() => setFieldTouched('targets', true)}
+                      onBlur={() => setFieldTouched('targetIds', true)}
                     />{' '}
                     {pt.slug}
                   </div>


### PR DESCRIPTION
Selecting targets was broken due to incorrect form field name.