### PR TITLE
Handle UTC +5:30 and similar timezones

### DIFF
--- a/packages/services/api/src/modules/operations/lib/pick-table-by-provider.ts
+++ b/packages/services/api/src/modules/operations/lib/pick-table-by-provider.ts
@@ -43,10 +43,11 @@ export function pickTableByPeriod(args: {
   logger?: Logger;
 }): Table {
   args.logger?.debug(
-    'Picking table by period (from: %s, to: %s, intervalUnit: %s',
+    'Picking table by period (from: %s, to: %s, intervalUnit: %s, now: %s)',
     args.period.from.toISOString(),
     args.period.to.toISOString(),
     args.intervalUnit ?? 'none',
+    args.now.toISOString(),
   );
   // The oldest data point we can fetch from the database, per table.
   // ! We subtract 2 minutes as we round the date to the nearest minute on UI
@@ -61,6 +62,12 @@ export function pickTableByPeriod(args: {
   const intervalUnit = args.intervalUnit ? intervalUnitToTable[args.intervalUnit] : undefined;
 
   let potentialTables: Array<'hourly' | 'daily' | 'minutely'> = ['daily', 'hourly', 'minutely'];
+
+  args.logger?.debug('Oldest available data points: %o', {
+    daily: tableOldestDateTimePoint.daily.toISOString(),
+    hourly: tableOldestDateTimePoint.hourly.toISOString(),
+    minutely: tableOldestDateTimePoint.minutely.toISOString,
+  });
 
   // filter out tables can't be used due to TTL
   potentialTables = potentialTables.filter(

--- a/packages/web/app/src/lib/hooks/use-date-range-controller.spec.ts
+++ b/packages/web/app/src/lib/hooks/use-date-range-controller.spec.ts
@@ -40,6 +40,121 @@ describe('useDateRangeController', () => {
         to: '1992-10-21T10:59:59.999Z', // endOfHour as it cannot use minutely aggregation
       },
     },
+    //
+    //
+    // Testing a date range,
+    // where potentially daily aggregation will be used.
+    // UTC+5:30
+    {
+      now: '1992-11-07T03:19:59+05:30', // it's 1992-11-06T21:49:59.000Z
+      from: 'now-7d',
+      to: 'now',
+      expected: {
+        from: '1992-10-30T21:00:00.000Z',
+        to: '1992-11-06T21:59:59.999Z',
+      },
+    },
+    // Testing a date range,
+    // where potentially daily aggregation will be used.
+    // The same as above but with a different time zone
+    {
+      now: '1992-11-06T21:49:59.000Z',
+      from: 'now-7d',
+      to: 'now',
+      expected: {
+        from: '1992-10-30T21:00:00.000Z',
+        to: '1992-11-06T21:59:59.999Z',
+      },
+    },
+    //
+    //
+    // Testing a date range,
+    // where potentially daily aggregation will be used.
+    // UTC-4:15
+    {
+      now: '1992-11-07T03:19:59-04:15', // it's 1992-11-07T07:34:59.000Z
+      from: 'now-7d',
+      to: 'now',
+      expected: {
+        from: '1992-10-31T07:00:00.000Z',
+        to: '1992-11-07T07:59:59.999Z',
+      },
+    },
+    // Testing a date range,
+    // where potentially daily aggregation will be used.
+    // The same as above but with a different time zone
+    {
+      now: '1992-11-07T07:34:59.000Z',
+      from: 'now-7d',
+      to: 'now',
+      expected: {
+        from: '1992-10-31T07:00:00.000Z',
+        to: '1992-11-07T07:59:59.999Z',
+      },
+    },
+    //
+    //
+    // Testing a date range,
+    // where potentially hourly aggregation will be used.
+    // UTC+5:30
+    {
+      now: '1992-11-07T03:19:59+05:30', // it's 1992-11-06T21:49:59.000Z
+      from: 'now-3d',
+      to: 'now',
+      expected: {
+        from: '1992-11-03T21:00:00.000Z',
+        to: '1992-11-06T21:59:59.999Z',
+      },
+    },
+    // Testing a date range,
+    // where potentially hourly aggregation will be used.
+    // The same as above but with a different time zone
+    {
+      now: '1992-11-06T21:49:59.000Z',
+      from: 'now-3d',
+      to: 'now',
+      expected: {
+        from: '1992-11-03T21:00:00.000Z',
+        to: '1992-11-06T21:59:59.999Z',
+      },
+    },
+    //
+    //
+    // Testing a date range,
+    // where potentially minutely aggregation will be used.
+    // UTC+5:30
+    {
+      now: '1992-11-07T03:19:59+05:30', // it's 1992-11-06T21:49:59.000Z
+      from: 'now-1d',
+      to: 'now',
+      expected: {
+        from: '1992-11-05T21:49:00.000Z',
+        to: '1992-11-06T21:49:59.999Z',
+      },
+    },
+    // Testing a date range,
+    // where potentially minutely aggregation will be used.
+    // The same as above but with a different time zone
+    {
+      now: '1992-11-06T21:49:59.000Z',
+      from: 'now-1d',
+      to: 'now',
+      expected: {
+        from: '1992-11-05T21:49:00.000Z',
+        to: '1992-11-06T21:49:59.999Z',
+      },
+    },
+    //
+    //
+    {
+      now: '1992-10-21T10:19:54.000Z',
+      from: 'now-7d',
+      to: 'now',
+      expected: {
+        from: '1992-10-14T10:00:00.000Z',
+        to: '1992-10-21T10:59:59.999Z', // endOfHour as it cannot use minutely aggregation
+      },
+    },
     {
       now: '1992-10-21T10:10:00.000Z',
       from: 'now-48d',

--- a/packages/web/app/src/lib/hooks/use-date-range-controller.ts
+++ b/packages/web/app/src/lib/hooks/use-date-range-controller.ts
@@ -2,10 +2,8 @@ import { useState } from 'react';
 import {
   addDays,
   addHours,
-  endOfHour,
   endOfMinute,
   formatISO,
-  startOfHour,
   startOfMinute,
   subHours,
   subMilliseconds,
@@ -128,6 +126,26 @@ function getUTCStartOfDay(date: Date) {
 /** Get the UTC end date of a day */
 function getUTCEndOfDay(date: Date) {
   return subMilliseconds(getUTCStartOfDay(addDays(date, 1)), 1);
+}
+
+function startOfHour(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours()),
+  );
+}
+
+function endOfHour(date: Date): Date {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      59,
+      59,
+      999,
+    ),
+  );
 }
 
 export function resolveRangeAndResolution(range: { from: Date; to: Date }, now = new Date()) {


### PR DESCRIPTION
date-fns's `startOfHour` and `endOfHour` caused time range to be incorrect in the context of how clickhouse data is aggregated (`startOfHour(UTC)`, ` startOfDay(UTC)` and `startOfMinute(UTC)`).

Showing data from `Oct 11, 11:30 UTC` would lead to empty result for that day (in case of daily aggregation).