### PR TITLE
Hide theme switcher on landing page

### DIFF
--- a/packages/web/docs/src/components/landing-page.tsx
+++ b/packages/web/docs/src/components/landing-page.tsx
@@ -51,6 +51,9 @@ export function IndexPage(): ReactElement {
             --nextra-primary-saturation: 40%;
             --nextra-bg: 255, 255, 255;
           }
+          .nextra-sidebar-footer {
+            display: none;
+          }
         `}
       </style>
       <Page className="text-green-1000 light mx-auto max-w-[90rem] overflow-hidden">


### PR DESCRIPTION
### Background

<img width="652" alt="image" src="https://github.com/user-attachments/assets/8ceed2cc-66ff-408f-9f92-56d57a425ca0">

### Description

Hiding theme switcher on landing page as it doesn't work there anyway.

